### PR TITLE
Cross compilation for scala 2.11 and 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 language: scala
 scala:
   - 2.12.4
+  - 2.11.11
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
-  releaseStepCommandAndRemaining("+test"),
+  runTest,
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ name := "eidos"
 organization := "org.clulab"
 
 scalaVersion := "2.12.4"
+crossScalaVersions := Seq("2.11.11", "2.12.4")
 
 //EclipseKeys.withSource := true
 
@@ -87,14 +88,14 @@ releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
-  runTest,
+  releaseStepCommandAndRemaining("+test"),
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(action = Command.process("publishSigned", _)),
+  releaseStepCommandAndRemaining("+publishSigned"),
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
+  releaseStepCommandAndRemaining("sonatypeReleaseAll"),
   pushChanges
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ crossScalaVersions := Seq("2.11.11", "2.12.4")
 //EclipseKeys.withSource := true
 
 libraryDependencies ++= {
-  val procVer = "7.1.0"
+  val procVer = "7.2.1"
 
   Seq(
     "org.clulab"    %% "processors-main"          % procVer,

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ crossScalaVersions := Seq("2.11.11", "2.12.4")
 //EclipseKeys.withSource := true
 
 libraryDependencies ++= {
-  val procVer = "7.2.1"
+  val procVer = "7.2.2"
 
   Seq(
     "org.clulab"    %% "processors-main"          % procVer,

--- a/src/main/scala/org/clulab/wm/eidos/apps/MakeRuleTSVs.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/MakeRuleTSVs.scala
@@ -9,6 +9,7 @@ import org.clulab.wm.eidos.utils.FileUtils
 
 import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.forkjoin.ForkJoinPool
 import scala.collection.parallel.ForkJoinTaskSupport
 
 object MakeRuleTSVs extends App {
@@ -20,7 +21,7 @@ object MakeRuleTSVs extends App {
   val outputDir = args(1)
   val nCores = 4
   val files = FileUtils.findFiles(inputDir, "txt").par
-  files.tasksupport = new ForkJoinTaskSupport(new java.util.concurrent.ForkJoinPool(nCores))
+  files.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(nCores))
 
   val annotatedDocuments = for {
       file <- files //foreach { file =>

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEidosActions.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEidosActions.scala
@@ -1,7 +1,7 @@
 package org.clulab.wm.eidos.system
 
 import java.util.IdentityHashMap
-
+import scala.collection.JavaConverters._
 import org.clulab.odin._
 import org.clulab.serialization.json.stringify
 import org.clulab.struct.Interval
@@ -9,8 +9,6 @@ import org.clulab.wm.eidos.{EidosActions, EidosSystem}
 import org.clulab.wm.eidos.attachments.{Decrease, EidosAttachment, Increase, Quantification}
 import org.clulab.wm.eidos.serialization.json.WMJSONSerializer
 import org.clulab.wm.eidos.test.TestUtils._
-
-import scala.collection.JavaConverters.asScalaSet
 
 class TestEidosActions extends Test {
 
@@ -39,7 +37,7 @@ class TestEidosActions extends Test {
     val mapOfMentions = new IdentityHashMap[Mention, Mention]()
 
     addAllMentions(mentions, mapOfMentions)
-    asScalaSet(mapOfMentions.keySet()).toSeq
+    mapOfMentions.keySet.asScala.toSeq
   }
 
   def areMatching(left: Mention, right: Mention): Boolean = {


### PR DESCRIPTION
This PR adds cross-compilation to the release process so that two artefacts are published, for scala 2.11 and 2.12. Depends on clulab/processors#237