### PR TITLE
Turn groundings and word2vec into classes and move out of EidosSystem

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -12,9 +12,9 @@ import org.clulab.wm.eidos.Aliases._
 import org.clulab.wm.eidos.attachments.Score
 import org.clulab.wm.eidos.entities.EidosEntityFinder
 import org.clulab.wm.eidos.groundings.{AdjectiveGrounder, AdjectiveGrounding, EidosAdjectiveGrounder}
-import org.clulab.wm.eidos.groundings.{OntologyGrounder, OntologyGrounding}
+import org.clulab.wm.eidos.groundings.{OntologyGrounder, OntologyGrounding, EidosOntologyGrounder}
+import org.clulab.wm.eidos.groundings.EidosWordToVec
 import org.clulab.wm.eidos.mentions.EidosMention
-import org.clulab.wm.eidos.utils.DomainOntology
 import org.clulab.wm.eidos.utils.FileUtils
 import org.clulab.wm.eidos.utils.Sourcer
 
@@ -50,8 +50,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
       val actions: EidosActions,
       val engine: ExtractorEngine,
       val ner: LexiconNER,
-      val stopWords: Set[String],
-      val transparentWords: Set[String]
+      val ontologyGrounder: EidosOntologyGrounder
   )
   
   object LoadableAttributes {
@@ -94,8 +93,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
           actions, 
           ExtractorEngine(masterRules, actions), // ODIN component 
           LexiconNER(Seq(quantifierPath), caseInsensitiveMatching = true), //TODO: keep Quantifier...
-          FileUtils.getCommentedTextsFromResource(stopwordsPath).toSet,
-          FileUtils.getCommentedTextsFromResource(transparentPath).toSet
+          EidosOntologyGrounder(stopwordsPath, transparentPath)
       )
     }
   }
@@ -110,16 +108,14 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
   protected def actions = loadableAttributes.actions
   def engine = loadableAttributes.engine
   def ner = loadableAttributes.ner
-  protected def stopWords = loadableAttributes.stopWords
-  protected def transparentWords = loadableAttributes.transparentWords
-
-  // These aren't intended to be (re)loadable.  This only happens once.
-  val  wordToVecPath: String = getPath( "wordToVecPath", "/org/clulab/wm/eidos/sameas/vectors.txt")
-  val domainOntoPath: String = getPath("domainOntoPath", "/org/clulab/wm/eidos/toy_ontology.yml")
-  val topKNodeGroundings: Int = getArgInt(getFullName("topKNodeGroundings"), Some(10))
-
-  val (w2v: Word2Vec, conceptEmbeddings: Map[String, Seq[Double]]) =
-      initSameAsDataStructures(wordToVecPath, domainOntoPath)
+  
+  // This isn't intended to be (re)loadable.  This only happens once.
+  val wordToVec = EidosWordToVec(
+      word2vec,
+      getPath( "wordToVecPath", "/org/clulab/wm/eidos/sameas/vectors.txt"),
+      getPath("domainOntoPath", "/org/clulab/wm/eidos/toy_ontology.yml"),
+      getArgInt(getFullName("topKNodeGroundings"), Some(10))
+  )
 
   def reload() = loadableAttributes = LoadableAttributes()
 
@@ -145,23 +141,6 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
     new AnnotatedDocument(doc, odinMentions, eidosMentions)
   }
   
