### PR TITLE
Reorganize rules

### DIFF
--- a/src/main/resources/org/clulab/wm/grammars/causal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/causal.yml
@@ -12,19 +12,6 @@ vars:
 
 rules:
 
-# ------------------- Verbal PROMOTION/INHIBITION Rules --------------------------
-
-  - name: ${ label }_ported_syntax_1_verb_edited
-    priority: ${ rulepriority }
-    example: "With the high cost of production, food imports will further reduce farmers’ chances to make a living from agriculture."
-    label: ${ label }
-    pattern: |
-      trigger = [word=/(?i)^(${ promotion_trigger })/ & tag=/^V/] # original rule had RB as possible tag
-      # | ${complements} originally in the () with with the FIRST ${ objects }.
-      cause: Entity = nsubj
-      effect: Entity = nmod_by? (${objects}) /${ conjunctions }|${ objects }|${ noun_modifiers }|${ preps }/{,2}
-      quantifier:Quantifier? = ${quant_modifiers}
-
 
 # ------------------- Nominal Triggers --------------------------
 
@@ -47,20 +34,12 @@ rules:
       effect: Entity = nsubj
       cause: Entity = /${ preps }$/
 
-#  - name: causal-2
-#    priority: ${ rulepriority }
-#    example: "More water resulting in an increase of productivity."
-#    label: ${ label }
-#    pattern: |
-#      trigger = [word=/(?i)^(${ trigger })/]
-#      cause: Entity  = nsubj acl dobj |nmod_)/
-#      effect: Entity = nmod_in | nmod_to
 
-#
 
 # ------------------- Previous Grammar Unsorted --------------------------
 
 
+  # todo: not very general
   - name: dueTo2-${addlabel}
     priority: ${rulepriority}
     type: token
@@ -73,19 +52,8 @@ rules:
     label: ${label}
     pattern: |
       trigger = [lemma="due" & tag=/JJ/]
-      cause: Entity = prep_to
-      effect: Entity = <acomp
-
-# todo: I don't think this rule applies in new grammar - remove?
-#  - name: dueToSyntax2-${addlabel}
-#    priority: ${rulepriority}
-#    label: ${label}
-#    pattern: |
-#      trigger: Change_Event
-#      #effect: ${ effect_types } = prep_to
-#      cause: ${ cause_types } = prep_due_to
-
-
+      cause: Entity = </case|advmod/ <nmod_due_to? nsubj
+      effect: Entity = /<case|>nmod_to/  # /<case|nmod_to/
 
 #
 # Something-A (effect) due to|because of Something-B (case)
@@ -213,6 +181,7 @@ rules:
       effect: Entity = (nmod_in$ | nmod_to) /${ noun_modifiers }/{,2}
       cause: Entity = (nsubj | <rcmod) /${ conjunctions }|${ noun_modifiers }|nmod_in/{,2}
 
+  # todo: I think this is no longer relevant with the new stateful entities
   - name: causeEffect_ported_syntax_8_verb-${addlabel}
     priority: ${ rulepriority }
     #Original example: "We found that prolonged expression of active Ras resulted in up-regulation of the MKP3 gene"
@@ -225,6 +194,7 @@ rules:
       cause: Entity = nsubj /${ noun_modifiers }|${ conjunctions }|${ preps }|/{,2}
 
 
+  # todo: maybe applies only to promotion triggers
   - name: causeEffect_ported_syntax_1_noun-${addlabel}
     priority: ${ rulepriority }
     example: "The cause of increasing poverty by bad water quality is the worst."

--- a/src/main/resources/org/clulab/wm/grammars/causal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/causal.yml
@@ -13,16 +13,7 @@ vars:
 rules:
 
 
-# ------------------- Nominal Triggers --------------------------
-
-  - name: causal-noun-1
-    priority: ${ rulepriority }
-    example: "More water resulting in an increase of productivity."
-    label: ${ label }
-    pattern: |
-      trigger = [word=/(?i)^(${ reverse_noun_trigger })/]
-      cause: Entity  = nsubj
-      effect: Entity = (nmod_in | nmod_to){1,2} | ccomp (nsubj | dobj)?
+# ------------------- Copular Constructions --------------------------
 
   - name: causeEffect_ported_copula_1-${addlabel}
     priority: ${ rulepriority }
@@ -75,7 +66,7 @@ rules:
     example: ""
     pattern: |
       trigger = [word=/(?i)^(${ trigger })/ & tag=/^V/]
-      effect: Entity = nsubj
+      effect: Entity = <xcomp? nsubj
       cause: Entity = nmod_with /${ preps }/{,2}
 
 

--- a/src/main/resources/org/clulab/wm/grammars/causal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/causal.yml
@@ -50,42 +50,33 @@ rules:
   - name: dueToSyntax1-${addlabel}
     priority: ${rulepriority}
     label: ${label}
+    example: "food imports will decrease due to rainfall today"
     pattern: |
       trigger = [lemma="due" & tag=/JJ/]
-      cause: Entity = </case|advmod/ <nmod_due_to? nsubj
-      effect: Entity = /<case|>nmod_to/  # /<case|nmod_to/
+      cause: Entity = <advmod <nmod_due_to? nsubj
+      effect: Entity = nmod_to
 
