### PR TITLE
Making the webapp show increased NPs as green, decreased as red, and otherwise quantified as blue...

### DIFF
--- a/src/main/resources/org/clulab/wm/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/wm/grammars/taxonomy.yml
@@ -2,9 +2,6 @@
   - Param
   - Agrovoc
   - NounPhrase
-    - NounPhrase-Inc
-    - NounPhrase-Dec
-    - NounPhrase-Quant
 - Transparent
 - Quantifier
 - Event:

--- a/src/main/resources/org/clulab/wm/grammars/taxonomy.yml
+++ b/src/main/resources/org/clulab/wm/grammars/taxonomy.yml
@@ -2,6 +2,9 @@
   - Param
   - Agrovoc
   - NounPhrase
+    - NounPhrase-Inc
+    - NounPhrase-Dec
+    - NounPhrase-Quant
 - Transparent
 - Quantifier
 - Event:

--- a/src/main/scala/org/clulab/wm/AgroActions.scala
+++ b/src/main/scala/org/clulab/wm/AgroActions.scala
@@ -41,7 +41,7 @@ class AgroActions extends Actions with LazyLogging {
     // remove incomplete entities (i.e. under specified when more fully specified exists)
 
     val tbMentionGroupings =
-      textBounds.map(_.asInstanceOf[TextBoundMention]).groupBy(m => (m.tokenInterval, reduceNounPhrases(m.label)))
+      textBounds.map(_.asInstanceOf[TextBoundMention]).groupBy(m => (m.tokenInterval, m.label))
 
     // remove incomplete mentions
     val completeTBMentions =
@@ -72,13 +72,6 @@ class AgroActions extends Actions with LazyLogging {
     completeTBMentions.flatten.toSeq ++ relationMentions ++ completeEventMentions.flatten.toSeq
   }
 
-  // Use to temporarily collapse noun phrase types for grouping
-  def reduceNounPhrases(s:String) = s match {
-    case "NounPhrase-Inc" => "NounPhrase"
-    case "NounPhrase-Dec" => "NounPhrase"
-    case "NounPhrase-Quant" => "NounPhrase"
-    case _ => s
-  }
 
   //Rule to apply quantifiers directly to the state of an Entity (e.g. "small puppies") and
   //Rule to add Increase/Decrease to the state of an entity
@@ -87,21 +80,17 @@ class AgroActions extends Actions with LazyLogging {
   def applyAttachment(ms: Seq[Mention], state: State): Seq[Mention] = for {
     m <- ms
     //if m matches "EntityModifier"
-    (attachment, npLabel) = getAttachment(m)
+    attachment = getAttachment(m)
 
     copyWithMod = m match {
-      case tb: TextBoundMention =>
-        val copyLabels = Seq(npLabel) ++ m.labels
-        tb.copy(attachments = tb.attachments ++ Set(attachment), foundBy = s"${tb.foundBy}++mod", labels = copyLabels)
+      case tb: TextBoundMention => tb.copy(attachments = tb.attachments ++ Set(attachment), foundBy = s"${tb.foundBy}++mod")
       // Here, we want to keep the theme that is being modified, not the modification event itself
       case rm: RelationMention =>
         val theme = rm.arguments("theme").head.asInstanceOf[TextBoundMention]
-        val copyLabels = Seq(npLabel) ++ theme.labels
-        theme.copy(attachments = theme.attachments ++ Set(attachment), foundBy = s"${theme.foundBy}++${rm.foundBy}", labels = copyLabels)
+        theme.copy(attachments = theme.attachments ++ Set(attachment), foundBy = s"${theme.foundBy}++${rm.foundBy}")
       case em: EventMention =>
         val theme = em.arguments("theme").head.asInstanceOf[TextBoundMention]
-        val copyLabels = Seq(npLabel) ++ theme.labels
-        theme.copy(attachments = theme.attachments ++ Set(attachment), foundBy = s"${theme.foundBy}++${em.foundBy}", labels = copyLabels)
+        theme.copy(attachments = theme.attachments ++ Set(attachment), foundBy = s"${theme.foundBy}++${em.foundBy}")
     }
   } yield copyWithMod
 
@@ -113,22 +102,22 @@ class AgroActions extends Actions with LazyLogging {
   }
 
 
-  def getAttachment(m: Mention): (Attachment, String) = {
+  def getAttachment(m: Mention): Attachment = {
     m.label match {
       case "Quantification" => {
         val quantifier = m.asInstanceOf[EventMention].trigger.text
-        (new Quantification(quantifier), NP_QUANT_LABEL)
+        new Quantification(quantifier)
       }
       case "Increase" => {
         val quantifiers = getOptionalQuantifiers(m)
         val trigger = m.asInstanceOf[EventMention].trigger.text
-        (new Increase(trigger, quantifiers), NP_INC_LABEL)
+        new Increase(trigger, quantifiers)
       }
       case "Decrease" => {
         val quantifiers = getOptionalQuantifiers(m)
         val trigger = m.asInstanceOf[EventMention].trigger.text
         //println(s"Decrease found: ${new Decrease(trigger, quantifiers)}")
-        (new Decrease(trigger, quantifiers), NP_DEC_LABEL)
+        new Decrease(trigger, quantifiers)
       }
     }
   }
@@ -147,9 +136,6 @@ class AgroActions extends Actions with LazyLogging {
 object AgroActions extends Actions {
 
   val taxonomy = readTaxonomy("org/clulab/wm/grammars/taxonomy.yml")
-  val NP_INC_LABEL = "NounPhrase-Inc"
-  val NP_DEC_LABEL = "NounPhrase-Dec"
-  val NP_QUANT_LABEL = "NounPhrase-Quant"
 
   private def readTaxonomy(path: String): Taxonomy = {
     val url = getClass.getClassLoader.getResource(path)

--- a/src/main/scala/org/clulab/wm/AgroSystem.scala
+++ b/src/main/scala/org/clulab/wm/AgroSystem.scala
@@ -107,6 +107,11 @@ object AgroSystem {
   val INTERCEPT: String = "intercept"
   val PARAM_MEAN: String = "mean"
   val PARAM_STDEV: String = "stdev"
+  // Stateful Labels used by webapp
+  val INC_LABEL_AFFIX = "-Inc"
+  val DEC_LABEL_AFFIX = "-Dec"
+  val QUANT_LABEL_AFFIX = "-Quant"
+
 
 }
 

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -76,7 +76,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     var objectToReturn = ""
 
     if(groundedEntities.size > 0){
-      objectToReturn += """<br><br><font size="3" color="cadetblue">Grounded Entities:</font>"""
+      objectToReturn += """<br><br><font size="4" color="#2471A3">Grounded Entities:</font>"""
 
       // Make the string for each grounded entity
       val toPrint = for (grounding <- groundedEntities) yield {
@@ -105,7 +105,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     // Entities
     val entities = mentions.filter(_ matches "Entity")
     if (entities.nonEmpty){
-      objectToReturn += """<br><font size="3" color="rebeccapurple">Found Entities:</font><br>"""
+      objectToReturn += """<br><font size="4" color="#2471A3">Found Entities:</font><br>"""
       for (entity <- entities) {
         objectToReturn += s"${utils.DisplayUtils.webAppMention(entity)}"
       }
@@ -114,7 +114,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
 
     val events = mentions.filter(_ matches "Event")
     if (events.nonEmpty) {
-      objectToReturn += """<font size="3" color="green">Found Events:</font><br>"""
+      objectToReturn += """<font size="4" color="#2471A3">Found Events:</font><br>"""
       for (event <- events) {
         objectToReturn += s"${utils.DisplayUtils.webAppMention(event)}"
       }

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -76,7 +76,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     var objectToReturn = ""
 
     if(groundedEntities.size > 0){
-      objectToReturn += """<br><br><font size="4" color="#2471A3">Grounded Entities:</font>"""
+      objectToReturn += s"""<br><br><font size="4" color="${HomeController.sectionTitleColor}">Grounded Entities:</font>"""
 
       // Make the string for each grounded entity
       val toPrint = for (grounding <- groundedEntities) yield {
@@ -105,7 +105,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     // Entities
     val entities = mentions.filter(_ matches "Entity")
     if (entities.nonEmpty){
-      objectToReturn += """<br><font size="4" color="#2471A3">Found Entities:</font><br>"""
+      objectToReturn += s"""<br><font size="4" color="${HomeController.sectionTitleColor}">Found Entities:</font><br>"""
       for (entity <- entities) {
         objectToReturn += s"${utils.DisplayUtils.webAppMention(entity)}"
       }
@@ -114,7 +114,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
 
     val events = mentions.filter(_ matches "Event")
     if (events.nonEmpty) {
-      objectToReturn += """<font size="4" color="#2471A3">Found Events:</font><br>"""
+      objectToReturn += s"""<font size="4" color="${HomeController.sectionTitleColor}">Found Events:</font><br>"""
       for (event <- events) {
         objectToReturn += s"${utils.DisplayUtils.webAppMention(event)}"
       }
@@ -266,6 +266,8 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
 }
 
 object HomeController {
+
+  val sectionTitleColor = "#2471A3"
 
   // fixme: ordering/precedence...
   def statefulRepresentation(m: Mention): Mention = {

--- a/webapp/app/views/index.scala.html
+++ b/webapp/app/views/index.scala.html
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-    <p> <b> RAPShell </b> </p>
+    <p> <b> World Modelers -- Eidos Visualizer </b> </p>
     
     <form>
         <input type="text" name="sent" style="font-size:10pt;height:50px;width:800px;">

--- a/webapp/public/javascripts/main.js
+++ b/webapp/public/javascripts/main.js
@@ -4,6 +4,7 @@ var bratLocation = 'assets/brat';
 var baseNounPhraseColor = '#CCD1D1';
 var increaseNounPhraseColor = '#BBDC90';
 var decreaseNounPhraseColor = '#FC5C38';
+var quantifierColor = '#AED6F1';
 var quantifiedNounPhraseColor = '#85C1E9';
 var causalEventColor = '#BB8FCE';
 var affectEventColor = '#F7DC6F';
@@ -38,7 +39,7 @@ var collData = {
         "type"   : "Quantifier",
         "labels" : ["Quantifier", "Quant"],
         // Blue is a nice colour for a person?
-        "bgColor": "#AED6F1",
+        "bgColor": quantifierColor,
         // Use a slightly darker version of the bgColor for the border
         "borderColor": "darken"
     },

--- a/webapp/public/javascripts/main.js
+++ b/webapp/public/javascripts/main.js
@@ -1,5 +1,14 @@
 var bratLocation = 'assets/brat';
 
+// Color names used
+var baseNounPhraseColor = '#CCD1D1';
+var increaseNounPhraseColor = '#BBDC90';
+var decreaseNounPhraseColor = '#FC5C38';
+var quantifiedNounPhraseColor = '#85C1E9';
+var causalEventColor = '#BB8FCE';
+var affectEventColor = '#F7DC6F';
+
+
 head.js(
     // External libraries
     bratLocation + '/client/lib/jquery.min.js',
@@ -38,7 +47,7 @@ var collData = {
             "labels" : ["NounPhrase", "NP"],
             // Blue is a nice colour for a person?
             //"bgColor": "thistle",
-            "bgColor": "#CCD1D1",
+            "bgColor": baseNounPhraseColor,
             // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
@@ -47,7 +56,7 @@ var collData = {
             "labels" : ["NounPhrase", "NP"],
             // Blue is a nice colour for a person?
             //"bgColor": "thistle",
-            "bgColor": "#BBDC90",
+            "bgColor": increaseNounPhraseColor,
             // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
@@ -56,7 +65,7 @@ var collData = {
             "labels" : ["NounPhrase", "NP"],
             // Blue is a nice colour for a person?
             //"bgColor": "thistle",
-            "bgColor": "#FC5C38",
+            "bgColor": decreaseNounPhraseColor,
             // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
@@ -65,7 +74,7 @@ var collData = {
             "labels" : ["NounPhrase", "NP"],
             // Blue is a nice colour for a person?
             //"bgColor": "thistle",
-            "bgColor": "#85C1E9",
+            "bgColor": quantifiedNounPhraseColor,
             // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
@@ -334,7 +343,7 @@ var collData = {
       {
         "type": "Causal",
         "labels": ["CAUSAL"],
-        "bgColor": "#BB8FCE",
+        "bgColor": causalEventColor,
         "borderColor": "darken",
         "arcs": [
           {"type": "cause", "labels": ["cause"], "borderColor": "darken", "bgColor":"pink"},
@@ -345,7 +354,7 @@ var collData = {
       {
         "type": "Affect",
         "labels": ["AFFECT"],
-        "bgColor": "#F7DC6F",
+        "bgColor": affectEventColor,
         "borderColor": "darken",
         "arcs": [
           {"type": "cause", "labels": ["cause"], "borderColor": "darken", "bgColor":"pink"},

--- a/webapp/public/javascripts/main.js
+++ b/webapp/public/javascripts/main.js
@@ -29,7 +29,7 @@ var collData = {
         "type"   : "Quantifier",
         "labels" : ["Quantifier", "Quant"],
         // Blue is a nice colour for a person?
-        "bgColor": "lightblue",
+        "bgColor": "#AED6F1",
         // Use a slightly darker version of the bgColor for the border
         "borderColor": "darken"
     },
@@ -37,7 +37,35 @@ var collData = {
             "type"   : "NounPhrase",
             "labels" : ["NounPhrase", "NP"],
             // Blue is a nice colour for a person?
-            "bgColor": "thistle",
+            //"bgColor": "thistle",
+            "bgColor": "#CCD1D1",
+            // Use a slightly darker version of the bgColor for the border
+            "borderColor": "darken"
+        },
+        {
+            "type"   : "NounPhrase-Inc",
+            "labels" : ["NounPhrase", "NP"],
+            // Blue is a nice colour for a person?
+            //"bgColor": "thistle",
+            "bgColor": "#BBDC90",
+            // Use a slightly darker version of the bgColor for the border
+            "borderColor": "darken"
+        },
+        {
+            "type"   : "NounPhrase-Dec",
+            "labels" : ["NounPhrase", "NP"],
+            // Blue is a nice colour for a person?
+            //"bgColor": "thistle",
+            "bgColor": "#FC5C38",
+            // Use a slightly darker version of the bgColor for the border
+            "borderColor": "darken"
+        },
+        {
+            "type"   : "NounPhrase-Quant",
+            "labels" : ["NounPhrase", "NP"],
+            // Blue is a nice colour for a person?
+            //"bgColor": "thistle",
+            "bgColor": "#85C1E9",
             // Use a slightly darker version of the bgColor for the border
             "borderColor": "darken"
         },
@@ -306,7 +334,7 @@ var collData = {
       {
         "type": "Causal",
         "labels": ["CAUSAL"],
-        "bgColor": "lightgreen",
+        "bgColor": "#BB8FCE",
         "borderColor": "darken",
         "arcs": [
           {"type": "cause", "labels": ["cause"], "borderColor": "darken", "bgColor":"pink"},
@@ -317,7 +345,7 @@ var collData = {
       {
         "type": "Affect",
         "labels": ["AFFECT"],
-        "bgColor": "PALETURQUOISE",
+        "bgColor": "#F7DC6F",
         "borderColor": "darken",
         "arcs": [
           {"type": "cause", "labels": ["cause"], "borderColor": "darken", "bgColor":"pink"},


### PR DESCRIPTION
To be honest -- I'm not sure this is the best way to accomplish this, so @kwalcock if you have another, cleaner suggestion or if @MihaiSurdeanu  you think this is all dumb, we can close the PR w/o merge

These changes are done for the benefit of the webapp display.  They include:
- adding NounPhrase-Inc, -Dec, and -Quant to the taxonomy under NounPhrase
- adding a helper method in the keepMostComplete action that collapses all of these to "NounPhrase" so that only one (most complete) nounPhrase is kept for each span
- adding extra entity types in the brat display stuff (main.js)
- and the whole reason for doing this -- I updated the colors of the display items 