### PR TITLE
Fix polarity of dueToSyntax2, fixes p4s3

### DIFF
--- a/src/main/resources/org/clulab/wm/grammars/causal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/causal.yml
@@ -53,8 +53,8 @@ rules:
     example: "food imports will decrease due to rainfall"
     pattern: |
       trigger = [lemma="due" & tag=/JJ/]
-      cause: Entity = <case <nmod_due_to? nsubj
-      effect: Entity = <case
+      cause: Entity = <case
+      effect: Entity = <case <nmod_due_to? nsubj
 
 
   #

--- a/src/test/scala/org/clulab/wm/TestCagP4.scala
+++ b/src/test/scala/org/clulab/wm/TestCagP4.scala
@@ -30,13 +30,13 @@ class TestCagP4 extends Test {
   
   { // S3
     val tester = new Tester(p4s3)
-
+    // water trucking has decreased due to the cost of fuel
     val cost     = newNodeSpec("cost of fuel")
     val trucking = newNodeSpec("water trucking", newDecrease("decreased"))
   
     behavior of "p4s3"
     
-    failingTest should "have correct edges 1" taggedAs(Ben) in {
+    it should "have correct edges 1" taggedAs(Ben) in {
       tester.test(newEdgeSpec(cost, Causal, trucking)) should be (successful)
     }
   }


### PR DESCRIPTION
This rule seemed to be working but assigned the cause/effect arguments incorretly, as far as I can tell. Did I get this right?