### PR TITLE
Egoitz test2

### DIFF
--- a/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
@@ -25,7 +25,7 @@ rules:
     example: "X HINDERS Y."
     type: token
     pattern: |
-      # avoid verbs with arguments
+      # avoid verbs with arguments but maintain copula
       [outgoing=/^nsubj/ & ! outgoing=/cop/]
 
   - name: "references-et-al"
@@ -77,6 +77,14 @@ rules:
     priority: 1
     type: token
     pattern: |
-      # avoid coordinations
-      # we want any coordinated entities we might encounter to be split
+      # avoid verbal affect triggers
       [tag = /VBG/ & word = /${ affect_triggers }/]
+
+  - name: "during"
+    label: Avoid
+    priority: 1
+    type: token
+    pattern: |
+      # avoid nmod_during
+      [incoming = nmod_during]
+

--- a/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
@@ -25,8 +25,8 @@ rules:
     example: "X HINDERS Y."
     type: token
     pattern: |
-      # avoid verbs with arguments but maintain copula
-      [outgoing=/^nsubj/ & ! outgoing=/cop/]
+      # avoid verbs with arguments
+      [outgoing=/^nsubj/ & tag=/^V/]
 
   - name: "references-et-al"
     label: Avoid

--- a/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
+++ b/src/main/resources/org/clulab/wm/grammars/avoidLocal.yml
@@ -1,3 +1,6 @@
+vars:
+  affect_triggers: "affect|alter|chang|impact|influenc|modifi|modify"
+  
 taxonomy:
   - Entity:
     - NounPhrase
@@ -23,7 +26,7 @@ rules:
     type: token
     pattern: |
       # avoid verbs with arguments
-      [outgoing=/^nsubj/]
+      [outgoing=/^nsubj/ & ! outgoing=/cop/]
 
   - name: "references-et-al"
     label: Avoid
@@ -47,7 +50,7 @@ rules:
       induc|initi|interconvert|lead|led|mediat|modul|necess|overexpress|potenti|prolong|promot|rais|reactivat|
       re-express|rescu|restor|retent|signal|stimul|synerg|synthes|target|trigger|underli|up-regul|upregul| # pos reg guys,
       #removed: support, produc
-      attenu|abolish|abrog|antagon|arrest|attenu|block|collaps|deactiv|decreas|degrad|deplet|depress|deregul|diminish|disrupt|
+      attenu|abolish|abrog|antagon|arrest|attenu|block|collaps|deactiv|decreas|defici|degrad|deplet|depress|deregul|diminish|disrupt|
       down-reg|downreg|dysregul|elimin|exhaust|impair|imped|inactiv|inhibit|knockdown|limit|loss|lower|negat|nullifi|
       perturb|poor|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shutdown|slow|starv|suppress|supress|worse/] # neg reg guys
 
@@ -69,3 +72,11 @@ rules:
       # we want any coordinated entities we might encounter to be split
       [word = /result|lead|due/]
 
+  - name: "affect-triggers"
+    label: Avoid
+    priority: 1
+    type: token
+    pattern: |
+      # avoid coordinations
+      # we want any coordinated entities we might encounter to be split
+      [tag = /VBG/ & word = /${ affect_triggers }/]

--- a/src/main/resources/org/clulab/wm/grammars/master.yml
+++ b/src/main/resources/org/clulab/wm/grammars/master.yml
@@ -3,7 +3,7 @@ taxonomy: org/clulab/wm/grammars/taxonomy.yml
 vars:
   increase_triggers: "acceler|aid|augment|better|boost|elev|enhanc|greater|high|improv|increas|prolong|promot|rais|reactivat|restor|retent|stimul|support|synerg|up-regul|upregul"
 
-  decrease_triggers: "attenu|abolish|abrog|advers|antagon|arrest|attenu|block|collaps|cut|deactiv|decimat|declin|decreas|degrad|deplet|depress|deregul|deteriorat|diminish|disrupt|down-reg|downreg|dysregul|elimin|exhaust|impair|imped|inactiv|inadequate|inhibit|knockdown|limit|less|loss|low|negat|nullifi|perturb|phase|poor|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shortage|shrink|shutdown|slow|starv|suppress|supress|worse"
+  decrease_triggers: "attenu|abolish|abrog|advers|antagon|arrest|attenu|block|collaps|cut|deactiv|decimat|declin|decreas|defici|degrad|deplet|depress|deregul|deteriorat|diminish|disrupt|down-reg|downreg|dysregul|elimin|exhaust|impair|imped|inactiv|inadequate|inhibit|knockdown|limit|less|loss|low|negat|nullifi|perturb|phase|poor|prevent|reduc|reliev|repress|resist|restrict|revers|sequester|shortage|shrink|shutdown|slow|starv|suppress|supress|worse"
 
   cause_triggers: "activat|allow|cataly|caus|contribut|driv|elicit|enabl|induc|initi|interconvert|lead|led|mediat|modul|produc|signal|synthes|target|trigger|underli|"
 

--- a/src/test/scala/org/clulab/wm/TestCagP1.scala
+++ b/src/test/scala/org/clulab/wm/TestCagP1.scala
@@ -54,7 +54,7 @@ class TestCagP1 extends Test {
     val tester = new Tester(p1s3)
   
     val rainfall = newNodeSpec("Rainfall", newDecrease("deficits"))
-    val shock = newNodeSpec("shock during the last agricultural season", newQuantification("major"))
+    val shock = newNodeSpec("shock", newQuantification("major"))
     val pasture = newNodeSpec("pasture")
     val waterAvailability = newNodeSpec("water availability")
     val foodProduction = newNodeSpec("local food production")

--- a/src/test/scala/org/clulab/wm/TestCagP1.scala
+++ b/src/test/scala/org/clulab/wm/TestCagP1.scala
@@ -54,23 +54,23 @@ class TestCagP1 extends Test {
     val tester = new Tester(p1s3)
   
     val rainfall = newNodeSpec("Rainfall", newDecrease("deficits"))
-    val shock = newNodeSpec("shock", newQuantification("major"))
+    val shock = newNodeSpec("shock during the last agricultural season", newQuantification("major"))
     val pasture = newNodeSpec("pasture")
     val waterAvailability = newNodeSpec("water availability")
     val foodProduction = newNodeSpec("local food production")
 
     behavior of "p1s3"
 
-    failingTest should "have correct edges 1" taggedAs(Egoitz) in {
+    passingTest should "have correct edges 1" taggedAs(Egoitz) in {
       tester.test(newEdgeSpec(shock, Affect, pasture)) should be (successful)
     }
-    failingTest should "have correct edges 2" taggedAs(Egoitz) in {
+    passingTest should "have correct edges 2" taggedAs(Egoitz) in {
       tester.test(newEdgeSpec(shock, Affect, waterAvailability)) should be (successful)
     }
-    failingTest should "have correct edges 3" taggedAs(Egoitz) in {
+    passingTest should "have correct edges 3" taggedAs(Egoitz) in {
       tester.test(newEdgeSpec(shock, Affect, foodProduction)) should be (successful)
     }
-    failingTest should "have correct singleton node 1" taggedAs(Egoitz) in {
+    passingTest should "have correct singleton node 1" taggedAs(Egoitz) in {
       tester.test(rainfall) should be (successful)
     }
   }


### PR DESCRIPTION
- Maintain copula when avoiding verbs with arguments: "was a major shock" 
- Avoid verbal affect triggers: "impacting pasture"
- Avoid nmod_during: "shock during the last agricultural season"