### PR TITLE
Becky tests

### DIFF
--- a/src/main/resources/org/clulab/wm/eidos/grammars/linkersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/eidos/grammars/linkersTemplate.yml
@@ -202,6 +202,27 @@ rules:
       effect: Entity  = <ccomp (?=/nmod_since/) nsubj
       cause: Entity = dobj
 
+  - name: token_1_verb-${addlabel}
+    priority: ${ rulepriority }
+    # Helps in some cases of broken syntax
+    example: "ongoing insecurity is limiting access to assistance and movement towards natural food sources"
+    type: token
+    label: ${ label }
+    pattern: |
+      @cause: Entity is (?<trigger> [word=/(?i)^(${ trigger })/ & tag=/^VBG/]) [mention=Entity]+ and @effect: Entity
+
+  # Couldn't get the suntax right to combine this with preceding rule...
+  - name: token_2_verb-${addlabel}
+    priority: ${ rulepriority }
+    # Helps in some cases of broken syntax
+    example: "ongoing insecurity is limiting access to assistance and movement towards natural food sources"
+    type: token
+    label: ${ label }
+    pattern: |
+      @cause: Entity is (?<trigger> [word=/(?i)^(${ trigger })/ & tag=/^VBG/]) @effect: Entity
+
+
+
   # todo: maybe applies only to promotion triggers
   - name: ported_syntax_1_noun-${addlabel}
     priority: ${ rulepriority }

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -122,6 +122,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
   def extractFromText(text: String, keepText: Boolean = false): AnnotatedDocument = {
     val doc = annotate(text, keepText)
     val odinMentions = extractFrom(doc)
+    //println(s"\nodinMentions() -- entities : \n\t${odinMentions.map(m => m.text).sorted.mkString("\n\t")}")
     val cagRelevant = keepCAGRelevant(odinMentions)
     val eidosMentions = EidosMention.asEidosMentions(cagRelevant, this)
 
@@ -130,23 +131,18 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
 
   def extractEventsFrom(doc: Document, state: State): Vector[Mention] = {
     val res = engine.extractFrom(doc, state).toVector
-
-    val cleanMentions = loadableAttributes.actions.keepMostCompleteEvents(res, State(res)).toVector
-    //    val longest = actions.keepLongestMentions(cleanMentions, State(cleanMentions)).toVector
-    //   longest
-    cleanMentions
+    loadableAttributes.actions.keepMostCompleteEvents(res, State(res)).toVector
   }
 
   def extractFrom(doc: Document): Vector[Mention] = {
     // get entities
     val entities = loadableAttributes.entityFinder.extractAndFilter(doc).toVector
     // filter entities which are entirely stop or transparent
-    //    println(s"In extractFrom() -- entities : ${entities.map(m => m.text).mkString(",\t")}")
+    //println(s"In extractFrom() -- entities : \n\t${entities.map(m => m.text).sorted.mkString("\n\t")}")
     val filtered = loadableAttributes.ontologyGrounder.filterStopTransparent(entities)
-    //    println(s"In extractFrom() -- filtered : ${filtered.map(m => m.text).mkString(",\t")}")
+    //println(s"\nAfter filterStopTransparent() -- entities : \n\t${filtered.map(m => m.text).sorted.mkString("\n\t")}")
     val events = extractEventsFrom(doc, State(filtered)).distinct
-    //    if (!populateSameAs) return events
-    //    println(s"In extractFrom() -- res : ${res.map(m => m.text).mkString(",\t")}")
+    //println(s"In extractFrom() -- res : ${res.map(m => m.text).mkString(",\t")}")
 
     events
   }

--- a/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
@@ -32,13 +32,9 @@ class EidosEntityFinder(entityEngine: ExtractorEngine, avoidEngine: ExtractorEng
     val trimmedEntities = distinctEntities.map(trimEntityEdges)
     // if there are no avoid mentions, no need to filter
     val res = if (avoid.isEmpty) {
-      println("** avoid.isEmpty == true")
       trimmedEntities
     } else {
-      println("** avoid has content: ")
       val avoidLabel = avoid.head.labels.last
-      println("**** avoid has content: ")
-
       trimmedEntities.filter{ m => stateFromAvoid.mentionsFor(m.sentence, m.tokenInterval, avoidLabel).isEmpty }
     }
 

--- a/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
@@ -32,17 +32,21 @@ class EidosEntityFinder(entityEngine: ExtractorEngine, avoidEngine: ExtractorEng
     val trimmedEntities = distinctEntities.map(trimEntityEdges)
     // if there are no avoid mentions, no need to filter
     val res = if (avoid.isEmpty) {
+      println("** avoid.isEmpty == true")
       trimmedEntities
     } else {
+      println("** avoid has content: ")
       val avoidLabel = avoid.head.labels.last
+      println("**** avoid has content: ")
+
       trimmedEntities.filter{ m => stateFromAvoid.mentionsFor(m.sentence, m.tokenInterval, avoidLabel).isEmpty }
     }
 
-//    println(s"Base-entities  -- ${baseEntities.map(m => m.text).mkString(",\t")}")
-//    println(s"Expanded-entities  -- ${expandedEntities.map(m => m.text).mkString(",\t")}")
-//    println(s"distinct-Entities -- ${distinctEntities.map(m => m.text).mkString(",\t")}")
-//    println(s"trimmed-Entities -- ${trimmedEntities.map(m => m.text).mkString(",\t")}")
-//    println(s"Entities finally returned -- ${res.map(m => m.text).mkString(",\t")}")
+//    println(s"Base-entities  -- \n\t${baseEntities.map(m => m.text).mkString("\n\t")}")
+//    println(s"Expanded-entities  -- \n\t${expandedEntities.map(m => m.text).mkString("\n\t")}")
+//    println(s"distinct-Entities -- \n\t${distinctEntities.map(m => m.text).mkString("\n\t")}")
+//    println(s"trimmed-Entities -- \n\t${trimmedEntities.map(m => m.text).mkString("\n\t")}")
+//    println(s"Entities finally returned -- \n\t${res.map(m => m.text).mkString("\n\t")}")
     res
   }
 

--- a/src/test/scala/org/clulab/wm/eidos/text/eval6/TestDoc6.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/eval6/TestDoc6.scala
@@ -75,7 +75,7 @@ class TestDoc6 extends Test {
     val access = NodeSpec("access to sufficient food", Dec("lack"))
     val catastrophe = NodeSpec("Catastrophe", Quant("likely"))
     val households = NodeSpec("households did not harvest") // todo -- handle
-    val insecurity = NodeSpec("ongoing insecurity")
+    val insecurity = NodeSpec("insecurity", Quant("ongoing"))
     val assistance = NodeSpec("access to assistance", Dec("limiting"))
     val movement = NodeSpec("movement towards natural food sources", Dec("limiting"))
 
@@ -88,19 +88,20 @@ class TestDoc6 extends Test {
 //    failingTest should "have correct singleton node 1" taggedAs(Becky) in {
 //      tester.test(concerns) should be (successful)
 //    }
-    failingTest should "have correct singleton node 2" taggedAs(Becky) in {
+    brokenSyntaxTest should "have correct singleton node 2" taggedAs(Becky) in {
       tester.test(foodSec) should be (successful)
     }
     passingTest should "have correct singleton node 3" taggedAs(Becky) in {
       tester.test(access) should be (successful)
     }
-    failingTest should "have correct edge 1" taggedAs(Becky) in {
+    // Relies on VP entities
+    futureWorkTest should "have correct edge 1" taggedAs(Becky) in {
       tester.test(EdgeSpec(catastrophe, Correlation, households)) should be (successful)
     }
-    failingTest should "have correct edge 2" taggedAs(Becky) in {
+    passingTest should "have correct edge 2" taggedAs(Becky) in {
       tester.test(EdgeSpec(insecurity, Causal, assistance)) should be (successful)
     }
-    failingTest should "have correct edge 3" taggedAs(Becky) in {
+    passingTest should "have correct edge 3" taggedAs(Becky) in {
       tester.test(EdgeSpec(insecurity, Causal, movement)) should be (successful)
     }
 

--- a/src/test/scala/org/clulab/wm/eidos/text/eval6/TestDoc6.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/eval6/TestDoc6.scala
@@ -84,9 +84,10 @@ class TestDoc6 extends Test {
 
     behavior of "TestDoc6 Paragraph 2"
 
-    failingTest should "have correct singleton node 1" taggedAs(Becky) in {
-      tester.test(concerns) should be (successful)
-    }
+    // Removed because concern is considered a transparent word, so it is removed.
+//    failingTest should "have correct singleton node 1" taggedAs(Becky) in {
+//      tester.test(concerns) should be (successful)
+//    }
     failingTest should "have correct singleton node 2" taggedAs(Becky) in {
       tester.test(foodSec) should be (successful)
     }


### PR DESCRIPTION
nothing earth-shattering, just a couple of tests now passing and some marked as either broken syntax or future work (i.e. dependent on VP entities).  
I wrote a pair of surface/token rules to help with one occurrence of broken syntax.  The 2 surface rules can likely be merged but I tried and tried and couldn't make it work 