### PR TITLE
P6 three more passing tests for now

### DIFF
--- a/src/main/resources/org/clulab/wm/grammars/linkersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/grammars/linkersTemplate.yml
@@ -73,16 +73,18 @@ rules:
       cause: Entity = </xcomp|advcl/? (${ agents }) /${ noun_modifiers }|${ conjunctions }|${ preps }/{,2}
 
 
-  # Note: Captures passive voice; thus verb must be VBD|VBN
-  - name: ported_syntax_2_verb-${addlabel}
-    priority: ${ rulepriority }
-    #example: "Increase in poverty was caused by the water quality."
-    example: "intensive cultivation will be caused by a shrinking land base for agriculture"
-    label: ${ label }
-    pattern: |
-      trigger = [word=/(?i)^(${ trigger })/ & tag=/VBD|VBN|RB/]
-      effect: Entity = (>/^nsubj/|<vmod) /${ noun_modifiers }|${ conjunctions }/{,2}
-      cause: Entity = (agent|nmod_by) /${ noun_modifiers }|${ conjunctions }|${ preps }/{,2}
+# BS: removed bc seems that passive voice is consistently captured with nsubjpass, and was mis-labeling some causal events (i.e. their polarity)
+# ex of issue: The water quality caused poverty by an increase in productivity.
+#  # Note: Captures passive voice; thus verb must be VBD|VBN
+#  - name: ported_syntax_2_verb-${addlabel}
+#    priority: ${ rulepriority }
+#    #example: "Increase in poverty was caused by the water quality."
+#    example: "intensive cultivation will be caused by a shrinking land base for agriculture"
+#    label: ${ label }
+#    pattern: |
+#      trigger = [word=/(?i)^(${ trigger })/ & tag=/VBD|VBN|RB/]
+#      effect: Entity = (>/^nsubj/|<vmod) /${ noun_modifiers }|${ conjunctions }/{,2}
+#      cause: Entity = (agent|nmod_by) /${ noun_modifiers }|${ conjunctions }|${ preps }/{,2}
 
 
 #  #Is this trying to catch parser errors??? what???

--- a/src/main/resources/org/clulab/wm/grammars/linkersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/grammars/linkersTemplate.yml
@@ -2,6 +2,7 @@ vars:
   agents: "nsubj | nsubjpass | csubj | csubjpass | <acl"  #Comment:  nsubjpass for cause should not be there in an ideal world; but it does show up in practice
   conjunctions: "appos|conj|conj_|cc"
   complements: "xcomp|ccomp"
+  adverbial_clause: "advcl"
   noun_modifiers: "amod|compound|dep|name"
   negTriggers: "not"
   objects: "dobj"
@@ -56,7 +57,7 @@ rules:
     pattern: |
       trigger = [word=/(?i)^(${ trigger })/ & tag=/^V/] # original rule had RB as possible tag
       effect: Entity = prepc_by? (${objects} | ${complements}) /${ conjunctions }|${ objects }|${ noun_modifiers }|${ preps }/{,2}
-      cause: Entity = </xcomp|advcl/? (${ agents }) /${ conjunctions }|${ noun_modifiers}|${ preps }/{,2}
+      cause: Entity = </${complements}|${adverbial_clause}/? (${ agents }) /${ conjunctions }|${ noun_modifiers}|${ preps }/{,2}
 
 
 
@@ -70,7 +71,7 @@ rules:
     pattern: |
       trigger = [word=/(?i)^(${ trigger })/ & tag=/^V/]
       effect: Entity = nmod_by /${ conjunctions }|${ objects }|${ noun_modifiers }|${ preps }/{,2}
-      cause: Entity = </xcomp|advcl/? (${ agents }) /${ noun_modifiers }|${ conjunctions }|${ preps }/{,2}
+      cause: Entity = </${complements}|${adverbial_clause}/? (${ agents }) /${ noun_modifiers }|${ conjunctions }|${ preps }/{,2}
 
 
 # BS: removed bc seems that passive voice is consistently captured with nsubjpass, and was mis-labeling some causal events (i.e. their polarity)

--- a/src/main/resources/org/clulab/wm/grammars/linkersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/grammars/linkersTemplate.yml
@@ -56,7 +56,9 @@ rules:
     pattern: |
       trigger = [word=/(?i)^(${ trigger })/ & tag=/^V/] # original rule had RB as possible tag
       effect: Entity = prepc_by? (${objects} | ${complements}) /${ conjunctions }|${ objects }|${ noun_modifiers }|${ preps }/{,2}
-      cause: Entity = <xcomp? (${ agents }) /${ conjunctions }|${ noun_modifiers}|${ preps }/{,2}
+      cause: Entity = </xcomp|advcl/? (${ agents }) /${ conjunctions }|${ noun_modifiers}|${ preps }/{,2}
+
+
 
 
 
@@ -68,7 +70,7 @@ rules:
     pattern: |
       trigger = [word=/(?i)^(${ trigger })/ & tag=/^V/]
       effect: Entity = nmod_by /${ conjunctions }|${ objects }|${ noun_modifiers }|${ preps }/{,2}
-      cause: Entity = <xcomp? (${ agents }) /${ noun_modifiers }|${ conjunctions }|${ preps }/{,2}
+      cause: Entity = </xcomp|advcl/? (${ agents }) /${ noun_modifiers }|${ conjunctions }|${ preps }/{,2}
 
 
   # Note: Captures passive voice; thus verb must be VBD|VBN

--- a/src/test/scala/org/clulab/wm/TestCagP6.scala
+++ b/src/test/scala/org/clulab/wm/TestCagP6.scala
@@ -16,7 +16,7 @@ class TestCagP6 extends Test {
   
     behavior of "p6s1"
     
-    failingTest should "have correct edges 1" taggedAs(Becky) in {
+    passingTest should "have correct edges 1" taggedAs(Becky) in {
       tester.test(newEdgeSpec(insecurity, Affect, functionality)) should be (successful)
     }
     passingTest should "have correct edges 2" taggedAs(Becky) in {
@@ -26,10 +26,10 @@ class TestCagP6 extends Test {
       tester.test(newEdgeSpec(insecurity, Causal, access)) should be (successful)
     }
     
-    failingTest should "have correct edges 4" taggedAs(Becky) in {
+    passingTest should "have correct edges 4" taggedAs(Becky) in {
       tester.test(newEdgeSpec(conflict, Affect, functionality)) should be (successful)
     }
-    failingTest should "have correct edges 5" taggedAs(Becky) in {
+    passingTest should "have correct edges 5" taggedAs(Becky) in {
       tester.test(newEdgeSpec(conflict, Causal, activities)) should be (successful)
     }
     failingTest should "have correct edges 6" taggedAs(Becky) in {


### PR DESCRIPTION
- added adverbial clauses to a couple of rules, 
- removed a rule that seems to mislabel polarity of passive constructions now that it was "converted" to universal deps representation.  we can either add it back or fix it (or maybe with new syntax rep it's subsumed by the other passive test?)