### PR TITLE
Add function to get JSON string from mentions

### DIFF
--- a/src/main/scala/org/clulab/wm/serialization/json/JSONSerializer.scala
+++ b/src/main/scala/org/clulab/wm/serialization/json/JSONSerializer.scala
@@ -41,6 +41,10 @@ object WMJSONSerializer {
     parse(contents)
   }
 
+  def toJsonStr(mentions: Seq[Mention]): String = {
+    pretty(render(jsonAST(mentions)))
+    }
+
   def toAttachments(json: JValue): Set[Attachment] = {
     // Get the Attachment from the json string
     def findAttachment(json: JValue): Attachment = {


### PR DESCRIPTION
This addition allows getting mentions serialized into JSON as a String, and helps accessing reading results (for technical reasons, calling `render` and `pretty` from Python is not straightforward).