-  // Be careful, because object may not be completely constructed.
-  def groundOntology(mention: EidosMention): OntologyGrounding = {
-
-    if (word2vec && mention.odinMention.matches("Entity")) { // TODO: Store this string somewhere
-      val canonicalName = mention.canonicalName
-      // Make vector for canonicalName
-      val canonicalNameParts = canonicalName.split(" +")
-      val nodeEmbedding = w2v.makeCompositeVector(canonicalNameParts)
-      // Calc dot prods
-      val similarities = conceptEmbeddings.toSeq.map(concept => (concept._1, Word2Vec.dotProduct(concept._2.toArray, nodeEmbedding)))
-      // sort and return top k
-      OntologyGrounding(similarities.sortBy(- _._2).slice(0, topKNodeGroundings))
-    }
-    else
-      OntologyGrounding(Seq.empty)
-  }
-
   def extractEventsFrom(doc: Document, state: State): Vector[Mention] = {
     val res = engine.extractFrom(doc, state).toVector
     val cleanMentions = actions.keepMostCompleteEvents(res, State(res)).toVector
@@ -175,7 +154,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
     val entities = entityFinder.extractAndFilter(doc).toVector
     // filter entities which are entirely stop or transparent
 //    println(s"In extractFrom() -- entities : ${entities.map(m => m.text).mkString(",\t")}")
-    val filtered = filterStopTransparent(entities)
+    val filtered = loadableAttributes.ontologyGrounder.filterStopTransparent(entities)
 //    println(s"In extractFrom() -- filtered : ${filtered.map(m => m.text).mkString(",\t")}")
     val events = extractEventsFrom(doc, State(filtered)).distinct
 //    if (!populateSameAs) return events
@@ -211,75 +190,28 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
     val sameAsRelations = for {
       (m1, i) <- ms.zipWithIndex
       m2 <- ms.slice(i+1, ms.length)
-      score = calculateSameAs(m1, m2)
+      score = wordToVec.calculateSameAs(m1, m2)
     } yield sameAs(m1, m2, score)
 
     sameAsRelations
   }
 
-  // fixme: implement
-  protected def calculateSameAs (m1: Mention, m2: Mention): Double = {
-    val sanitisedM1 =  m1.text.split(" +").map( Word2Vec.sanitizeWord(_) )
-    val sanitisedM2 =  m2.text.split(" +").map( Word2Vec.sanitizeWord(_) )
-    val score = w2v.avgSimilarity(sanitisedM1, sanitisedM2)
-    score
-  }
+  def keepCAGRelavant(mentions: Seq[Mention]): Seq[Mention] =
+      mentions.filter(isCAGRelevant)
 
-  protected def initSameAsDataStructures (word2VecPath: String, ontologyPath: String): (Word2Vec, Map[String, Seq[Double]]) = {
-    if (word2vec) {
-      val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath))
-      val source = Sourcer.sourceFromResource(word2VecPath)
-      try {
-        val w2v = new Word2Vec(source, None)
-        val conceptEmbeddings = ontology.iterateOntology(w2v)
-
-        (w2v, conceptEmbeddings)
-      }
-      finally {
-        source.close()
-      }
-    }
-    else {
-      val w2v = new Word2Vec(Map[String, Array[Double]]())
-      val conceptEmbeddings = Map[String, Seq[Double]]()
-      
-      (w2v, conceptEmbeddings)
-    }
-  }
-
-  def keepCAGRelavant(mentions: Seq[Mention]): Seq[Mention] = {
-    mentions.filter(isCAGRelevant)
-  }
-
-  def isCAGRelevant(m:Mention): Boolean = {
-    if (m.matches("Entity") && m.attachments.nonEmpty) {
-      true
-    }
-    else if (EidosSystem.CAG_EDGES.contains(m.label)) {
-      true
-    }
-    else {
-      false
-    }
-  }
-
+  def isCAGRelevant(m:Mention): Boolean =
+      (m.matches("Entity") && m.attachments.nonEmpty) ||
+          (EidosSystem.CAG_EDGES.contains(m.label))
 
   /*
-      Filtering
+      Grounding
   */
+  
+  def groundOntology(mention: EidosMention): OntologyGrounding =
+      loadableAttributes.ontologyGrounder.groundOntology(mention, wordToVec)
 
   def containsStopword(stopword: String) =
-      (stopWords ++ transparentWords).contains(stopword)
-
-  def filterStopTransparent(mentions: Seq[Mention]): Seq[Mention] = {
-    // remove mentions which are entirely stop/transparent words
-    mentions.filter(hasContent)
-  }
-
-  def hasContent(m: Mention): Boolean = {
-    val contentfulLemmas = m.lemmas.get.filterNot(lemma => (stopWords ++ transparentWords).contains(lemma))
-    contentfulLemmas.nonEmpty
-  }
+      loadableAttributes.ontologyGrounder.containsStopword(stopword)
 
   def groundAdjective(mention: Mention, quantifier: Quantifier): AdjectiveGrounding =
       loadableAttributes.adjectiveGrounder.groundAdjective(mention, quantifier)
@@ -293,7 +225,6 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
   def debugMentions(mentions: Seq[Mention]): Unit = {
     if (debug) mentions.foreach(m => println(s" * ${m.text} [${m.label}, ${m.tokenInterval}]"))
   }
