### PR TITLE
Rest of the RAPs tests

### DIFF
--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps.scala
@@ -1,7 +1,7 @@
-package org.clulab.wm.eidos.system
+package org.clulab.wm.eidos.text.raps
 
 import org.clulab.wm.eidos.test.TestUtils._
-import org.clulab.wm.eidos.text.{Inc, Dec, Quant, Causal, Origin, TransparentLink, EdgeSpec, NodeSpec}
+import org.clulab.wm.eidos.text._
 
 
 class TestRaps extends Test {

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -204,11 +204,31 @@ class TestRaps1 extends Test {
     behavior of "Raps_28"
 
     failingTest should "have correct edge 1" taggedAs(Heather) in {
-      tester.test(EdgeSpec(pollution, Causal, soil))
+      tester.test(EdgeSpec(pollution, Causal, soil)) should be (successful)
     }
 
     passingTest should "have correct edge 2" taggedAs(Heather) in {
-      tester.test(EdgeSpec(shrink, Causal, cultivation))
+      tester.test(EdgeSpec(shrink, Causal, cultivation)) should be (successful)
+    }
+
+  }
+
+  {
+    val sent29 = "Labor migration and HIV/AIDS result in labor shortage."
+    val tester = new Tester(sent29)
+
+    val migration = NodeSpec("Labor migration")
+    val hiv = NodeSpec("HIV/AIDS")
+    val labor = NodeSpec("labor", Dec("shortage"))
+
+    behavior of "Raps_29"
+
+    failingTest should "have correct edge 1" taggedAs(Heather) in {
+      tester.test(EdgeSpec(migration, Causal, labor)) should be (successful)
+    }
+
+    failingTest should "have correct edge 2" taggedAs(Heather) in {
+      tester.test(EdgeSpec(hiv, Causal, labor)) should be (successful)
     }
 
   }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -55,5 +55,24 @@ class TestRaps1 extends Test {
 
   }
 
+  {
+    val sent22 = "Along with the support programs such as agricultural insurance and input subsidies, the government efforts and investments will be increased for extending irrigation services, agricultural mechanization, and developing disaster risk-management practices."
+    val tester = new Tester(sent22)
+
+    val gov = NodeSpec("government efforts", Inc("increased"))
+    val investments = NodeSpec("investments", Inc("increased"))
+
+    behavior of "Raps_sent22"
+
+    passingTest should "have correct node 1" taggedAs(Heather) in {
+      tester.test(gov) should be (successful)
+    }
+
+    passingTest should "have correct node 2" taggedAs(Heather) in {
+      tester.test(investments) should be (successful)
+    }
+
+  }
+
 
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -192,5 +192,26 @@ class TestRaps1 extends Test {
 
   }
 
+  {
+    val sent28 = "Soil quality will decline by a small-to-medium extent, due to pollution, and intensive cultivation will be caused by a shrinking land base for agriculture."
+    val tester = new Tester(sent28)
+
+    val soil = NodeSpec("Soil quality", Dec("decline", "small-to-medium"))
+    val pollution = NodeSpec("pollution")
+    val shrink = NodeSpec("land base for agriculture", Dec("shrinking"))
+    val cultivation = NodeSpec("intensive cultivation")
+
+    behavior of "Raps_28"
+
+    failingTest should "have correct edge 1" taggedAs(Heather) in {
+      tester.test(EdgeSpec(pollution, Causal, soil))
+    }
+
+    passingTest should "have correct edge 2" taggedAs(Heather) in {
+      tester.test(EdgeSpec(shrink, Causal, cultivation))
+    }
+
+  }
+
 
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -144,5 +144,29 @@ class TestRaps1 extends Test {
 
   }
 
+  {
+    val sent26 = "Labor migration to urban areas, non agricultural activities and impact of HIV/AIDS also leads to labor shortages."
+    val tester = new Tester(sent26)
+
+    val migration = NodeSpec("Labor migration to urban areas")
+    val activities = NodeSpec("non agricultural activities")
+    val hiv = NodeSpec("impact of HIV/AIDS")
+    val shortage = NodeSpec("labor", Dec("shortages"))
+
+    behavior of "Raps_26"
+
+    failingTest should "have correct edge 1" taggedAs(Heather) in {
+      tester.test(EdgeSpec(migration, Causal, shortage)) should be (successful)
+    }
+
+    failingTest should "have correct edge 2" taggedAs(Heather) in {
+      tester.test(EdgeSpec(activities, Causal, shortage)) should be (successful)
+    }
+
+    failingTest should "have correct edge 3" taggedAs(Heather) in {
+      tester.test(EdgeSpec(hiv, Causal, shortage)) should be (successful)
+    }
+  }
+
 
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -31,4 +31,29 @@ class TestRaps1 extends Test {
 
   }
 
+  {
+    //Unsure exactly what this sentences convey. Are there actually any causal events here?
+    val sent21 = "A combination of increasing population, government plans to invest in fertilizer factory, " +
+      "government subsidy on fertilizers, improved economic performance expected to cause a shift from agriculture to service industry, " +
+      "government plans for massive expansion of irrigation (irrigate 1 million ha.), newly devolved county governments etc. are some of the developments " +
+      "expected to change agriculture development in the country."
+    val tester = new Tester(sent21)
+
+    val population = NodeSpec("population", Inc("increasing"))
+    val econ = NodeSpec("economic performance", Inc("improved"))
+
+    behavior of "Raps_sent21"
+
+    passingTest should "have correct node 1" taggedAs(Heather) in {
+      tester.test(population) should be (successful)
+    }
+
+    //currently extracts "economic performance expected" as the entity text
+    failingTest should "have correct node 2" taggedAs(Heather) in {
+      tester.test(econ) should be (successful)
+    }
+
+  }
+
+
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -168,5 +168,29 @@ class TestRaps1 extends Test {
     }
   }
 
