### PR TITLE
Bugfix in ExampleGenerator

### DIFF
--- a/src/main/scala/agro/demo/ExampleGenerator.scala
+++ b/src/main/scala/agro/demo/ExampleGenerator.scala
@@ -31,9 +31,9 @@ object ExampleGenerator extends App {
   println(pretty(render(mentionsJSON)))
 
 
-  val pw = new PrintWriter("/Users/bsharp/wmExampleJson_dec7.txt")
-  pw.println(pretty(render(mentionsJSON)))
-  pw.close()
+//  val pw = new PrintWriter("/Users/bsharp/wmExampleJson_dec7.txt")
+//  pw.println(pretty(render(mentionsJSON)))
+//  pw.close()
 
 
 


### PR DESCRIPTION
this object is really just for use as an example for how to serialize/deserialize as json, but there was a bug where the text was being annotated using the default method (processors).  We needed to use the method in AgroSystem so that the gradable adj tags were getting populated.