-  
 }
 
 object EidosSystem {

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -86,12 +86,9 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
   
   var loadableAttributes = LoadableAttributes()
 
-  // These public variables are accessed directly by clients and
-  // the protected variables by local methods, neither of which
-  // know they are loadable and which had better not keep copies.
-  protected def entityFinder = loadableAttributes.entityFinder
-  def domainParams = loadableAttributes.domainParams
-  protected def actions = loadableAttributes.actions
+  // These public variables are accessed directly by clients which
+  // don't know they are loadable and which had better not keep copies.
+  def domainParams = loadableAttributes.domainParams 
   def engine = loadableAttributes.engine
   def ner = loadableAttributes.ner
   
@@ -129,7 +126,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
   
   def extractEventsFrom(doc: Document, state: State): Vector[Mention] = {
     val res = engine.extractFrom(doc, state).toVector
-    val cleanMentions = actions.keepMostCompleteEvents(res, State(res)).toVector
+    val cleanMentions = loadableAttributes.actions.keepMostCompleteEvents(res, State(res)).toVector
 //    val longest = actions.keepLongestMentions(cleanMentions, State(cleanMentions)).toVector
 //   longest
     cleanMentions
@@ -137,7 +134,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
 
   def extractFrom(doc: Document, populateSameAs: Boolean = false): Vector[Mention] = {
     // get entities
-    val entities = entityFinder.extractAndFilter(doc).toVector
+    val entities = loadableAttributes.entityFinder.extractAndFilter(doc).toVector
     // filter entities which are entirely stop or transparent
 //    println(s"In extractFrom() -- entities : ${entities.map(m => m.text).mkString(",\t")}")
     val filtered = loadableAttributes.ontologyGrounder.filterStopTransparent(entities)
@@ -182,7 +179,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
     sameAsRelations
   }
 
-  def keepCAGRelavant(mentions: Seq[Mention]): Seq[Mention] = {
+  def keepCAGRelevant(mentions: Seq[Mention]): Seq[Mention] = {
     
     def isCAGRelevant(m: Mention): Boolean =
         (m.matches("Entity") && m.attachments.nonEmpty) ||

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractFromFile.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractFromFile.scala
@@ -26,7 +26,7 @@ object ExtractFromFile extends App {
     val doc = ieSystem.proc.annotate(text.mkString(" "))
     pw.println(s"Filename: ${filename.getName}")
     val mentions = ieSystem.extractFrom(doc).distinct
-    val keptMentions = ieSystem.keepCAGRelavant(mentions)
+    val keptMentions = ieSystem.keepCAGRelevant(mentions)
     val mentionsBySentence = keptMentions.groupBy(_.sentence).toSeq.sortBy(_._1)
     for ((sentence, sentenceMentions) <- mentionsBySentence){
       pw.println(s"\nSENTENCE ${sentence}: ${doc.sentences(sentence).getSentenceText()}")

--- a/src/main/scala/org/clulab/wm/eidos/apps/MakeRuleTSVs.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/MakeRuleTSVs.scala
@@ -30,7 +30,7 @@ object MakeRuleTSVs extends App {
 
   // Organize
   val mentions = annotatedDocuments.seq.flatMap(ad => ad.odinMentions)
-  val keptMentions = reader.keepCAGRelavant(mentions)
+  val keptMentions = reader.keepCAGRelevant(mentions)
   // create a map where the key is the Set of rule/rule components and the values are the Mentions
   val byRules = keptMentions.groupBy(_.foundBy)
     .map(grouping => (grouping._1.split("\\+\\+").toSet, grouping._2))

--- a/src/main/scala/org/clulab/wm/eidos/groundings/AdjectiveGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/AdjectiveGrounder.scala
@@ -6,7 +6,11 @@ import org.clulab.wm.eidos.utils.Sourcer
 import org.clulab.odin.Mention
 
 case class AdjectiveGrounding(intercept: Option[Double], mu: Option[Double], sigma: Option[Double]) {
-  def isGrounded = intercept != None && mu != None && sigma != None
+  protected def isGrounded = intercept != None && mu != None && sigma != None
+
+  def predictDelta(mean: Double, stdev: Double): Option[Double] =
+      if (!isGrounded) None
+      else Some(math.pow(math.E, intercept.get + (mu.get * mean) + (sigma.get * stdev)) * stdev)
 }
 
 object AdjectiveGrounding {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/AdjectiveGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/AdjectiveGrounder.scala
@@ -1,0 +1,69 @@
+package org.clulab.wm.eidos.groundings
+
+import org.clulab.wm.eidos.Aliases.Quantifier
+import org.clulab.wm.eidos.utils.FileUtils
+import org.clulab.wm.eidos.utils.Sourcer
+import org.clulab.odin.Mention
+
+case class AdjectiveGrounding(intercept: Option[Double], mu: Option[Double], sigma: Option[Double]) {
+  def isGrounded = intercept != None && mu != None && sigma != None
+}
+
+object AdjectiveGrounding {
+  val noAdjectiveGrounding = AdjectiveGrounding(None, None, None)
+}
+
+trait AdjectiveGrounder {
+  def groundAdjective(mention: Mention, quantifier: Quantifier): AdjectiveGrounding
+}
+
+class  EidosAdjectiveGrounder(quantifierKBFile: String) extends AdjectiveGrounder {
+  
+  protected def load(): Map[Quantifier, Map[String, Double]] =
+      // adjective -> Map(name:value)
+      FileUtils.getCommentedLinesFromSource(Sourcer.sourceFromResource(quantifierKBFile))
+          .map { line => // "adjective	mu_coefficient	sigma_coefficient	intercept"
+            val fields = line.split("\t")
+            val adj = fields(0)
+            val mu_coeff = fields(1).toDouble
+            val sigma_coeff = fields(2).toDouble
+            val intercept = fields(3).toDouble
+            adj -> Map(EidosAdjectiveGrounder.MU_COEFF -> mu_coeff, EidosAdjectiveGrounder.SIGMA_COEFF -> sigma_coeff, EidosAdjectiveGrounder.INTERCEPT -> intercept)
+          }.toMap
+  
+  protected val grounder: Map[Quantifier, Map[String, Double]] = load()
+  
+  def groundAdjective(mention: Mention, quantifier: Quantifier): AdjectiveGrounding = {
+    
+    def stemIfAdverb(word: String) = {
+      if (word.endsWith("ly"))
+        if (word.endsWith("ily"))
+          word.slice(0, word.length - 3) ++ "y"
+        else
+          word.slice(0, word.length - 2)
+      else
+        word
+    }
+    
+    val pseudoStemmed = stemIfAdverb(quantifier)
+    val modelRow = grounder.getOrElse(pseudoStemmed, Map.empty)
+    
+    if (modelRow.isEmpty)
+      AdjectiveGrounding.noAdjectiveGrounding
+    else {
+      val intercept = modelRow.get(EidosAdjectiveGrounder.INTERCEPT)
+      val mu = modelRow.get(EidosAdjectiveGrounder.MU_COEFF)
+      val sigma = modelRow.get(EidosAdjectiveGrounder.SIGMA_COEFF)
+      
+      AdjectiveGrounding(intercept, mu, sigma)
+    }
+  }
+}
+
+object EidosAdjectiveGrounder {
+  val INTERCEPT: String = "intercept"
+  val MU_COEFF: String = "mu_coeff"
+  val SIGMA_COEFF: String = "sigma_coeff"
+
+  def apply(quantifierKBFile: String) = new EidosAdjectiveGrounder(quantifierKBFile)
+}

--- a/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
@@ -1,0 +1,55 @@
+package org.clulab.wm.eidos.groundings
+
+import org.clulab.embeddings.word2vec.Word2Vec
+import org.clulab.odin.Mention
+import org.clulab.wm.eidos.utils.DomainOntology
+import org.clulab.wm.eidos.utils.FileUtils
+import org.clulab.wm.eidos.utils.Sourcer
+
+class EidosWordToVec(enabled: Boolean, wordToVecPath: String, domainOntoPath: String, topKNodeGroundings: Int) {
+  protected val (w2v: Word2Vec, conceptEmbeddings: Map[String, Seq[Double]]) =
+      if (enabled) {
+        val ontology = DomainOntology(FileUtils.loadYamlFromResource(domainOntoPath))
+        val source = Sourcer.sourceFromResource(wordToVecPath)
+
+        try {
+          val w2v = new Word2Vec(source, None)
+          val conceptEmbeddings = ontology.iterateOntology(w2v)
+  
+          (w2v, conceptEmbeddings)
+        }
+        finally {
+          source.close()
+        }
+      }
+      else {
+        val w2v = new Word2Vec(Map[String, Array[Double]]())
+        val conceptEmbeddings = Map[String, Seq[Double]]()
+        
+        (w2v, conceptEmbeddings)
+      }
+
+  def calculateSameAs(m1: Mention, m2: Mention): Double = {
+    val sanitisedM1 =  m1.text.split(" +").map(Word2Vec.sanitizeWord(_))
+    val sanitisedM2 =  m2.text.split(" +").map(Word2Vec.sanitizeWord(_))
+    val score = w2v.avgSimilarity(sanitisedM1, sanitisedM2)
+    score
+  }
+  
+  def calculateSimilarities(canonicalNameParts: Array[String]): Seq[(String, Double)] = {
+    if (enabled) {
+      val nodeEmbedding = w2v.makeCompositeVector(canonicalNameParts)
+      // Calc dot prods
+      val similarities = conceptEmbeddings.toSeq.map(concept => (concept._1, Word2Vec.dotProduct(concept._2.toArray, nodeEmbedding)))
+      
+      similarities.sortBy(- _._2).slice(0, topKNodeGroundings)
+    }
+    else
+      Seq.empty
+  }
+}
+
+object EidosWordToVec {
+  def apply(enabled: Boolean, wordToVecPath: String, domainOntoPath: String, topKNodeGroundings: Int) =
+      new EidosWordToVec(enabled, wordToVecPath, domainOntoPath, topKNodeGroundings)
+}

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -1,0 +1,10 @@
+package org.clulab.wm.eidos.groundings
+
+import org.clulab.wm.eidos.mentions.EidosMention
+
+case class OntologyGrounding(grounding: Seq[(String, Double)])
+
+trait OntologyGrounder {
+  def groundOntology(mention: EidosMention): OntologyGrounding
+  def containsStopword(stopword: String): Boolean
+}

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -1,10 +1,50 @@
 package org.clulab.wm.eidos.groundings
 
+import org.clulab.embeddings.word2vec.Word2Vec
+import org.clulab.odin.Mention
 import org.clulab.wm.eidos.mentions.EidosMention
+import org.clulab.wm.eidos.utils.FileUtils
 
 case class OntologyGrounding(grounding: Seq[(String, Double)])
 
 trait OntologyGrounder {
   def groundOntology(mention: EidosMention): OntologyGrounding
   def containsStopword(stopword: String): Boolean
+}
+
+class EidosOntologyGrounder(stopwordsPath: String, transparentPath: String) {
+  protected val stopwords = FileUtils.getCommentedTextsFromResource(stopwordsPath).toSet
+  protected val transparentWords = FileUtils.getCommentedTextsFromResource(transparentPath).toSet
+  protected val bothWords = stopwords ++ transparentWords
+  
+  // Be careful, because object may not be completely constructed.
+  def groundOntology(mention: EidosMention, wordToVec: EidosWordToVec): OntologyGrounding = {
+    if (mention.odinMention.matches("Entity")) { // TODO: Store this string somewhere
+      val canonicalName = mention.canonicalName
+      // Make vector for canonicalName
+      val canonicalNameParts = canonicalName.split(" +")
+
+      OntologyGrounding(wordToVec.calculateSimilarities(canonicalNameParts))
+    }
+    else
+      OntologyGrounding(Seq.empty)
+  }
+  
+  def containsStopword(stopword: String): Boolean = bothWords.contains(stopword)
+  
+  protected def hasContent(m: Mention): Boolean = {
+    // TODO: make this exists
+    val contentfulLemmas = m.lemmas.get.filterNot(lemma => bothWords.contains(lemma)) 
+    
+    contentfulLemmas.nonEmpty 
+  }   
+  
+  def filterStopTransparent(mentions: Seq[Mention]): Seq[Mention] =
+      // Remove mentions which are entirely stop/transparent words 
+      mentions.filter(hasContent) 
+}
+
+object EidosOntologyGrounder {
+  
+  def apply(stopWordsPath: String, transparentPath: String) = new EidosOntologyGrounder(stopWordsPath, transparentPath)
 }

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
@@ -14,9 +14,7 @@ import org.clulab.struct.Interval
 import org.clulab.wm.eidos.Aliases.Quantifier
 import org.clulab.wm.eidos.AnnotatedDocument
 import org.clulab.wm.eidos.EidosSystem.Corpus
-import org.clulab.wm.eidos.EntityGrounder
-import org.clulab.wm.eidos.EntityGrounding
-import org.clulab.wm.eidos.SameAsGrounding
+import org.clulab.wm.eidos.groundings.{AdjectiveGrounder, AdjectiveGrounding}
 import org.clulab.wm.eidos.attachments._
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.mentions.EidosEventMention
@@ -67,7 +65,7 @@ object JLDObject {
 // This class helps serialize/convert a JLDObject to JLD by keeping track of
 // what types are included and providing IDs so that references to can be made
 // within the JSON structure.
-class JLDSerializer(val entityGrounder: Some[EntityGrounder]) {
+class JLDSerializer(val adjectiveGrounder: Some[AdjectiveGrounder]) {
   protected val typenames = mutable.HashSet[String]()
   protected val typenamesByIdentity = new IdentityHashMap[Any, String]()
   protected val idsByTypenameByIdentity: mutable.HashMap[String, IdentityHashMap[Any, Int]] = mutable.HashMap()
@@ -142,8 +140,8 @@ class JLDSerializer(val entityGrounder: Some[EntityGrounder]) {
   }
   
   def ground(mention: EidosMention, quantifier: Quantifier) =
-    if (entityGrounder.isDefined) entityGrounder.get.ground(mention.odinMention, quantifier)
-    else EntityGrounding(None, None, None)
+    if (adjectiveGrounder.isDefined) adjectiveGrounder.get.groundAdjective(mention.odinMention, quantifier)
+    else AdjectiveGrounding.noAdjectiveGrounding
 }
 
 object JLDSerializer {
@@ -483,7 +481,7 @@ object JLDDocument {
 class JLDCorpus(serializer: JLDSerializer, corpus: Corpus)
     extends JLDObject(serializer, "Corpus", corpus) {
   
-  def this(corpus: Corpus, entityGrounder: EntityGrounder) = this(new JLDSerializer(Some(entityGrounder)), corpus)
+  def this(corpus: Corpus, entityGrounder: AdjectiveGrounder) = this(new JLDSerializer(Some(entityGrounder)), corpus)
   
   protected def collectMentions(mentions: Seq[EidosMention], mapOfMentions: IdentityHashMap[EidosMention, Int]): Seq[JLDExtraction] = {
     val newMentions = mentions.filter(isExtractable(_)).filter { mention => 

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/odin/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/odin/JLDSerializer.scala
@@ -17,8 +17,7 @@ import org.clulab.struct.Interval
 import org.clulab.wm.eidos.Aliases.Quantifier
 import org.clulab.wm.eidos.AnnotatedDocument
 import org.clulab.wm.eidos.EidosSystem.Corpus
-import org.clulab.wm.eidos.EntityGrounder
-import org.clulab.wm.eidos.EntityGrounding
+import org.clulab.wm.eidos.groundings.{AdjectiveGrounder, AdjectiveGrounding}
 import org.clulab.wm.eidos.attachments._
 
 import org.json4s._
@@ -62,7 +61,7 @@ object JLDObject {
 // This class helps serialize/convert a JLDObject to JLD by keeping track of
 // what types are included and providing IDs so that references to can be made
 // within the JSON structure.
-class JLDSerializer(val entityGrounder: Some[EntityGrounder]) {
+class JLDSerializer(val entityGrounder: Some[AdjectiveGrounder]) {
   protected val typenames = mutable.HashSet[String]()
   protected val typenamesByIdentity = new IdentityHashMap[Any, String]()
   protected val idsByTypenameByIdentity: mutable.HashMap[String, IdentityHashMap[Any, Int]] = mutable.HashMap()
@@ -137,8 +136,8 @@ class JLDSerializer(val entityGrounder: Some[EntityGrounder]) {
   }
   
   def ground(mention: Mention, quantifier: Quantifier) =
-    if (entityGrounder.isDefined) entityGrounder.get.ground(mention, quantifier)
-    else EntityGrounding(None, None, None)
+    if (entityGrounder.isDefined) entityGrounder.get.groundAdjective(mention, quantifier)
+    else AdjectiveGrounding(None, None, None)
 }
 
 object JLDSerializer {
@@ -470,7 +469,7 @@ object JLDDocument {
 class JLDCorpus(serializer: JLDSerializer, corpus: Corpus)
     extends JLDObject(serializer, "Corpus", corpus) {
   
-  def this(corpus: Corpus, entityGrounder: EntityGrounder) = this(new JLDSerializer(Some(entityGrounder)), corpus)
+  def this(corpus: Corpus, entityGrounder: AdjectiveGrounder) = this(new JLDSerializer(Some(entityGrounder)), corpus)
   
   protected def collectMentions(mentions: Seq[Mention], mapOfMentions: IdentityHashMap[Mention, Int]): Seq[JLDExtraction] = {
     val newMentions = mentions.filter(isExtractable(_)).filter { mention => 

--- a/src/main/scala/org/clulab/wm/eidos/utils/DomainParams.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/DomainParams.scala
@@ -1,0 +1,34 @@
+package org.clulab.wm.eidos.utils
+
+import org.clulab.wm.eidos.Aliases.Param
+
+class DomainParams(domainParamKBFile: String) {
+  protected val domainParamValues: Map[Param, Map[String, Double]] =
+      FileUtils.getCommentedLinesFromSource(Sourcer.sourceFromResource(domainParamKBFile))
+          .map { line => // line = [param]\t[variable]\t[value] => e.g. "rainfall  mean  30.5"
+            val fields = line.split("\t")
+            val param = fields(0)
+            val var_values = fields.tail.map { var_value =>
+              val tmp = var_value.split(":")
+              val variable = tmp(0)
+              val value = tmp(1).toDouble // Assuming the value of the variable is a double. TODO: Change this appropriately
+              variable -> value
+            }.toMap
+            (param -> var_values)
+          }.toMap
+  
+  def get(key: String) = domainParamValues.get(key)
+  
+  def keys = domainParamValues.keys
+  
+  override def toString = domainParamValues.toString
+}
+
+object DomainParams {
+  val DEFAULT_DOMAIN_PARAM: String = "DEFAULT"
+  val PARAM_MEAN: String = "mean"
+  val PARAM_STDEV: String = "stdev"
+
+  def apply(domainParamKBFile: String) =
+      new DomainParams(domainParamKBFile)
+}

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDSerializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDSerializer.scala
@@ -5,13 +5,12 @@ import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.Aliases.Quantifier
 import org.clulab.wm.eidos.AnnotatedDocument
 import org.clulab.wm.eidos.EidosSystem.Corpus
-import org.clulab.wm.eidos.EntityGrounder
+import org.clulab.wm.eidos.groundings.{AdjectiveGrounder, AdjectiveGrounding}
 import org.clulab.wm.eidos.serialization.json.odin.{JLDCorpus => JLDOdinCorpus}
 import org.clulab.wm.eidos.serialization.json.{JLDCorpus => JLDEidosCorpus}
 import org.clulab.wm.eidos.test.TestUtils
 import org.clulab.wm.eidos.test.TestUtils.Test
 import org.clulab.wm.eidos.text.cag.CAG._
-import org.clulab.wm.eidos.{EntityGrounder, EntityGrounding}
 
 import scala.collection.Seq
 

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEidosMention.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEidosMention.scala
@@ -3,17 +3,16 @@ package org.clulab.wm.eidos.text.cag
 import java.util.IdentityHashMap  // Unfortunately borrowed from Java
 
 import org.clulab.odin.Mention
-import org.clulab.wm.eidos.SameAsGrounder
-import org.clulab.wm.eidos.SameAsGrounding
+import org.clulab.wm.eidos.groundings.{OntologyGrounder, OntologyGrounding}
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.test.TestUtils
 import org.clulab.wm.eidos.test.TestUtils._
 import org.clulab.wm.eidos.text.cag.CAG._
 
-class TestEidosMention extends Test with SameAsGrounder {
+class TestEidosMention extends Test with OntologyGrounder {
   
-  def ground(mention: EidosMention): SameAsGrounding = SameAsGrounding(Seq.empty)
-  def getStopwords(): Set[String] = Set("policy")
+  def groundOntology(mention: EidosMention): OntologyGrounding = OntologyGrounding(Seq.empty)
+  def containsStopword(stopword: String) = stopword == "policy"
 
   def test(text: String) = {
     def myprintln(text: String) = {


### PR DESCRIPTION
There are now AdjectiveGrounding and OntologyGrounding which are nearly self sufficient, leaving EidosSystem with its more important things to do than manage them.