+  {
+    val sent27 = "Agricultural production and profitability are declining, land is degrading and being underutilized."
+    val tester = new Tester(sent27)
+
+    val prod = NodeSpec("Agricultural production", Dec("declining"))
+    val profits = NodeSpec("profitability", Dec("declining"))
+    val land = NodeSpec("land", Dec("degrading"))
+
+    behavior of "Raps_27"
+
+    passingTest should "have correct node 1" taggedAs(Heather) in {
+      tester.test(prod) should be (successful)
+    }
+
+    passingTest should "have correct node 2" taggedAs(Heather) in {
+      tester.test(profits) should be (successful)
+    }
+
+    failingTest should "have correct node 3" taggedAs(Heather) in {
+      tester.test(land) should be (successful)
+    }
+
+  }
+
 
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -121,5 +121,28 @@ class TestRaps1 extends Test {
 
   }
 
+  {
+    val sent25 = "With a high cost of production and degraded natural resources, profitability in agriculture may be further reduced, making agriculture unprofitable."
+    val tester = new Tester(sent25)
+
+    val cost = NodeSpec("cost of production", Quant("high"), Inc("high"))
+    val resources = NodeSpec("natural resources", Dec("degraded"))
+    val profit = NodeSpec("profitability in agriculture", Dec("reduced"))
+
+
+    behavior of "Raps_25"
+
+    failingTest should "have correct edge 1" taggedAs(Heather) in {
+      tester.test(EdgeSpec(cost, Causal, profit)) should be (successful)
+
+    }
+
+    failingTest should "have correct edge 2" taggedAs(Heather) in {
+      tester.test(EdgeSpec(resources, Causal, profit)) should be (successful)
+
+    }
+
+  }
+
 
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -74,5 +74,52 @@ class TestRaps1 extends Test {
 
   }
 