-#
-# Something-A (effect) due to|because of Something-B (case)
-#
-#  - name: causeEffect-2-${addlabel}
-#    priority: ${rulepriority}
-#    label: ${label}
-#    pattern: |
-#      trigger = [lemma="due" & tag=/^JJ/]
-#      effect: Event = nsubj
-#      cause: Potential_Cause = prep_to # note -- should maybe be higher level than NP in taxonomy?
-
-
-  # Something-A (effect) caused|influenced|initiated| by Something-B (cause)
-  - name: causeEffect-3-${addlabel}
-    priority: ${ rulepriority }
+  - name: dueToSyntax2-${addlabel}
+    priority: ${rulepriority}
     label: ${label}
+    example: "food imports will decrease due to rainfall"
     pattern: |
-      trigger = [lemma=/cause|influence|initiate/ & tag=/^V/]
-      cause: Entity = nsubj
-      effect: Entity = dobj
+      trigger = [lemma="due" & tag=/JJ/]
+      cause: Entity = <case <nmod_due_to? nsubj
+      effect: Entity = <case
+
 
   #
   # param is nominal subject of verb: "PARAM increases/decreases with _____ "
   #
-#  - name: causeEffect-4-${addlabel}
-#    priority: ${rulepriority}
-#    label: ${label}
-#    pattern: |
-#      trigger = [word=with]
-#      cause: Entity = nsubj
-#      effect: Entity = prep_with
+  - name: with-${addlabel}
+    priority: ${rulepriority}
+    label: ${label}
+    example: ""
+    pattern: |
+      trigger = [word=/(?i)^(${ trigger })/ & tag=/^V/]
+      effect: Entity = nsubj
+      cause: Entity = nmod_with /${ preps }/{,2}
 
 
 

--- a/src/main/resources/org/clulab/wm/grammars/master.yml
+++ b/src/main/resources/org/clulab/wm/grammars/master.yml
@@ -70,8 +70,8 @@ rules:
     vars:
       rulepriority: "6"
       label: Causal
-      trigger: ${cause_triggers}
-      promotion_trigger: ${increase_triggers} | ${decrease_triggers}
+      trigger: ${cause_triggers} | ${increase_triggers} | ${decrease_triggers}
+      #promotion_trigger: ${increase_triggers} | ${decrease_triggers}
       # To handle the syntactic ambiguity of "A is the cause of B" versus "A is the result of B" which have
       # identical syntactic structure, but opposite directions for identifying the cause/effect, we introduce a set
       # of triggers for reversed direction nouns (e.g., "result" and "effect")

--- a/src/main/resources/org/clulab/wm/grammars/master.yml
+++ b/src/main/resources/org/clulab/wm/grammars/master.yml
@@ -71,13 +71,13 @@ rules:
       rulepriority: "6"
       label: Causal
       trigger: ${cause_triggers} | ${increase_triggers} | ${decrease_triggers}
-      #promotion_trigger: ${increase_triggers} | ${decrease_triggers}
-      # To handle the syntactic ambiguity of "A is the cause of B" versus "A is the result of B" which have
-      # identical syntactic structure, but opposite directions for identifying the cause/effect, we introduce a set
-      # of triggers for reversed direction nouns (e.g., "result" and "effect")
-      reverse_noun_trigger: "result|effect"
-      # results in versus results from
-      #action: ? #
+
+  - import: org/clulab/wm/grammars/reverse_direction_causal.yml
+    vars:
+      rulepriority: "6"
+      label: Causal
+      trigger: "result|effect"
+
 
   - import: org/clulab/wm/grammars/origin.yml
     vars:

--- a/src/main/resources/org/clulab/wm/grammars/reverse_direction_causal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/reverse_direction_causal.yml
@@ -1,0 +1,23 @@
+vars:
+  agents: "nsubj | nsubjpass | csubj | csubjpass | <acl"  #Comment:  nsubjpass for cause should not be there in an ideal world; but it does show up in practice
+  conjunctions: "appos|conj|conj_|cc"
+  complements: "xcomp|ccomp"
+  noun_modifiers: "amod|compound|dep|name"
+  negTriggers: "not"
+  objects: "dobj"
+  preps: "nmod_of|nmod_in|nmod_to"
+  prep_dobjs: "nmod"
+  quant_modifiers: "amod|advmod"
+  # Todo: nmod_from "X will follow from Y"
+
+rules:
+
+  - name: reverse_causal-noun-1
+    priority: ${ rulepriority }
+    example: "More water resulting in an increase of productivity."
+    label: ${ label }
+    pattern: |
+      trigger = [word=/(?i)^(${ trigger })/]
+      cause: Entity  = nsubj
+      effect: Entity = (nmod_in | nmod_to){1,2} | ccomp (nsubj | dobj)?
+


### PR DESCRIPTION
made some changes including:

- moved reverse-causal rules to a separate file, now loaded by master.yml
- removed some no-longer-relevant rules
- made due-to rule more robust (and added a 2nd)
- made "with" rule more robust
- added some examples to rules and some comments above some rule about perhaps removing, etc