### PR TITLE
Add dummy constructor for Python/Jnius use

### DIFF
--- a/src/main/scala/org/clulab/wm/AgroSystem.scala
+++ b/src/main/scala/org/clulab/wm/AgroSystem.scala
@@ -22,6 +22,7 @@ class AgroSystem(
   processor: Option[Processor] = None,
   debug: Boolean = true
 ) {
+  def this(x:Object) = this()
 
   // defaults to FastNLPProcessor if no processor is given
   val proc:Processor = if (processor.nonEmpty) processor.get else new FastNLPProcessor()


### PR DESCRIPTION
The Python/Java bridge `pyjnius` that can be used to interface with Eidos is not suited to deal with constructors that have default parameters in Scala. This is a small addition to define a dummy constructor that can be called from Python to instantiate AgroSystem with default parameters.