### PR TITLE
Handle "poor" to fix p6s2/8

### DIFF
--- a/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
@@ -49,7 +49,7 @@ rules:
       #removed: support, produc
       attenu|abolish|abrog|antagon|arrest|attenu|block|deactiv|decreas|degrad|deplet|deregul|diminish|disrupt|
       down-reg|downreg|dysregul|elimin|impair|imped|inactiv|inhibit|knockdown|limit|loss|lower|negat|nullifi|
-      perturb|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shutdown|slow|starv|suppress|supress|worse/] # neg reg guys
+      perturb|poor|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shutdown|slow|starv|suppress|supress|worse/] # neg reg guys
 
 
   - name: "gradable"

--- a/src/main/resources/org/clulab/wm/grammars/master.yml
+++ b/src/main/resources/org/clulab/wm/grammars/master.yml
@@ -3,7 +3,7 @@ taxonomy: org/clulab/wm/grammars/taxonomy.yml
 vars:
   increase_triggers: "acceler|aid|augment|better|boost|elev|enhanc|greater|improv|increas|prolong|promot|rais|reactivat|restor|retent|stimul|support|synerg|up-regul|upregul"
 
-  decrease_triggers: "attenu|abolish|abrog|advers|antagon|arrest|attenu|block|cut|deactiv|declin|decreas|degrad|deplet|deregul|deteriorat|diminish|disrupt|down-reg|downreg|dysregul|elimin|impair|imped|inactiv|inadequate|inhibit|knockdown|limit|less|loss|low|negat|nullifi|perturb|phase|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shortage|shrink|shutdown|slow|starv|suppress|supress|worse"
+  decrease_triggers: "attenu|abolish|abrog|advers|antagon|arrest|attenu|block|cut|deactiv|declin|decreas|degrad|deplet|deregul|deteriorat|diminish|disrupt|down-reg|downreg|dysregul|elimin|impair|imped|inactiv|inadequate|inhibit|knockdown|limit|less|loss|low|negat|nullifi|perturb|phase|poor|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shortage|shrink|shutdown|slow|starv|suppress|supress|worse"
 
   cause_triggers: "activat|allow|cataly|caus|contribut|driv|elicit|enabl|induc|initi|interconvert|lead|led|mediat|modul|produc|signal|synthes|target|trigger|underli|"
 

--- a/src/test/scala/org/clulab/wm/TestCagP6.scala
+++ b/src/test/scala/org/clulab/wm/TestCagP6.scala
@@ -42,7 +42,7 @@ class TestCagP6 extends Test {
 
     val insecurity   = newNodeSpec("food insecurity", newIncrease("high", "unprecedented"))
     val fighting     = newNodeSpec("fighting", newUnmarked("widespread"))
-    val access       = newNodeSpec("access to services", newDecrease("poor"))
+    val access       = newNodeSpec("access to services", newDecrease("poor"), newQuantification("poor"))
     val morbidity    = newNodeSpec("morbidity", newIncrease("high"))
     val diet         = newNodeSpec("diet", newDecrease("poor", "extremely"))
     val coverage     = newNodeSpec("coverage of sanitation facilities", newDecrease("low"))

--- a/src/test/scala/org/clulab/wm/TestCagP6.scala
+++ b/src/test/scala/org/clulab/wm/TestCagP6.scala
@@ -74,7 +74,7 @@ class TestCagP6 extends Test {
     failingTest should "have correct edges 7" taggedAs(Becky) in {
       tester.test(newEdgeSpec(practices, Causal, malnutrition)) should be (successful)
     }
-    failingTest should "have correct edges 8" taggedAs(Ben) in {
+    it should "have correct edges 8" taggedAs(Ben) in {
       tester.test(newEdgeSpec(displacement, Causal, access)) should be (successful)
     }
   }


### PR DESCRIPTION
In an attempt to fix the test for p6s2/8, I added "poor" to the decrease triggers and get
```
List(Causal, EntityLinker, Event) => displacement causing poor access to services
    ------------------------------
    Rule => ported_syntax_1_verb-Causal
    Type => EventMention
    ------------------------------
    trigger => causing
    effect (NounPhrase, Entity) => access to services
     * Attachments: Quantification(poor), Decrease(poor,None)
    cause (NounPhrase, Entity) => displacement
    ------------------------------
```
with the expected Decrease on the "access to services" entity, which I thought would result in the test passing, but it is still failing; could someone help me figure out why?