### PR TITLE
DisplayUtils cleanup

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
@@ -8,202 +8,151 @@ import scala.runtime.ZippedTraversable3.zippedTraversable3ToTraversable
 object DisplayUtils {
 
 
-  def displayMentions(mentions: Seq[Mention], doc: Document, printDeps: Boolean = false): Unit = {
+  def mentionsToDisplayString(
+    mentions: Seq[Mention],
+    doc: Document,
+    printDeps: Boolean = false,
+    newline: String = "\n",
+    tab: String = "\t"): String = {
+
+    val sb = new StringBuffer()
     val mentionsBySentence = mentions groupBy (_.sentence) mapValues (_.sortBy(_.start)) withDefaultValue Nil
     for ((s, i) <- doc.sentences.zipWithIndex) {
-      println(s"sentence #$i")
-      println(s.getSentenceText)
-      println("Tokens: " + (s.words.indices, s.words, s.tags.get).zipped.mkString(", "))
-      if(printDeps){
-          printSyntacticDependencies(s)
-      }
-      println
+      sb.append(s"sentence #$i $newline")
+      sb.append(s.getSentenceText + newline)
+      sb.append("Tokens: " + (s.words.indices, s.words, s.tags.get).zipped.mkString(", ") + newline)
+      if (printDeps) sb.append(syntacticDependenciesToString(s) + newline)
+      sb.append(newline)
+
 
       val sortedMentions = mentionsBySentence(i).sortBy(_.label)
       val (events, entities) = sortedMentions.partition(_ matches "Event")
       val (tbs, rels) = entities.partition(_.isInstanceOf[TextBoundMention])
       val sortedEntities = tbs ++ rels.sortBy(_.label)
-      println("entities:")
-      sortedEntities foreach displayMention
+      sb.append(s"entities: $newline")
+      sortedEntities.foreach(e => sb.append(s"${mentionToDisplayString(e, newline, tab)} $newline"))
 
-      println
-      println("events:")
-      events foreach displayMention
-      println("=" * 50)
-    }
-  }
-
-  def printMentions(mentions: Seq[Mention], doc: Document, pw: PrintWriter): Unit = {
-    val mentionsBySentence = mentions groupBy (_.sentence) mapValues (_.sortBy(_.start)) withDefaultValue Nil
-    for ((s, i) <- doc.sentences.zipWithIndex) {
-      pw.println(s"sentence #$i")
-      pw.println(s.getSentenceText)
-      pw.println("Tokens: " + (s.words.indices, s.words, s.tags.get).zipped.mkString(", "))
-      //      printSyntacticDependencies(s)
-      pw.println
-
-      val sortedMentions = mentionsBySentence(i).sortBy(_.label)
-      val (events, entities) = sortedMentions.partition(_ matches "Event")
-      val (tbs, rels) = entities.partition(_.isInstanceOf[TextBoundMention])
-      val sortedEntities = tbs ++ rels.sortBy(_.label)
-      pw.println("entities:")
-      sortedEntities.foreach(e => printMention(e, pw))
-
-      pw.println
-      pw.println("events:")
-      events.foreach(e => printMention(e, pw))
-      pw.println("=" * 50)
-    }
-  }
-
-  def printSyntacticDependencies(s:Sentence): Unit = {
-    if(s.dependencies.isDefined) {
-      println(s.dependencies.get.toString)
-    }
-  }
-
-  def attachmentsString(mods: Set[Attachment]): String = s"${mods.mkString(", ")}"
-
-  def displayMention(mention: Mention) {
-    val boundary = s"\t${"-" * 30}"
-    println(s"${mention.labels} => ${mention.text}")
-    println(boundary)
-    println(s"\tRule => ${mention.foundBy}")
-    val mentionType = mention.getClass.toString.split("""\.""").last
-    println(s"\tType => $mentionType")
-    println(boundary)
-    mention match {
-      case tb: TextBoundMention =>
-        println(s"\t${tb.labels.mkString(", ")} => ${tb.text}")
-        if (tb.attachments.nonEmpty) println(s"\t  * Attachments: ${attachmentsString(tb.attachments)}")
-      case em: EventMention =>
-        println(s"\ttrigger => ${em.trigger.text}")
-        if (em.trigger.attachments.nonEmpty) println(s"\t  * Attachments: ${attachmentsString(em.trigger.attachments)}")
-        displayArguments(em)
-        if (em.attachments.nonEmpty) {
-          println(s"\tEvent Attachments: ${attachmentsString(em.attachments)}")
-        }
-      case rel: RelationMention =>
-        displayArguments(rel)
-        if (rel.attachments.nonEmpty) {
-          println(s"\tRelation Attachments: ${attachmentsString(rel.attachments)}")
-        }
-      case cs: CrossSentenceMention =>
-        displayArguments(cs)
-        if (cs.attachments.nonEmpty) {
-          println(s"\tCross-sentence Attachments: ${attachmentsString(cs.attachments)}")
-        }
-      case _ => ()
-    }
-    println(s"$boundary\n")
-  }
-
-  def webAppMention(mention: Mention): String = {
-    val sb = new StringBuilder
-    val boundary = s"${tab}${"-" * 30}<br>"
-    sb.append(s"${mention.labels} => ${mention.text}<br>")
-    sb.append(boundary)
-    sb.append(s"${tab}Rule => ${mention.foundBy}<br>")
-    val mentionType = mention.getClass.toString.split("""\.""").last
-    sb.append(s"${tab}Type => $mentionType<br>")
-    sb.append(boundary)
-    mention match {
-      case tb: TextBoundMention =>
-        sb.append(s"${tab}${tb.labels.mkString(", ")} => ${tb.text}<br>")
-        if (tb.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(tb.attachments)}<br>")
-      case em: EventMention =>
-        sb.append(s"${tab}trigger => ${em.trigger.text}<br>")
-        if (em.trigger.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(em.trigger.attachments)}<br>")
-        sb.append(webAppArguments(em))
-        if (em.attachments.nonEmpty) {
-          sb.append(s"${tab}Event Attachments: ${attachmentsString(em.attachments)}<br>")
-        }
-      case rel: RelationMention =>
-        sb.append(webAppArguments(rel))
-        if (rel.attachments.nonEmpty) {
-          sb.append(s"${tab}Relation Attachments: ${attachmentsString(rel.attachments)}<br>")
-        }
-      case _ => ()
-    }
-    sb.append(s"$boundary<br>")
-
-    sb.toString()
-  }
-
-  def printMention(mention: Mention, pw: PrintWriter) {
-    val boundary = s"\t${"-" * 30}"
-    pw.println(s"${mention.labels} => ${mention.text}")
-    pw.println(boundary)
-    pw.println(s"\tRule => ${mention.foundBy}")
-    val mentionType = mention.getClass.toString.split("""\.""").last
-    pw.println(s"\tType => $mentionType")
-    pw.println(boundary)
-    mention match {
-      case tb: TextBoundMention =>
-        pw.println(s"\t${tb.labels.mkString(", ")} => ${tb.text}")
-        if (tb.attachments.nonEmpty) pw.println(s"\t  * Attachments: ${attachmentsString(tb.attachments)}")
-      case em: EventMention =>
-        pw.println(s"\ttrigger => ${em.trigger.text}")
-        if (em.trigger.attachments.nonEmpty) pw.println(s"\t  * Attachments: ${attachmentsString(em.trigger.attachments)}")
-        printArguments(em, pw)
-        if (em.attachments.nonEmpty) {
-          pw.println(s"\tEvent Attachments: ${attachmentsString(em.attachments)}")
-        }
-      case rel: RelationMention =>
-        printArguments(rel, pw)
-        if (rel.attachments.nonEmpty) {
-          pw.println(s"\tRelation Attachments: ${attachmentsString(rel.attachments)}")
-        }
-      case _ => ()
-    }
-    pw.println(s"$boundary\n")
-  }
-
-
-
-  def displayArguments(b: Mention): Unit = {
-    b.arguments foreach {
-      case (argName, ms) =>
-        ms foreach { v =>
-          println(s"\t$argName ${v.labels.mkString("(", ", ", ")")} => ${v.text}")
-          if (v.attachments.nonEmpty) println(s"\t  * Attachments: ${attachmentsString(v.attachments)}")
-        }
-    }
-  }
-
-  def webAppArguments(b: Mention): String = {
-    val sb = new StringBuilder
-    b.arguments foreach {
-      case (argName, ms) =>
-        ms foreach { v =>
-          sb.append(s"${tab}$argName ${v.labels.mkString("(", ", ", ")")} => ${v.text}<br>")
-          if (v.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(v.attachments)}<br>")
-        }
+      sb.append(newline)
+      sb.append(s"events: $newline")
+      events.foreach(e => sb.append(s"${mentionToDisplayString(e, newline, tab)} $newline"))
+      sb.append(s"${"=" * 50} $newline")
     }
     sb.toString()
   }
 
-  def printArguments(b: Mention, pw: PrintWriter): Unit = {
-    b.arguments foreach {
-      case (argName, ms) =>
-        ms foreach { v =>
-          pw.println(s"\t$argName ${v.labels.mkString("(", ", ", ")")} => ${v.text}")
-          if (v.attachments.nonEmpty) pw.println(s"\t  * Attachments: ${attachmentsString(v.attachments)}")
+  def mentionToDisplayString(mention: Mention, newline: String, tab: String): String = {
+    val sb = new StringBuffer()
+    val boundary = s"$tab ${"-" * 30} $newline"
+    sb.append(s"${mention.labels} => ${mention.text} $newline")
+    sb.append(boundary)
+    sb.append(s"$tab Rule => ${mention.foundBy} $newline")
+    val mentionType = mention.getClass.toString.split("""\.""").last
+    sb.append(s"$tab Type => $mentionType $newline")
+    sb.append(boundary)
+    mention match {
+      case tb: TextBoundMention =>
+        sb.append(s"$tab ${tb.labels.mkString(", ")} => ${tb.text} $newline")
+        if (tb.attachments.nonEmpty) sb.append(s"$tab  * Attachments: ${attachmentsString(tb.attachments)} $newline")
+      case em: EventMention =>
+        sb.append(s"$tab trigger => ${em.trigger.text} $newline")
+        if (em.trigger.attachments.nonEmpty) sb.append(s"$tab  * Attachments: ${attachmentsString(em.trigger.attachments)} $newline")
+        sb.append(argumentsToString(em, newline, tab) + newline)
+        if (em.attachments.nonEmpty) {
+          sb.append(s"$tab Event Attachments: ${attachmentsString(em.attachments)} $newline")
         }
+      case rel: RelationMention =>
+        sb.append(argumentsToString(rel, newline, tab) + newline)
+        if (rel.attachments.nonEmpty) {
+          sb.append(s"$tab Relation Attachments: ${attachmentsString(rel.attachments)} $newline")
+        }
+      case _ => ()
     }
+    sb.append(s"$boundary $newline")
+    sb.toString()
   }
 
-  def argumentsToString(b: Mention): String = {
+  def argumentsToString(b: Mention, newline: String, tab: String): String = {
     val sb = new StringBuffer
     b.arguments foreach {
       case (argName, ms) =>
         ms foreach { v =>
-          sb.append(s"\t$argName ${v.labels.mkString("(", ", ", ")")} => ${v.text}")
+          sb.append(s"$tab $argName ${v.labels.mkString("(", ", ", ")")} => ${v.text} $newline")
+          if (v.attachments.nonEmpty) sb.append(s"$tab  * Attachments: ${attachmentsString(v.attachments)} $newline")
         }
     }
-    sb.toString
+    sb.toString()
   }
 
+  def attachmentsString(mods: Set[Attachment]): String = s"${mods.mkString(", ")}"
+
+
+  def displayMentions(mentions: Seq[Mention], doc: Document, printDeps: Boolean = false): Unit = {
+    println(mentionsToDisplayString(mentions, doc, printDeps, "\n", "\t"))
+  }
+
+  def printMentions(mentions: Seq[Mention], doc: Document, pw: PrintWriter, printDeps: Boolean = false): Unit = {
+    pw.println(mentionsToDisplayString(mentions, doc, printDeps, "\n", "\t"))
+  }
+
+  def syntacticDependenciesToString(s:Sentence): String = {
+    if (s.dependencies.isDefined) {
+      s.dependencies.get.toString
+    } else "[Dependencies not defined]"
+  }
+
+
+  def displayMention(mention: Mention) = println(mentionToDisplayString(mention, "\n", "\t"))
+
+
+  def webAppMention(mention: Mention): String = {
+    mentionToDisplayString(mention, "<br>", htmltab)
+
+//    val sb = new StringBuilder
+//    val boundary = s"${tab}${"-" * 30}<br>"
+//    sb.append(s"${mention.labels} => ${mention.text}<br>")
+//    sb.append(boundary)
+//    sb.append(s"${tab}Rule => ${mention.foundBy}<br>")
+//    val mentionType = mention.getClass.toString.split("""\.""").last
+//    sb.append(s"${tab}Type => $mentionType<br>")
+//    sb.append(boundary)
+//    mention match {
+//      case tb: TextBoundMention =>
+//        sb.append(s"${tab}${tb.labels.mkString(", ")} => ${tb.text}<br>")
+//        if (tb.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(tb.attachments)}<br>")
+//      case em: EventMention =>
+//        sb.append(s"${tab}trigger => ${em.trigger.text}<br>")
+//        if (em.trigger.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(em.trigger.attachments)}<br>")
+//        sb.append(webAppArguments(em))
+//        if (em.attachments.nonEmpty) {
+//          sb.append(s"${tab}Event Attachments: ${attachmentsString(em.attachments)}<br>")
+//        }
+//      case rel: RelationMention =>
+//        sb.append(webAppArguments(rel))
+//        if (rel.attachments.nonEmpty) {
+//          sb.append(s"${tab}Relation Attachments: ${attachmentsString(rel.attachments)}<br>")
+//        }
+//      case _ => ()
+//    }
+//    sb.append(s"$boundary<br>")
+//
+//    sb.toString()
+  }
+
+  def printMention(mention: Mention, pw: PrintWriter) = pw.println(mentionToDisplayString(mention, "\n", "\t"))
+
+//  def webAppArguments(b: Mention): String = {
+//    val sb = new StringBuilder
+//    b.arguments foreach {
+//      case (argName, ms) =>
+//        ms foreach { v =>
+//          sb.append(s"${tab}$argName ${v.labels.mkString("(", ", ", ")")} => ${v.text}<br>")
+//          if (v.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(v.attachments)}<br>")
+//        }
+//    }
+//    sb.toString()
+//  }
+
+
   // html tab
-  def tab():String = "&nbsp;&nbsp;&nbsp;&nbsp;"
+  val htmltab:String = "&nbsp;&nbsp;&nbsp;&nbsp;"
 }

--- a/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
@@ -37,7 +37,7 @@ object DisplayUtils {
       events.foreach(e => sb.append(s"${mentionToDisplayString(e, newline, tab)} $newline"))
       sb.append(s"${"=" * 50} $newline")
     }
-    sb.toString()
+    sb.toString
   }
 
   def mentionToDisplayString(mention: Mention, newline: String, tab: String): String = {
@@ -68,7 +68,7 @@ object DisplayUtils {
       case _ => ()
     }
     sb.append(s"$boundary $newline")
-    sb.toString()
+    sb.toString
   }
 
   def argumentsToString(b: Mention, newline: String, tab: String): String = {
@@ -80,19 +80,10 @@ object DisplayUtils {
           if (v.attachments.nonEmpty) sb.append(s"$tab  * Attachments: ${attachmentsString(v.attachments)} $newline")
         }
     }
-    sb.toString()
+    sb.toString
   }
 
   def attachmentsString(mods: Set[Attachment]): String = s"${mods.mkString(", ")}"
-
-
-  def displayMentions(mentions: Seq[Mention], doc: Document, printDeps: Boolean = false): Unit = {
-    println(mentionsToDisplayString(mentions, doc, printDeps, "\n", "\t"))
-  }
-
-  def printMentions(mentions: Seq[Mention], doc: Document, pw: PrintWriter, printDeps: Boolean = false): Unit = {
-    pw.println(mentionsToDisplayString(mentions, doc, printDeps, "\n", "\t"))
-  }
 
   def syntacticDependenciesToString(s:Sentence): String = {
     if (s.dependencies.isDefined) {
@@ -101,58 +92,23 @@ object DisplayUtils {
   }
 
 
-  def displayMention(mention: Mention) = println(mentionToDisplayString(mention, "\n", "\t"))
-
-
-  def webAppMention(mention: Mention): String = {
-    mentionToDisplayString(mention, "<br>", htmltab)
-
-//    val sb = new StringBuilder
-//    val boundary = s"${tab}${"-" * 30}<br>"
-//    sb.append(s"${mention.labels} => ${mention.text}<br>")
-//    sb.append(boundary)
-//    sb.append(s"${tab}Rule => ${mention.foundBy}<br>")
-//    val mentionType = mention.getClass.toString.split("""\.""").last
-//    sb.append(s"${tab}Type => $mentionType<br>")
-//    sb.append(boundary)
-//    mention match {
-//      case tb: TextBoundMention =>
-//        sb.append(s"${tab}${tb.labels.mkString(", ")} => ${tb.text}<br>")
-//        if (tb.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(tb.attachments)}<br>")
-//      case em: EventMention =>
-//        sb.append(s"${tab}trigger => ${em.trigger.text}<br>")
-//        if (em.trigger.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(em.trigger.attachments)}<br>")
-//        sb.append(webAppArguments(em))
-//        if (em.attachments.nonEmpty) {
-//          sb.append(s"${tab}Event Attachments: ${attachmentsString(em.attachments)}<br>")
-//        }
-//      case rel: RelationMention =>
-//        sb.append(webAppArguments(rel))
-//        if (rel.attachments.nonEmpty) {
-//          sb.append(s"${tab}Relation Attachments: ${attachmentsString(rel.attachments)}<br>")
-//        }
-//      case _ => ()
-//    }
-//    sb.append(s"$boundary<br>")
-//
-//    sb.toString()
+  /* Wrappers for displaying the mention string */
+  def displayMentions(mentions: Seq[Mention], doc: Document, printDeps: Boolean = false): Unit = {
+    println(mentionsToDisplayString(mentions, doc, printDeps, "\n", "\t"))
   }
-
-  def printMention(mention: Mention, pw: PrintWriter) = pw.println(mentionToDisplayString(mention, "\n", "\t"))
-
-//  def webAppArguments(b: Mention): String = {
-//    val sb = new StringBuilder
-//    b.arguments foreach {
-//      case (argName, ms) =>
-//        ms foreach { v =>
-//          sb.append(s"${tab}$argName ${v.labels.mkString("(", ", ", ")")} => ${v.text}<br>")
-//          if (v.attachments.nonEmpty) sb.append(s"${tab}  * Attachments: ${attachmentsString(v.attachments)}<br>")
-//        }
-//    }
-//    sb.toString()
-//  }
+  def displayMention(mention: Mention): Unit = println(mentionToDisplayString(mention, "\n", "\t"))
 
 
-  // html tab
-  val htmltab:String = "&nbsp;&nbsp;&nbsp;&nbsp;"
+  /* Wrappers for printing the mention string to a file */
+  def printMentions(mentions: Seq[Mention], doc: Document, pw: PrintWriter, printDeps: Boolean = false): Unit = {
+    pw.println(mentionsToDisplayString(mentions, doc, printDeps, "\n", "\t"))
+  }
+  def printMention(mention: Mention, pw: PrintWriter): Unit = pw.println(mentionToDisplayString(mention, "\n", "\t"))
+
+
+  /* Wrapper for getting html version of the mention string for use in the webapp */
+  protected val htmltab:String = "&nbsp;&nbsp;&nbsp;&nbsp;"
+  def webAppMention(mention: Mention): String = mentionToDisplayString(mention, "<br>", htmltab)
+
+
 }

--- a/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
@@ -23,8 +23,7 @@ object DisplayUtils {
       sb.append("Tokens: " + (s.words.indices, s.words, s.tags.get).zipped.mkString(", ") + newline)
       if (printDeps) sb.append(syntacticDependenciesToString(s) + newline)
       sb.append(newline)
-
-
+      
       val sortedMentions = mentionsBySentence(i).sortBy(_.label)
       val (events, entities) = sortedMentions.partition(_ matches "Event")
       val (tbs, rels) = entities.partition(_.isInstanceOf[TextBoundMention])


### PR DESCRIPTION
I've been wanting to do this for a while.  In DisplayUtils over time we had accrued three "sets" of methods -- those that println-ed stuff, those that returned the string, and those that did almost the same as the println ones but for html (i.e. `<br>` and the weird html tab).  I finally consoldated them and switched to wrapper methods.  We can also remove the wrappers if people want... up to you all.

Also -- not sure what the diff between StringBuilder and StringBuffer is so I picked one....! But that can be changed if you care!

@kwalcock I used `protected` in this object, I don't even know if that's valid but seemed like something you would have wanted done, so I did, but I can remove that for sure :)