### PR TITLE
Token noun rule

### DIFF
--- a/src/main/resources/org/clulab/wm/eidos/grammars/explicitLinkers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/grammars/explicitLinkers.yml
@@ -62,3 +62,11 @@ rules:
       effect: Entity  = <acl
       cause: Entity = nmod_by compound?
 
+  - name: syntax_1d_verb-Correlation
+    priority: ${ rulepriority }
+    example: "Worsening food security trends linked to continued conflict have been causing problems."
+    label: Correlation
+    pattern: |
+      trigger = [word=/(?i)^(${ correlation_trigger })/ & tag=/VBN/]
+      effect: Entity = nmod_to /${ conjunctions }|${ objects }|${ noun_modifiers }/{,2} ([word=/(?i)^(${ trigger })/] /${ preps }/{,2})?
+      cause: Entity = </${complements}|${adverbial_clause}/? (${ agents }) /${ noun_modifiers }|${ conjunctions }/{,2} ([word=/(?i)^(${ trigger })/] /${ preps }/{,2})?

--- a/src/main/resources/org/clulab/wm/eidos/grammars/explicitModifiers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/grammars/explicitModifiers.yml
@@ -33,6 +33,16 @@ rules:
       trigger = no longer [word=/(?i)^(occur)/]
       theme: Entity = /${agents}/
 
+  # Surely this can be made more generic, but it's a start
+  - name: Decrease_explicit_limited-to-no
+    priority: ${ rulepriority }
+    example: "... X is no longer occurring ..."
+    label: Decrease
+    action: ${ action }
+    pattern: |
+      trigger = [word=/(?i)^(limit|little)/] to no
+      theme: Entity = <neg
+
   - name: increase_explicit_increaseup_1
     priority: ${ rulepriority }
     example: "We have started ramping up food and nutrition support, but much more is needed to keep things from deteriorating even further during the lean season"

--- a/src/main/resources/org/clulab/wm/eidos/grammars/linkersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/eidos/grammars/linkersTemplate.yml
@@ -75,7 +75,7 @@ rules:
       cause: Entity = nmod_by /${ conjunctions }|${ objects }|${ noun_modifiers }/{,2} ([word=/(?i)^(${ trigger })/] /${ preps }/{,2})?
       effect: Entity = </${complements}|${adverbial_clause}/? (${ agents }) /${ noun_modifiers }|${ conjunctions }/{,2} ([word=/(?i)^(${ trigger })/] /${ preps }/{,2})?
 
-#Handles occurrence of prep_by when NOT passive voice
+  #Handles occurrence of prep_by when NOT passive voice
   #misfires on "floods caused by rain"
   - name: ported_syntax_1d_verb-${addlabel}
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/wm/eidos/grammars/linkersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/eidos/grammars/linkersTemplate.yml
@@ -213,16 +213,6 @@ rules:
       effect: Entity = /nmod:poss/ # I think this is the UDep version
 
 
-  - name: ported_token_1_noun-${addlabel}
-    priority: ${ rulepriority }
-    #Original example: "mTOR activator Rapamycin"
-    example: ""
-    type: token
-    label: ${ label }
-    pattern: |
-      @effect: Entity (?<trigger> [word=/(?i)^(${ trigger })/ & tag=/^NN/]) @cause: Entity
-
-
   # this rule is needed because PP attachment of "by" is often wrong
   - name: ported_token_2_noun-${addlabel}
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/wm/eidos/grammars/linkersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/eidos/grammars/linkersTemplate.yml
@@ -82,7 +82,7 @@ rules:
     example: "The water quality contributes to poverty."
     label: ${ label }
     pattern: |
-      trigger = [word=/(?i)^(${ trigger })/ & tag=/^V/]
+      trigger = [word=/(?i)^(${ trigger })/ & tag=/^V/ & !tag=/VBN/]
       effect: Entity = nmod_to /${ conjunctions }|${ objects }|${ noun_modifiers }/{,2} ([word=/(?i)^(${ trigger })/] /${ preps }/{,2})?
       cause: Entity = </${complements}|${adverbial_clause}/? (${ agents }) /${ noun_modifiers }|${ conjunctions }/{,2} ([word=/(?i)^(${ trigger })/] /${ preps }/{,2})?
 

--- a/src/main/resources/org/clulab/wm/eidos/grammars/master.yml
+++ b/src/main/resources/org/clulab/wm/eidos/grammars/master.yml
@@ -109,6 +109,7 @@ rules:
     vars:
       rulepriority: "6"
       trigger: ${increase_triggers}|${decrease_triggers}
+      correlation_trigger: ${correlation_triggers}
       #action: ? #
 
   # ------------ Correlation ------------
@@ -118,3 +119,4 @@ rules:
       addlabel: "Correlation"
       label: Correlation
       trigger: ${correlation_triggers}
+

--- a/src/main/resources/org/clulab/wm/eidos/grammars/unused_rules.yml
+++ b/src/main/resources/org/clulab/wm/eidos/grammars/unused_rules.yml
@@ -133,3 +133,17 @@
     #      trigger = [word=/(?i)^(${ trigger })/ & tag=/^N/]
     #      effect: Entity = < ${noun_modifiers} > /nmod_/ /${ conjunctions }|${ noun_modifiers }/{,2}
     #      cause: Entity = < ${noun_modifiers} /${ conjunctions }|${ noun_modifiers }/{,2}
+
+    # removed because it was matching inappropriately:
+    # exs:
+    #   social support networks
+    #   climate change impacts
+    #   etc.
+    - name: ported_token_1_noun-${addlabel}
+      priority: ${ rulepriority }
+      #Original example: "mTOR activator Rapamycin"
+      example: ""
+      type: token
+      label: ${ label }
+      pattern: |
+        @effect: Entity (?<trigger> [word=/(?i)^(${ trigger })/ & tag=/^NN/]) @cause: Entity


### PR DESCRIPTION
- removed a problematic surface rule that was invalid with the types of triggers we're using here
- expanded the base_entity filtering in EidosEntityFinder to handle precentage entities (and other NE entities as well, prob)
- added filter on ported_syntax_1d_verb for issue 266 list 2 problems (see issue)
- added a decrease rule for `[limited|little] to no X`

@bgyori fyi

closes https://github.com/clulab/eidos/issues/264
closes https://github.com/clulab/eidos/issues/265
closes https://github.com/clulab/eidos/issues/266