### PR TITLE
Egoitz test1

### DIFF
--- a/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
@@ -43,12 +43,12 @@ rules:
       # we want any coordinated entities we might encounter to be split
       [word = /increas|improv|promot|boost|better|  # increase guys
       cut|declin|decreas|degrad|deteriorat|inadequate|less|limit|low|phase|reduc|shortage|shrink| # decrease guys
-      acceler|accept|activat|aid|allow|augment|cataly|caus|contribut|direct|driv|elev|elicit|enabl|enhanc|great|increas|
+      acceler|accept|activat|aid|allow|augment|cataly|caus|contribut|direct|driv|elev|elicit|enabl|enhanc|great|high|increas|
       induc|initi|interconvert|lead|led|mediat|modul|necess|overexpress|potenti|prolong|promot|rais|reactivat|
       re-express|rescu|restor|retent|signal|stimul|synerg|synthes|target|trigger|underli|up-regul|upregul| # pos reg guys,
       #removed: support, produc
-      attenu|abolish|abrog|antagon|arrest|attenu|block|deactiv|decreas|degrad|deplet|deregul|diminish|disrupt|
-      down-reg|downreg|dysregul|elimin|impair|imped|inactiv|inhibit|knockdown|limit|loss|lower|negat|nullifi|
+      attenu|abolish|abrog|antagon|arrest|attenu|block|collaps|deactiv|decreas|degrad|deplet|deregul|diminish|disrupt|
+      down-reg|downreg|dysregul|elimin|exhaust|impair|imped|inactiv|inhibit|knockdown|limit|loss|lower|negat|nullifi|
       perturb|poor|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shutdown|slow|starv|suppress|supress|worse/] # neg reg guys
 
 

--- a/src/main/resources/org/clulab/wm/grammars/causal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/causal.yml
@@ -31,8 +31,8 @@ rules:
     example: "food imports will decrease due to rainfall today"
     pattern: |
       trigger = [lemma="due" & tag=/JJ/]
-      cause: Entity = <advmod <nmod_due_to? nsubj
-      effect: Entity = nmod_to
+      cause: Entity = nmod_to (${ conjunctions })?
+      effect: Entity = <advmod|<amod <nmod_due_to? nsubj
 
   - name: dueToSyntax2-${addlabel}
     priority: ${rulepriority}
@@ -42,6 +42,16 @@ rules:
       trigger = [lemma="due" & tag=/JJ/]
       cause: Entity = <case
       effect: Entity = <case <nmod_due_to? nsubj
+
+  - name: dueToSyntax3-${addlabel}
+    priority: ${rulepriority}
+    label: ${label}
+    example: "food imports will decrease due to the exhaustion of coping capacities"
+    pattern: |
+      trigger = [lemma="due" & tag=/JJ/]
+      cause: Entity = nmod_to /_of$/ dobj? (${ conjunctions })?
+      effect: Entity = <advmod|<amod <nmod_due_to? nsubj
+
 
 # ------------------- Explicity Causal REACH --------------------------
 

--- a/src/main/resources/org/clulab/wm/grammars/master.yml
+++ b/src/main/resources/org/clulab/wm/grammars/master.yml
@@ -1,9 +1,9 @@
 taxonomy: org/clulab/wm/grammars/taxonomy.yml
 
 vars:
-  increase_triggers: "acceler|aid|augment|better|boost|elev|enhanc|greater|improv|increas|prolong|promot|rais|reactivat|restor|retent|stimul|support|synerg|up-regul|upregul"
+  increase_triggers: "acceler|aid|augment|better|boost|elev|enhanc|greater|high|improv|increas|prolong|promot|rais|reactivat|restor|retent|stimul|support|synerg|up-regul|upregul"
 
-  decrease_triggers: "attenu|abolish|abrog|advers|antagon|arrest|attenu|block|cut|deactiv|decimat|declin|decreas|degrad|deplet|deregul|deteriorat|diminish|disrupt|down-reg|downreg|dysregul|elimin|impair|imped|inactiv|inadequate|inhibit|knockdown|limit|less|loss|low|negat|nullifi|perturb|phase|poor|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shortage|shrink|shutdown|slow|starv|suppress|supress|worse"
+  decrease_triggers: "attenu|abolish|abrog|advers|antagon|arrest|attenu|block|collaps|cut|deactiv|decimat|declin|decreas|degrad|deplet|deregul|deteriorat|diminish|disrupt|down-reg|downreg|dysregul|elimin|exhaust|impair|imped|inactiv|inadequate|inhibit|knockdown|limit|less|loss|low|negat|nullifi|perturb|phase|poor|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shortage|shrink|shutdown|slow|starv|suppress|supress|worse"
 
   cause_triggers: "activat|allow|cataly|caus|contribut|driv|elicit|enabl|induc|initi|interconvert|lead|led|mediat|modul|produc|signal|synthes|target|trigger|underli|"
 

