### PR TITLE
Add option to print syntactic dependencies and enable it in RAPShell

### DIFF
--- a/src/main/scala/agro/demo/RAPShell.scala
+++ b/src/main/scala/agro/demo/RAPShell.scala
@@ -89,7 +89,7 @@ object RAPShell extends App {
     val mentions = ieSystem.extractFrom(doc).sortBy(m => (m.sentence, m.getClass.getSimpleName))
 
     // debug display the mentions
-    displayMentions(mentions, doc)
+    displayMentions(mentions, doc, true)
 
     // pretty display
 //    prettyDisplay(mentions, doc)

--- a/src/main/scala/utils/DisplayUtils.scala
+++ b/src/main/scala/utils/DisplayUtils.scala
@@ -8,13 +8,15 @@ import org.clulab.processors.{Document, Sentence}
 object DisplayUtils {
 
 
-  def displayMentions(mentions: Seq[Mention], doc: Document): Unit = {
+  def displayMentions(mentions: Seq[Mention], doc: Document, printDeps: Boolean = false): Unit = {
     val mentionsBySentence = mentions groupBy (_.sentence) mapValues (_.sortBy(_.start)) withDefaultValue Nil
     for ((s, i) <- doc.sentences.zipWithIndex) {
       println(s"sentence #$i")
       println(s.getSentenceText)
       println("Tokens: " + (s.words.indices, s.words, s.tags.get).zipped.mkString(", "))
-//      printSyntacticDependencies(s)
+      if(printDeps){
+          printSyntacticDependencies(s)
+      }
       println
 
       val sortedMentions = mentionsBySentence(i).sortBy(_.label)


### PR DESCRIPTION
This implements the approach in which syntactic dependencies are not printed by default, but they are specifically enabled in the RAPShell. Resolves #51 .