### PR TITLE
Filter for no-NN entities

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -2,9 +2,6 @@ package org.clulab.wm.eidos
 
 import com.typesafe.config.{Config, ConfigFactory}
 
-import java.util.Collection
-
-import org.clulab.embeddings.word2vec.Word2Vec
 import org.clulab.odin._
 import org.clulab.processors.fastnlp.FastNLPProcessor
 import org.clulab.processors.{Document, Processor, Sentence}
@@ -19,7 +16,6 @@ import org.clulab.wm.eidos.groundings.EidosWordToVec
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.DomainParams
 import org.clulab.wm.eidos.utils.FileUtils
-import org.clulab.wm.eidos.utils.Sourcer
 
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
@@ -64,12 +64,11 @@ class EidosEntityFinder(entityEngine: ExtractorEngine, avoidEngine: ExtractorEng
 
     val sent = entity.sentenceObj
     // If there's a noun in the entity, it's valid
-    if (entity.tags.get.exists(tag => tag.startsWith("NN"))) true
+    entity.tags.get.exists(tag => tag.startsWith("NN")) ||
     // Otherwise, if the entity ends with an adjective and the next word is a noun (which was excluded because ]
     // it's needed as a trigger downstream), it's valid (ex: 'economic declines')
-    else if (entity.tags.get.last.startsWith("JJ") && nextTagNN(entity)) true
+    entity.tags.get.last.startsWith("JJ") && nextTagNN(entity)
     // Otherwise, it's not valid
-    else false
   }
 
 

--- a/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
@@ -59,7 +59,7 @@ class EidosEntityFinder(entityEngine: ExtractorEngine, avoidEngine: ExtractorEng
     // Helper method for determining if the next word after the entity is a noun
     def nextTagNN(entity: Mention): Boolean = {
       val sent = entity.sentenceObj
-      if (sent.tags.get(entity.end).startsWith("NN")) true else false
+      sent.tags.get(entity.end).startsWith("NN")
     }
 
     val sent = entity.sentenceObj

--- a/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
@@ -21,11 +21,14 @@ class EidosEntityFinder(entityEngine: ExtractorEngine, avoidEngine: ExtractorEng
     // avoid refs, etc.
     val avoid = avoidEngine.extractFrom(doc)
     val stateFromAvoid = State(avoid)
+    // extract the base entities
     val baseEntities = entityEngine.extractFrom(doc, stateFromAvoid).filter{ entity => ! stateFromAvoid.contains(entity) }
-    val expandedEntities: Seq[Mention] = baseEntities.map(entity => expand(entity, maxHops, stateFromAvoid))
-    // debugDisplay("expanded", expandedEntities)
+    // make sure that all are valid (i.e., contain a noun or would have contained a noun except for trigger avoidance)
+    val validBaseEntities = baseEntities.filter(isValidBaseEntity)
+    // expand the entities
+    val expandedEntities: Seq[Mention] = validBaseEntities.map(entity => expand(entity, maxHops, stateFromAvoid))
     // split entities on likely coordinations
-    val splitEntities = (baseEntities ++ expandedEntities).flatMap(splitCoordinatedEntities)
+    val splitEntities = (validBaseEntities ++ expandedEntities).flatMap(splitCoordinatedEntities)
     // remove entity duplicates introduced by splitting expanded
     val distinctEntities = splitEntities.distinct
     // trim unwanted POS from entity edges
@@ -45,6 +48,30 @@ class EidosEntityFinder(entityEngine: ExtractorEngine, avoidEngine: ExtractorEng
 //    println(s"Entities finally returned -- ${res.map(m => m.text).mkString(",\t")}")
     res
   }
+
+
+
+  /**
+    * Determines whether or not an entity is a valid base entity. We want to disallow JJ-only entities except
+    * when they are a result of the head noun being a trigger (i.e. being avoided)
+    */
+  def isValidBaseEntity(entity: Mention): Boolean = {
+    // Helper method for determining if the next word after the entity is a noun
+    def nextTagNN(entity: Mention): Boolean = {
+      val sent = entity.sentenceObj
+      if (sent.tags.get(entity.end).startsWith("NN")) true else false
+    }
+
+    val sent = entity.sentenceObj
+    // If there's a noun in the entity, it's valid
+    if (entity.tags.get.exists(tag => tag.startsWith("NN"))) true
+    // Otherwise, if the entity ends with an adjective and the next word is a noun (which was excluded because ]
+    // it's needed as a trigger downstream), it's valid (ex: 'economic declines')
+    else if (entity.tags.get.last.startsWith("JJ") && nextTagNN(entity)) true
+    // Otherwise, it's not valid
+    else false
+  }
+
 
   /**
     * Expands an entity up to the specified number of hops along valid grammatical relations.

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
@@ -1,7 +1,6 @@
 package org.clulab.wm.eidos.system
 
 import org.clulab.wm.eidos.test.TestUtils._
-import org.scalactic.source.Position.apply
 
 class TestEntityFinder extends Test {
 

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
@@ -12,4 +12,12 @@ class TestEntityFinder extends Test {
     mentions.filter(_.text == "in rainfall") should have size (0)
   }
 
+  "JJ entity" should "only be kept if following word was avoided as a trigger" in {
+    val text = "Happy "
+    val mentions = extractMentions(text)
+    mentions.filter(_.text == "rainfall") should have size (1)
+    mentions.filter(_.text == "in rainfall") should have size (0)
+  }
+
+
 }

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
@@ -13,7 +13,8 @@ class TestEntityFinder extends Test {
   }
 
   "JJ entity" should "only be kept if following word was avoided as a trigger" in {
-    val text = "Happy "
+    val text1 = "some happy caused the recession."
+    val text1 = "some happy declines caused the recession."
     val mentions = extractMentions(text)
     mentions.filter(_.text == "rainfall") should have size (1)
     mentions.filter(_.text == "in rainfall") should have size (0)

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
@@ -13,11 +13,13 @@ class TestEntityFinder extends Test {
   }
 
   "JJ entity" should "only be kept if following word was avoided as a trigger" in {
-    val text1 = "some happy caused the recession."
-    val text1 = "some happy declines caused the recession."
-    val mentions = extractMentions(text)
-    mentions.filter(_.text == "rainfall") should have size (1)
-    mentions.filter(_.text == "in rainfall") should have size (0)
+    val text1 = "some economic caused the recession."
+    val mentions1 = extractMentions(text1)
+    mentions1.exists(_.text == "economic") should be (false)
+
+    val text2 = "some economic declines caused the recession."
+    val mentions2 = extractMentions(text2)
+    mentions2.exists(_.text == "economic") should be (true)
   }
 
 


### PR DESCRIPTION
I added a filter for entities found in the entitiyFinder that don't have a noun:
- before expansion, I check to see if the entity contains a noun OR
- if it ends with an adj and the *next* word is a noun (i.e., if it got filtered out bc it's a trigger needed later)

I also added a test in TestEntityFinder to demo the desired behavior, but please let me know if it's obviously incomplete.

Thanks!