--- a/src/main/resources/org/clulab/wm/grammars/modifiersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/grammars/modifiersTemplate.yml
@@ -128,3 +128,13 @@ rules:
       trigger = [word=/(?i)^(${ trigger })/ & tag=/^N/]
       theme: Entity = /${ preps }$/? /${ conjunctions }|${ noun_modifiers }/{1,2}
       quantifier:Quantifier? = ${ quant_modifiers }
+
+  - name: ${ label }_ported_syntax_3_noun
+    priority: ${ objrulepriority }
+    example: "exhaustion of copying capacities"
+    label: ${ label }
+    action: ${ action }
+    pattern: |
+      trigger = [word=/(?i)^(${ trigger })/ & tag=/^N/]
+      theme: Entity = acl_of dobj
+      quantifier:Quantifier? = ${ quant_modifiers }

--- a/src/main/scala/org/clulab/wm/AgroActions.scala
+++ b/src/main/scala/org/clulab/wm/AgroActions.scala
@@ -54,7 +54,7 @@ class AgroActions extends Actions with LazyLogging {
     // We need to remove underspecified EventMentions of near-duplicate groupings
     // (ex. same phospho, but one is missing a site)
     val eventMentionGroupings =
-      events.map(_.asInstanceOf[EventMention]).groupBy(m => (m.trigger, m.label))
+      events.map(_.asInstanceOf[EventMention]).groupBy(m => (m.trigger, m.label, m.tokenInterval))
 
     // remove incomplete mentions
     val completeEventMentions =

--- a/src/test/scala/org/clulab/wm/TestCagP1.scala
+++ b/src/test/scala/org/clulab/wm/TestCagP1.scala
@@ -11,25 +11,25 @@ class TestCagP1 extends Test {
     val foodInsecurityLevels = newNodeSpec("Food insecurity levels") //fixme: add extra mods
     val conflict = newNodeSpec("conflict")
     val economy = newNodeSpec("economy", newDecrease("collapsing"))
-    val cerealProduction = newNodeSpec("cereal production", newDecrease("low"))
-    val rainfall = newNodeSpec("rainfall in southeastern areas", newDecrease("poor"))
+    val cerealProduction = newNodeSpec("cereal production", newDecrease("low"), newQuantification("low"))
+    val rainfall = newNodeSpec("rainfall in southeastern areas", newDecrease("poor"), newQuantification("poor"))
     val copingCapacities = newNodeSpec("coping capacities", newDecrease("exhaustion"))
 
     behavior of "p1s1"
 
-    failingTest should "have correct edges 1" taggedAs(Egoitz) in {
+    passingTest should "have correct edges 1" taggedAs(Egoitz) in {
       tester.test(newEdgeSpec(conflict, Causal, foodInsecurityLevels)) should be (successful)
     }
-    failingTest should "have correct edges 2" taggedAs(Egoitz) in {
+    passingTest should "have correct edges 2" taggedAs(Egoitz) in {
       tester.test(newEdgeSpec(economy, Causal, foodInsecurityLevels)) should be (successful)
     }
-    failingTest should "have correct edges 3" taggedAs(Egoitz) in {
+    passingTest should "have correct edges 3" taggedAs(Egoitz) in {
       tester.test(newEdgeSpec(cerealProduction, Causal, foodInsecurityLevels)) should be (successful)
     }
-    failingTest should "have correct edges 4" taggedAs(Egoitz) in {
+    passingTest should "have correct edges 4" taggedAs(Egoitz) in {
       tester.test(newEdgeSpec(rainfall, Causal, foodInsecurityLevels)) should be (successful)
     }
-    failingTest should "have correct edges 5" taggedAs(Egoitz) in {
+    passingTest should "have correct edges 5" taggedAs(Egoitz) in {
       tester.test(newEdgeSpec(copingCapacities, Causal, foodInsecurityLevels)) should be (successful)
     }
   }


### PR DESCRIPTION
- Changed keepMostCompleteEvents to remove incomplete event mentions only when overlap.
- Added dueToSyntax3 in causal.yml to capture entites with clausal modifiers
- Added ported_syntax_3_noun in modifiersTemplate.yml to link quantifiers to entities with clausal modifiers.
- Added newQuantification("low") and newQuantification("poor")  in TestCagP1.scala
- Changed "coping capacities" to "capacities" in TestCagP1. The entity "coping capacities" is not extracted due to a parse fail.