+  {
+    val sent23 = "The transformation however starts under extremely difficult conditions, characterized by large account deficit and liquidity challenges and limited direct foreign investment due to lack of clarity on investment security and high interest rates."
+    val tester = new Tester(sent23)
+
+    val account = NodeSpec("account", Dec("deficit", "large"))
+    val invest = NodeSpec("direct foreign investment", Dec("limited"))
+    val noClarity = NodeSpec("clarity", Dec("lack"))
+    val interestRates = NodeSpec("interest rates", Quant("high"), Inc("high"))
+
+    val conditions = NodeSpec("difficult conditions", Quant("extremely"))
+
+    behavior of "Raps_sent23"
+
+    passingTest should "have correct node 1" taggedAs(Heather) in {
+      tester.test(conditions) should be (successful)
+    }
+
+    //extracts properly in the Eidos shell
+    failingTest should "have correct node 2" taggedAs(Heather) in {
+      tester.test(account) should be (successful)
+    }
+
+    failingTest should "have correct edge 1" taggedAs(Heather) in {
+      tester.test(EdgeSpec(invest, Causal, noClarity)) should be (successful)
+    }
+
+    failingTest should "have correct edge 2" taggedAs(Heather) in {
+      tester.test(EdgeSpec(invest, Causal, interestRates)) should be (successful)
+    }
+
+  }
+
+  { //TODO: does "adversely" affect mean a decrease?
+    val sent24 = "Global trends suggest that rice wheat production in the region will be adversely affected by climate change."
+    val tester = new Tester(sent24)
+
+    val wheat = NodeSpec("rice wheat production in the region")
+    val climate = NodeSpec("climate")
+
+    behavior of "Raps_24"
+
+    passingTest should "have correct edge" taggedAs(Heather) in {
+      tester.test(EdgeSpec(climate, Causal, wheat)) should be (successful)
+    }
+
+  }
+
 
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -243,7 +243,23 @@ class TestRaps1 extends Test {
     behavior of "Raps_30"
 
     failingTest should "have correct edge" taggedAs(Heather) in {
-      tester.test(EdgeSpec(inequality, Causal, share))
+      tester.test(EdgeSpec(inequality, Causal, share)) should be (successful)
+    }
+
+  }
+
+  {
+    val sent31 = "The adoption process will be instigated due to the anticipated losses in agricultural productivity in the face of climatic uncertainties."
+    val tester = new Tester(sent31)
+
+    val adoption = NodeSpec("adoption process")
+    val losses = NodeSpec("anticipated losses")
+    val prod = NodeSpec("agricultural productivity", Dec("losses"))
+
+    behavior of "Raps_31"
+
+    failingTest should "have correct edge" taggedAs(Heather) in {
+      tester.test(EdgeSpec(losses, Causal, adoption)) should be (successful)
     }
 
   }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -233,5 +233,20 @@ class TestRaps1 extends Test {
 
   }
 
+  {
+    val sent30 = "Share of agriculture in overall economy will decrease with increase in inequality."
+    val tester = new Tester(sent30)
+
+    val share = NodeSpec("Share of agriculture in overall economy", Dec("decrease"))
+    val inequality = NodeSpec("inequality", Inc("increase"))
+
+    behavior of "Raps_30"
+
+    failingTest should "have correct edge" taggedAs(Heather) in {
+      tester.test(EdgeSpec(inequality, Causal, share))
+    }
+
+  }
+
 
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -1,0 +1,34 @@
+package org.clulab.wm.eidos.text.raps
+
+import org.clulab.wm.eidos.test.TestUtils._
+import org.clulab.wm.eidos.text._
+
+
+class TestRaps1 extends Test {
+
+  { //3 Increase
+    val sent20 = "Hence, government liberalizes imports of food grains, invests in food chain logistics, and boost research and development for new crop cultivars to boost agricultural production for ensuring food security."
+    val tester = new Tester(sent20)
+
+    val research = NodeSpec("research", Inc("boost"))
+    val dev = NodeSpec("development", Inc("boost"))
+    val prod = NodeSpec("agricultural production", Inc("boost"))
+
+
+    behavior of "Raps_sent20"
+
+    passingTest should "have the correct node 1" taggedAs(Heather) in {
+      tester.test(research) should be (successful)
+    }
+
+    passingTest should "have the correct node 2" taggedAs(Heather) in {
+      tester.test(dev) should be (successful)
+    }
+
+    passingTest should "have the correct node 3" taggedAs(Heather) in {
+      tester.test(prod) should be (successful)
+    }
+
+  }
+
+}


### PR DESCRIPTION
* Finished all tests for RAPs tests! 
    * Note: Not all of the tests are passing here, but I can work on updating the grammar to address reoccurring failures in failing `raps`, `eval6`, and `cag` tests when we get there :) 
* Restructured RAPs tests to be similar to `cag`and `eval6` (as discussed in my last PR) 

Let me know if there's anything you'd like to see added before a merge. 