### PR TITLE
W2v access

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -1,7 +1,6 @@
 package org.clulab.wm.eidos
 
 import com.typesafe.config.{Config, ConfigFactory}
-
 import org.clulab.odin._
 import org.clulab.processors.fastnlp.FastNLPProcessor
 import org.clulab.processors.{Document, Processor, Sentence}
@@ -10,13 +9,10 @@ import org.clulab.utils.Configured
 import org.clulab.wm.eidos.Aliases._
 import org.clulab.wm.eidos.attachments.Score
 import org.clulab.wm.eidos.entities.EidosEntityFinder
-import org.clulab.wm.eidos.groundings.{AdjectiveGrounder, AdjectiveGrounding, EidosAdjectiveGrounder}
-import org.clulab.wm.eidos.groundings.{OntologyGrounder, OntologyGrounding, EidosOntologyGrounder}
-import org.clulab.wm.eidos.groundings.EidosWordToVec
+import org.clulab.wm.eidos.groundings._
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.DomainParams
 import org.clulab.wm.eidos.utils.FileUtils
-
 import org.slf4j.LoggerFactory
 
 case class AnnotatedDocument(var document: Document, var odinMentions: Seq[Mention], var eidosMentions: Seq[EidosMention])
@@ -193,6 +189,16 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
 
   def groundAdjective(mention: Mention, quantifier: Quantifier): AdjectiveGrounding =
     loadableAttributes.adjectiveGrounder.groundAdjective(mention, quantifier)
+
+  /*
+      Wrapper for using w2v on some strings
+   */
+  def stringSimilarity(s1: String, s2: String): Double = {
+    wordToVec match {
+      case w2v: RealWordToVec => w2v.stringSimilarity(s1, s2)
+      case _ => throw new RuntimeException("Word2Vec wasn't loaded, please check configurations.")
+    }
+  }
 
   /*
      Debugging Methods

--- a/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
@@ -13,6 +13,10 @@ trait EidosWordToVec {
 
 class RealWordToVec(w2v: Word2Vec, conceptEmbeddings: Map[String, Seq[Double]], topKNodeGroundings: Int) extends EidosWordToVec {
 
+  def stringSimilarity(s1: String, s2: String): Double = {
+    w2v.avgSimilarity(s1.split(" +"), s2.split(" +"))
+  }
+
   def calculateSimilarity(m1: Mention, m2: Mention): Double = {
     // avgSimilarity does sanitizeWord itself, so it is unnecessary here.
     val sanitisedM1 =  m1.text.split(" +")


### PR DESCRIPTION
@kwalcock feel free to refactor/request stuff.  we wanted to give HMS easier access to w2v for string similarity that isn't a part of the regular pipeline.  I thought about putting the method in the Grounder stuff (i.e., adding a version of the method to the trait and then each of the classes that extend it, but I wanted it to barf if the w2v wasn't loaded.  All that to say -- that's why I put it here, but feel free to move.

@bgyori -- sorry I took so long to PR this, I had it done a few days ago and just forgot.  PLease forgive the delay!  Here's a simple example of usage:
```
object testme extends App {
  val es = new EidosSystem()
  val sim = es.stringSimilarity("cat in the house", "dog in the house")
  val sim2 = es.stringSimilarity("cat in the house", "dog in the yard")
  val sim3 = es.stringSimilarity("groundskeepers are cool", "dog in the house")
  println(s"$sim\t$sim2\t$sim3")
}
```
This prints the following:
```
0.4281447618301553	0.35720187497529654	0.17503918311177405
```

similarity is based on average pairwise similarity, and each similarity ranges from -1 to 1 (higher = more similar)

hope it's helpful!

@MihaiSurdeanu fyi