### PR TITLE
Enable sbt assembly to make fat jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,3 +31,9 @@ lazy val webapp = project
   .enablePlugins(PlayScala)
   .aggregate(core)
   .dependsOn(core)
+
+test in assembly := {}
+assemblyMergeStrategy in assembly := {
+    case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+    case x => MergeStrategy.first
+}

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")


### PR DESCRIPTION
These additions make it possible to do `sbt assembly` to create a single fat jar with Eidos and all its dependencies. This will make using Eidos easier from Python and other environments.