### PR TITLE
Multi-ontology groundings

### DIFF
--- a/src/main/resources/org/clulab/wm/eidos/fao_variable_ontology.yml
+++ b/src/main/resources/org/clulab/wm/eidos/fao_variable_ontology.yml
@@ -1,2706 +1,3980 @@
-- events:
-  - Agriculture orientation index:
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Agriculture orientation index Gross Fixed Capital Formation (Agriculture,\
-        \ Forestry and Fishing)"
-    - DFA Commitment to Agriculture, Forestry and Fishing:
-      - "Agriculture orientation index DFA Commitment to Agriculture, Forestry and\
-        \ Fishing"
-  - Agriculture orientation index US$, 2005 prices:
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Agriculture orientation index US$, 2005 prices Gross Fixed Capital Formation\
-        \ (Agriculture, Forestry and Fishing)"
-  - Amount excreted in manure (N content):
-    - Chickens, broilers:
-      - "amount excreted in manure (n content) broiler chickens"
-    - Cattle:
-      - "Amount excreted in manure (N content) Cattle"
-    - Goats:
-      - "Amount excreted in manure (N content) Goats"
-    - Poultry Birds:
-      - "Amount excreted in manure (N content) Poultry Birds"
-    - Sheep:
-      - "Amount excreted in manure (N content) Sheep"
-    - Chickens, layers:
-      - "amount excreted in manure (n content) layer chickens"
-    - Mules and Asses:
-      - "Amount excreted in manure (N content) Mules and Asses"
-    - All Animals:
-      - "Amount excreted in manure (N content) All Animals"
-    - Asses:
-      - "Amount excreted in manure (N content) Asses"
-    - Cattle, dairy:
-      - "amount excreted in manure (n content) dairy cattle"
-    - Chickens:
-      - "Amount excreted in manure (N content) Chickens"
-    - Cattle, non-dairy:
-      - "amount excreted in manure (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Amount excreted in manure (N content) Sheep and Goats"
-  - Annual growth Local Currency:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Annual growth Local Currency Value Added (Agriculture, Forestry and Fishing)"
-    - Gross Domestic Product:
-      - "Annual growth Local Currency Gross Domestic Product"
-    - Value Added (Agriculture):
-      - "Annual growth Local Currency Value Added (Agriculture)"
-    - Gross Output (Agriculture, Forestry and Fishing):
-      - "Annual growth Local Currency Gross Output (Agriculture, Forestry and Fishing)"
-    - Gross Fixed Capital Formation:
-      - "Annual growth Local Currency Gross Fixed Capital Formation"
-    - Gross Output (Agriculture):
-      - "Annual growth Local Currency Gross Output (Agriculture)"
-    - Value Added (Total Manufacturing):
-      - "Annual growth Local Currency Value Added (Total Manufacturing)"
-  - Annual growth US$:
-    - Gross National Income:
-      - "Annual growth US$ Gross National Income"
-    - DFA Commitment to Agriculture, Forestry and Fishing:
-      - "Annual growth US$ DFA Commitment to Agriculture, Forestry and Fishing"
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Annual growth US$ Value Added (Agriculture, Forestry and Fishing)"
-    - Gross Domestic Product:
-      - "Annual growth US$ Gross Domestic Product"
-    - Value Added (Agriculture):
-      - "Annual growth US$ Value Added (Agriculture)"
-    - Gross Output (Agriculture, Forestry and Fishing):
-      - "Annual growth US$ Gross Output (Agriculture, Forestry and Fishing)"
-    - Gross Fixed Capital Formation:
-      - "Annual growth US$ Gross Fixed Capital Formation"
-    - Gross Domestic Product per capita:
-      - "Annual growth US$ Gross Domestic Product per capita"
-    - Agriculture, forestry, fishing (Central Government):
-      - "Annual growth US$ Agriculture, forestry, fishing (Central Government)"
-    - Gross Output (Agriculture):
-      - "Annual growth US$ Gross Output (Agriculture)"
-    - Value Added (Total Manufacturing):
-      - "Annual growth US$ Value Added (Total Manufacturing)"
-  - Annual growth US$, 2005 prices:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Annual growth US$, 2005 prices Value Added (Agriculture, Forestry and Fishing)"
-  - Annual growth, Local Currency, 2010 prices:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Annual growth, Local Currency, 2010 prices Value Added (Agriculture, Forestry\
-        \ and Fishing)"
-    - Gross Domestic Product:
-      - "Annual growth, Local Currency, 2010 prices Gross Domestic Product"
-    - Value Added (Total Manufacturing):
-      - "Annual growth, Local Currency, 2010 prices Value Added (Total Manufacturing)"
-    - Gross Fixed Capital Formation:
-      - "Annual growth, Local Currency, 2010 prices Gross Fixed Capital Formation"
-  - Annual growth, US$, 2010 prices:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Annual growth, US$, 2010 prices Value Added (Agriculture, Forestry and Fishing)"
-    - Gross Domestic Product:
-      - "Annual growth, US$, 2010 prices Gross Domestic Product"
-    - Gross Fixed Capital Formation:
-      - "Annual growth, US$, 2010 prices Gross Fixed Capital Formation"
-    - Gross Domestic Product per capita:
-      - "Annual growth, US$, 2010 prices Gross Domestic Product per capita"
-    - Value Added (Total Manufacturing):
-      - "Annual growth, US$, 2010 prices Value Added (Total Manufacturing)"
-  - Area:
-    - Planted forest:
-      - "Area Planted forest"
-    - Cropland and grassland organic soils:
-      - "Area Cropland and grassland organic soils"
-    - Total area equipped for irrigation:
-      - "Area Total area equipped for irrigation"
-    - Arable land and Permanent crops:
-      - "Area Arable land and Permanent crops"
-    - Agricultural area organic, total:
-      - "Area Agricultural area organic, total"
-    - Other naturally regenerated forest:
-      - "Area Other naturally regenerated forest"
-    - Primary forest:
-      - "Area Primary forest"
-    - Grassland organic soils:
-      - "Area Grassland organic soils"
-    - Agricultural area certified organic:
-      - "Area Agricultural area certified organic"
-    - Permanent meadows and pastures:
-      - "Area Permanent meadows and pastures"
-    - Agricultural area:
-      - "Area Agricultural area"
-    - Cropland organic soils:
-      - "Area Cropland organic soils"
-    - Agricultural area in conversion to organic:
-      - "Area Agricultural area in conversion to organic"
-    - Forest:
-      - "Area Forest"
-  - Area harvested:
-    - Vegetables Primary:
-      - "Area harvested Vegetables Primary"
-    - Mangoes, mangosteens, guavas:
-      - "Area harvested Mangoes, mangosteens, guavas"
-    - Pineapples:
-      - "Area harvested Pineapples"
-    - Rice, paddy:
-      - "area harvested paddy rice"
-    - Pulses, nes:
-      - "area harvested ne pulses"
-    - Cabbages and other brassicas:
-      - "Area harvested Cabbages and other brassicas"
-    - Tangerines, mandarins, clementines, satsumas:
-      - "Area harvested Tangerines, mandarins, clementines, satsumas"
-    - Okra:
-      - "Area harvested Okra"
-    - Cereals,Total:
-      - "Area harvested Cereals,Total"
-    - Fruit, fresh nes:
-      - "Area harvested Fruit, fresh nes"
-    - Sugar cane:
-      - "Area harvested Sugar cane"
-    - Citrus Fruit,Total:
-      - "area harvested total citrus fruit"
-    - Tomatoes:
-      - "Area harvested Tomatoes"
-    - Maize:
-      - "Area harvested Maize"
-    - Carrots and turnips:
-      - "Area harvested Carrots and turnips"
-    - Cauliflowers and broccoli:
-      - "Area harvested Cauliflowers and broccoli"
-    - Onions, dry:
-      - "area harvested dry onions"
-    - Watermelons:
-      - "Area harvested Watermelons"
-    - Broad beans, horse beans, dry:
-      - "Area harvested Broad beans, horse beans, dry"
-    - Bananas:
-      - "Area harvested Bananas"
-    - Coarse Grain, Total:
-      - "Area harvested Coarse Grain, Total"
-    - Melonseed:
-      - "Area harvested Melonseed"
-    - Sesame seed:
-      - "Area harvested Sesame seed"
-    - Melons, other (inc.cantaloupes):
-      - "Area harvested Melons, other (inc.cantaloupes)"
-    - Beans, green:
-      - "area harvested green beans"
-    - Potatoes:
-      - "Area harvested Potatoes"
-    - Pumpkins, squash and gourds:
-      - "Area harvested Pumpkins, squash and gourds"
-    - Castor oil seed:
-      - "Area harvested Castor oil seed"
-    - Cow peas, dry:
-      - "Area harvested Cow peas, dry"
-    - Lemons and limes:
-      - "Area harvested Lemons and limes"
-    - Peas, green:
-      - "area harvested green peas"
-    - Seed cotton:
-      - "Area harvested Seed cotton"
-    - Sweet potatoes:
-      - "Area harvested Sweet potatoes"
-    - Cereals (Rice Milled Eqv):
-      - "Area harvested Cereals (Rice Milled Eqv)"
-    - Chick peas:
-      - "Area harvested Chick peas"
-    - Roots and Tubers,Total:
-      - "Area harvested Roots and Tubers,Total"
-    - Sunflower seed:
-      - "Area harvested Sunflower seed"
-    - Dates:
-      - "Area harvested Dates"
-    - Millet:
-      - "Area harvested Millet"
-    - Chillies and peppers, dry:
-      - "Area harvested Chillies and peppers, dry"
-    - Cucumbers and gherkins:
-      - "Area harvested Cucumbers and gherkins"
-    - Fruit, tropical fresh nes:
-      - "Area harvested Fruit, tropical fresh nes"
-    - Groundnuts, with shell:
-      - "Area harvested Groundnuts, with shell"
-    - Grapefruit (inc. pomelos):
-      - "Area harvested Grapefruit (inc. pomelos)"
-    - Eggplants (aubergines):
-      - "Area harvested Eggplants (aubergines)"
-    - Yams:
-      - "Area harvested Yams"
-    - Wheat:
-      - "Area harvested Wheat"
-    - Beans, dry:
-      - "area harvested dry beans"
-    - Cassava:
-      - "Area harvested Cassava"
-    - Sorghum:
-      - "Area harvested Sorghum"
-    - Pulses,Total:
-      - "Area harvested Pulses,Total"
-    - Chillies and peppers, green:
-      - "Area harvested Chillies and peppers, green"
-    - Garlic:
-      - "Area harvested Garlic"
-    - Oranges:
-      - "Area harvested Oranges"
-    - Vegetables, fresh nes:
-      - "Area harvested Vegetables, fresh nes"
-  - Biomass burned (dry matter):
-    - Savanna:
-      - "Biomass burned (dry matter) Savanna"
-    - Burning - all categories:
-      - "Biomass burned (dry matter) Burning - all categories"
-    - Woody savanna:
-      - "Biomass burned (dry matter) Woody savanna"
-    - Grassland:
-      - "Biomass burned (dry matter) Grassland"
-    - Open shrubland:
-      - "Biomass burned (dry matter) Open shrubland"
-    - Savanna and woody savanna:
-      - "Biomass burned (dry matter) Savanna and woody savanna"
-    - Closed and open shrubland:
-      - "Biomass burned (dry matter) Closed and open shrubland"
-    - Closed shrubland:
-      - "Biomass burned (dry matter) Closed shrubland"
-    - Maize:
-      - "Biomass burned (dry matter) Maize"
-    - All Crops:
-      - "Biomass burned (dry matter) All Crops"
-  - Burned Area:
-    - Savanna:
-      - "Burned Area Savanna"
-    - Burning - all categories:
-      - "Burned Area Burning - all categories"
-    - Woody savanna:
-      - "Burned Area Woody savanna"
-    - Grassland:
-      - "Burned Area Grassland"
-    - Open shrubland:
-      - "Burned Area Open shrubland"
-    - Savanna and woody savanna:
-      - "Burned Area Savanna and woody savanna"
-    - Closed and open shrubland:
-      - "Burned Area Closed and open shrubland"
-    - Closed shrubland:
-      - "Burned Area Closed shrubland"
-  - Carbon stock in living biomass:
-    - Forest:
-      - "Carbon stock in living biomass Forest"
-  - Density of livestock in the agricultural area:
-    - Cattle and Buffaloes:
-      - "Density of livestock in the agricultural area Cattle and Buffaloes"
-    - Cattle:
-      - "Density of livestock in the agricultural area Cattle"
-    - Goats:
-      - "Density of livestock in the agricultural area Goats"
-    - Sheep:
-      - "Density of livestock in the agricultural area Sheep"
-    - Major livestock types:
-      - "Density of livestock in the agricultural area Major livestock types"
-    - Equidae:
-      - "Density of livestock in the agricultural area Equidae"
-    - Asses:
-      - "Density of livestock in the agricultural area Asses"
-    - Chickens:
-      - "Density of livestock in the agricultural area Chickens"
-    - Sheep and Goats:
-      - "Density of livestock in the agricultural area Sheep and Goats"
-  - Direct emissions (CO2eq) (Crop residues):
-    - Beans, dry:
-      - "direct emissions (co2eq) (crop residues) dry beans"
-    - Sorghum:
-      - "Direct emissions (CO2eq) (Crop residues) Sorghum"
-    - Millet:
-      - "Direct emissions (CO2eq) (Crop residues) Millet"
-    - Maize:
-      - "Direct emissions (CO2eq) (Crop residues) Maize"
-    - All Crops:
-      - "Direct emissions (CO2eq) (Crop residues) All Crops"
-  - Direct emissions (CO2eq) (Manure applied):
-    - Chickens, broilers:
-      - "direct emissions (co2eq) (manure applied) broiler chickens"
-    - Cattle:
-      - "Direct emissions (CO2eq) (Manure applied) Cattle"
-    - Goats:
-      - "Direct emissions (CO2eq) (Manure applied) Goats"
-    - Poultry Birds:
-      - "Direct emissions (CO2eq) (Manure applied) Poultry Birds"
-    - Sheep:
-      - "Direct emissions (CO2eq) (Manure applied) Sheep"
-    - Chickens, layers:
-      - "direct emissions (co2eq) (manure applied) layer chickens"
-    - Mules and Asses:
-      - "Direct emissions (CO2eq) (Manure applied) Mules and Asses"
-    - All Animals:
-      - "Direct emissions (CO2eq) (Manure applied) All Animals"
-    - Asses:
-      - "Direct emissions (CO2eq) (Manure applied) Asses"
-    - Cattle, dairy:
-      - "direct emissions (co2eq) (manure applied) dairy cattle"
-    - Chickens:
-      - "Direct emissions (CO2eq) (Manure applied) Chickens"
-    - Cattle, non-dairy:
-      - "direct emissions (co2eq) (manure applied) non-dairy cattle"
-    - Sheep and Goats:
-      - "Direct emissions (CO2eq) (Manure applied) Sheep and Goats"
-  - Direct emissions (CO2eq) (Manure management):
-    - Chickens, broilers:
-      - "direct emissions (co2eq) (manure management) broiler chickens"
-    - Cattle:
-      - "Direct emissions (CO2eq) (Manure management) Cattle"
-    - Goats:
-      - "Direct emissions (CO2eq) (Manure management) Goats"
-    - Poultry Birds:
-      - "Direct emissions (CO2eq) (Manure management) Poultry Birds"
-    - Sheep:
-      - "Direct emissions (CO2eq) (Manure management) Sheep"
-    - Chickens, layers:
-      - "direct emissions (co2eq) (manure management) layer chickens"
-    - Mules and Asses:
-      - "Direct emissions (CO2eq) (Manure management) Mules and Asses"
-    - All Animals:
-      - "Direct emissions (CO2eq) (Manure management) All Animals"
-    - Asses:
-      - "Direct emissions (CO2eq) (Manure management) Asses"
-    - Cattle, dairy:
-      - "direct emissions (co2eq) (manure management) dairy cattle"
-    - Chickens:
-      - "Direct emissions (CO2eq) (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "direct emissions (co2eq) (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Direct emissions (CO2eq) (Manure management) Sheep and Goats"
-  - Direct emissions (CO2eq) (Manure on pasture):
-    - Chickens, broilers:
-      - "direct emissions (co2eq) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Direct emissions (CO2eq) (Manure on pasture) Cattle"
-    - Goats:
-      - "Direct emissions (CO2eq) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Direct emissions (CO2eq) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Direct emissions (CO2eq) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "direct emissions (co2eq) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Direct emissions (CO2eq) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Direct emissions (CO2eq) (Manure on pasture) All Animals"
-    - Asses:
-      - "Direct emissions (CO2eq) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "direct emissions (co2eq) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Direct emissions (CO2eq) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "direct emissions (co2eq) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Direct emissions (CO2eq) (Manure on pasture) Sheep and Goats"
-  - Direct emissions (N2O) (Crop residues):
-    - Beans, dry:
-      - "direct emissions (n2o) (crop residues) dry beans"
-    - Sorghum:
-      - "Direct emissions (N2O) (Crop residues) Sorghum"
-    - Millet:
-      - "Direct emissions (N2O) (Crop residues) Millet"
-    - Maize:
-      - "Direct emissions (N2O) (Crop residues) Maize"
-    - All Crops:
-      - "Direct emissions (N2O) (Crop residues) All Crops"
-  - Direct emissions (N2O) (Manure applied):
-    - Chickens, broilers:
-      - "direct emissions (n2o) (manure applied) broiler chickens"
-    - Cattle:
-      - "Direct emissions (N2O) (Manure applied) Cattle"
-    - Goats:
-      - "Direct emissions (N2O) (Manure applied) Goats"
-    - Poultry Birds:
-      - "Direct emissions (N2O) (Manure applied) Poultry Birds"
-    - Sheep:
-      - "Direct emissions (N2O) (Manure applied) Sheep"
-    - Chickens, layers:
-      - "direct emissions (n2o) (manure applied) layer chickens"
-    - Mules and Asses:
-      - "Direct emissions (N2O) (Manure applied) Mules and Asses"
-    - All Animals:
-      - "Direct emissions (N2O) (Manure applied) All Animals"
-    - Asses:
-      - "Direct emissions (N2O) (Manure applied) Asses"
-    - Cattle, dairy:
-      - "direct emissions (n2o) (manure applied) dairy cattle"
-    - Chickens:
-      - "Direct emissions (N2O) (Manure applied) Chickens"
-    - Cattle, non-dairy:
-      - "direct emissions (n2o) (manure applied) non-dairy cattle"
-    - Sheep and Goats:
-      - "Direct emissions (N2O) (Manure applied) Sheep and Goats"
-  - Direct emissions (N2O) (Manure management):
-    - Chickens, broilers:
-      - "direct emissions (n2o) (manure management) broiler chickens"
-    - Cattle:
-      - "Direct emissions (N2O) (Manure management) Cattle"
-    - Goats:
-      - "Direct emissions (N2O) (Manure management) Goats"
-    - Poultry Birds:
-      - "Direct emissions (N2O) (Manure management) Poultry Birds"
-    - Sheep:
-      - "Direct emissions (N2O) (Manure management) Sheep"
-    - Chickens, layers:
-      - "direct emissions (n2o) (manure management) layer chickens"
-    - Mules and Asses:
-      - "Direct emissions (N2O) (Manure management) Mules and Asses"
-    - All Animals:
-      - "Direct emissions (N2O) (Manure management) All Animals"
-    - Asses:
-      - "Direct emissions (N2O) (Manure management) Asses"
-    - Cattle, dairy:
-      - "direct emissions (n2o) (manure management) dairy cattle"
-    - Chickens:
-      - "Direct emissions (N2O) (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "direct emissions (n2o) (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Direct emissions (N2O) (Manure management) Sheep and Goats"
-  - Direct emissions (N2O) (Manure on pasture):
-    - Chickens, broilers:
-      - "direct emissions (n2o) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Direct emissions (N2O) (Manure on pasture) Cattle"
-    - Goats:
-      - "Direct emissions (N2O) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Direct emissions (N2O) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Direct emissions (N2O) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "direct emissions (n2o) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Direct emissions (N2O) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Direct emissions (N2O) (Manure on pasture) All Animals"
-    - Asses:
-      - "Direct emissions (N2O) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "direct emissions (n2o) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Direct emissions (N2O) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "direct emissions (n2o) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Direct emissions (N2O) (Manure on pasture) Sheep and Goats"
-  - Emissions (CH4) (Burning - savanna):
-    - Savanna:
-      - "Emissions (CH4) (Burning - savanna) Savanna"
-    - Burning - all categories:
-      - "Emissions (CH4) (Burning - savanna) Burning - all categories"
-    - Woody savanna:
-      - "Emissions (CH4) (Burning - savanna) Woody savanna"
-    - Grassland:
-      - "Emissions (CH4) (Burning - savanna) Grassland"
-    - Open shrubland:
-      - "Emissions (CH4) (Burning - savanna) Open shrubland"
-    - Savanna and woody savanna:
-      - "Emissions (CH4) (Burning - savanna) Savanna and woody savanna"
-    - Closed and open shrubland:
-      - "Emissions (CH4) (Burning - savanna) Closed and open shrubland"
-    - Closed shrubland:
-      - "Emissions (CH4) (Burning - savanna) Closed shrubland"
-  - Emissions (CH4) (Burning crop residues):
-    - Maize:
-      - "Emissions (CH4) (Burning crop residues) Maize"
-    - All Crops:
-      - "Emissions (CH4) (Burning crop residues) All Crops"
-  - Emissions (CH4) (Enteric):
-    - Cattle:
-      - "Emissions (CH4) (Enteric) Cattle"
-    - Goats:
-      - "Emissions (CH4) (Enteric) Goats"
-    - Sheep:
-      - "Emissions (CH4) (Enteric) Sheep"
-    - Mules and Asses:
-      - "Emissions (CH4) (Enteric) Mules and Asses"
-    - All Animals:
-      - "Emissions (CH4) (Enteric) All Animals"
-    - Asses:
-      - "Emissions (CH4) (Enteric) Asses"
-    - Cattle, dairy:
-      - "emissions (ch4) (enteric) dairy cattle"
-    - Cattle, non-dairy:
-      - "emissions (ch4) (enteric) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (CH4) (Enteric) Sheep and Goats"
-  - Emissions (CH4) (Manure management):
-    - Chickens, broilers:
-      - "emissions (ch4) (manure management) broiler chickens"
-    - Cattle:
-      - "Emissions (CH4) (Manure management) Cattle"
-    - Goats:
-      - "Emissions (CH4) (Manure management) Goats"
-    - Poultry Birds:
-      - "Emissions (CH4) (Manure management) Poultry Birds"
-    - Sheep:
-      - "Emissions (CH4) (Manure management) Sheep"
-    - Chickens, layers:
-      - "emissions (ch4) (manure management) layer chickens"
-    - Mules and Asses:
-      - "Emissions (CH4) (Manure management) Mules and Asses"
-    - All Animals:
-      - "Emissions (CH4) (Manure management) All Animals"
-    - Asses:
-      - "Emissions (CH4) (Manure management) Asses"
-    - Cattle, dairy:
-      - "emissions (ch4) (manure management) dairy cattle"
-    - Chickens:
-      - "Emissions (CH4) (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (ch4) (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (CH4) (Manure management) Sheep and Goats"
-  - Emissions (CO2eq):
-    - Milk, whole fresh goat:
-      - "Emissions (CO2eq) Milk, whole fresh goat"
-    - Meat, chicken:
-      - "emissions (co2eq) chicken meat"
-    - Crop Residues:
-      - "Emissions (CO2eq) Crop Residues"
-    - Enteric Fermentation:
-      - "Emissions (CO2eq) Enteric Fermentation"
-    - Cultivation of Organic Soils:
-      - "Emissions (CO2eq) Cultivation of Organic Soils"
-    - Agriculture total:
-      - "Emissions (CO2eq) Agriculture total"
-    - Meat, sheep:
-      - "emissions (co2eq) sheep meat"
-    - Manure left on Pasture:
-      - "Emissions (CO2eq) Manure left on Pasture"
-    - Manure Management:
-      - "Emissions (CO2eq) Manure Management"
-    - Manure applied to Soils:
-      - "Emissions (CO2eq) Manure applied to Soils"
-    - Burning - Crop residues:
-      - "Emissions (CO2eq) Burning - Crop residues"
-    - Agricultural Soils:
-      - "Emissions (CO2eq) Agricultural Soils"
-    - Meat, cattle:
-      - "emissions (co2eq) cattle meat"
-    - Cereals excluding rice:
-      - "Emissions (CO2eq) Cereals excluding rice"
-    - Burning - Savanna:
-      - "Emissions (CO2eq) Burning - Savanna"
-    - Milk, whole fresh sheep:
-      - "Emissions (CO2eq) Milk, whole fresh sheep"
-    - Milk, whole fresh cow:
-      - "Emissions (CO2eq) Milk, whole fresh cow"
-    - Meat, goat:
-      - "emissions (co2eq) goat meat"
-  - Emissions (CO2eq) (Burning - savanna):
-    - Savanna:
-      - "Emissions (CO2eq) (Burning - savanna) Savanna"
-    - Burning - all categories:
-      - "Emissions (CO2eq) (Burning - savanna) Burning - all categories"
-    - Woody savanna:
-      - "Emissions (CO2eq) (Burning - savanna) Woody savanna"
-    - Grassland:
-      - "Emissions (CO2eq) (Burning - savanna) Grassland"
-    - Open shrubland:
-      - "Emissions (CO2eq) (Burning - savanna) Open shrubland"
-    - Savanna and woody savanna:
-      - "Emissions (CO2eq) (Burning - savanna) Savanna and woody savanna"
-    - Closed and open shrubland:
-      - "Emissions (CO2eq) (Burning - savanna) Closed and open shrubland"
-    - Closed shrubland:
-      - "Emissions (CO2eq) (Burning - savanna) Closed shrubland"
-  - Emissions (CO2eq) (Burning crop residues):
-    - Maize:
-      - "Emissions (CO2eq) (Burning crop residues) Maize"
-    - All Crops:
-      - "Emissions (CO2eq) (Burning crop residues) All Crops"
-  - Emissions (CO2eq) (Crop residues):
-    - Beans, dry:
-      - "emissions (co2eq) (crop residues) dry beans"
-    - Sorghum:
-      - "Emissions (CO2eq) (Crop residues) Sorghum"
-    - Millet:
-      - "Emissions (CO2eq) (Crop residues) Millet"
-    - Maize:
-      - "Emissions (CO2eq) (Crop residues) Maize"
-    - All Crops:
-      - "Emissions (CO2eq) (Crop residues) All Crops"
-  - Emissions (CO2eq) (Cultivation of organic soils):
-    - Grassland organic soils:
-      - "Emissions (CO2eq) (Cultivation of organic soils) Grassland organic soils"
-    - Cropland and grassland organic soils:
-      - "Emissions (CO2eq) (Cultivation of organic soils) Cropland and grassland organic\
-        \ soils"
-    - Cropland organic soils:
-      - "Emissions (CO2eq) (Cultivation of organic soils) Cropland organic soils"
-  - Emissions (CO2eq) (Enteric):
-    - Cattle:
-      - "Emissions (CO2eq) (Enteric) Cattle"
-    - Goats:
-      - "Emissions (CO2eq) (Enteric) Goats"
-    - Sheep:
-      - "Emissions (CO2eq) (Enteric) Sheep"
-    - Mules and Asses:
-      - "Emissions (CO2eq) (Enteric) Mules and Asses"
-    - All Animals:
-      - "Emissions (CO2eq) (Enteric) All Animals"
-    - Asses:
-      - "Emissions (CO2eq) (Enteric) Asses"
-    - Cattle, dairy:
-      - "emissions (co2eq) (enteric) dairy cattle"
-    - Cattle, non-dairy:
-      - "emissions (co2eq) (enteric) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (CO2eq) (Enteric) Sheep and Goats"
-  - Emissions (CO2eq) (Manure applied):
-    - Chickens, broilers:
-      - "emissions (co2eq) (manure applied) broiler chickens"
-    - Cattle:
-      - "Emissions (CO2eq) (Manure applied) Cattle"
-    - Goats:
-      - "Emissions (CO2eq) (Manure applied) Goats"
-    - Poultry Birds:
-      - "Emissions (CO2eq) (Manure applied) Poultry Birds"
-    - Sheep:
-      - "Emissions (CO2eq) (Manure applied) Sheep"
-    - Chickens, layers:
-      - "emissions (co2eq) (manure applied) layer chickens"
-    - Mules and Asses:
-      - "Emissions (CO2eq) (Manure applied) Mules and Asses"
-    - All Animals:
-      - "Emissions (CO2eq) (Manure applied) All Animals"
-    - Asses:
-      - "Emissions (CO2eq) (Manure applied) Asses"
-    - Cattle, dairy:
-      - "emissions (co2eq) (manure applied) dairy cattle"
-    - Chickens:
-      - "Emissions (CO2eq) (Manure applied) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (co2eq) (manure applied) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (CO2eq) (Manure applied) Sheep and Goats"
-  - Emissions (CO2eq) (Manure management):
-    - Chickens, broilers:
-      - "emissions (co2eq) (manure management) broiler chickens"
-    - Cattle:
-      - "Emissions (CO2eq) (Manure management) Cattle"
-    - Goats:
-      - "Emissions (CO2eq) (Manure management) Goats"
-    - Poultry Birds:
-      - "Emissions (CO2eq) (Manure management) Poultry Birds"
-    - Sheep:
-      - "Emissions (CO2eq) (Manure management) Sheep"
-    - Chickens, layers:
-      - "emissions (co2eq) (manure management) layer chickens"
-    - Mules and Asses:
-      - "Emissions (CO2eq) (Manure management) Mules and Asses"
-    - All Animals:
-      - "Emissions (CO2eq) (Manure management) All Animals"
-    - Asses:
-      - "Emissions (CO2eq) (Manure management) Asses"
-    - Cattle, dairy:
-      - "emissions (co2eq) (manure management) dairy cattle"
-    - Chickens:
-      - "Emissions (CO2eq) (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (co2eq) (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (CO2eq) (Manure management) Sheep and Goats"
-  - Emissions (CO2eq) (Manure on pasture):
-    - Chickens, broilers:
-      - "emissions (co2eq) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Emissions (CO2eq) (Manure on pasture) Cattle"
-    - Goats:
-      - "Emissions (CO2eq) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Emissions (CO2eq) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Emissions (CO2eq) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "emissions (co2eq) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Emissions (CO2eq) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Emissions (CO2eq) (Manure on pasture) All Animals"
-    - Asses:
-      - "Emissions (CO2eq) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "emissions (co2eq) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Emissions (CO2eq) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (co2eq) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (CO2eq) (Manure on pasture) Sheep and Goats"
-  - Emissions (CO2eq) from CH4:
-    - Enteric Fermentation:
-      - "Emissions (CO2eq) from CH4 Enteric Fermentation"
-    - Agriculture total:
-      - "Emissions (CO2eq) from CH4 Agriculture total"
-    - Manure Management:
-      - "Emissions (CO2eq) from CH4 Manure Management"
-    - Burning - Crop residues:
-      - "Emissions (CO2eq) from CH4 Burning - Crop residues"
-    - Burning - Savanna:
-      - "Emissions (CO2eq) from CH4 Burning - Savanna"
-  - Emissions (CO2eq) from CH4 (Burning - savanna):
-    - Savanna:
-      - "Emissions (CO2eq) from CH4 (Burning - savanna) Savanna"
-    - Burning - all categories:
-      - "Emissions (CO2eq) from CH4 (Burning - savanna) Burning - all categories"
-    - Woody savanna:
-      - "Emissions (CO2eq) from CH4 (Burning - savanna) Woody savanna"
-    - Grassland:
-      - "Emissions (CO2eq) from CH4 (Burning - savanna) Grassland"
-    - Open shrubland:
-      - "Emissions (CO2eq) from CH4 (Burning - savanna) Open shrubland"
-    - Savanna and woody savanna:
-      - "Emissions (CO2eq) from CH4 (Burning - savanna) Savanna and woody savanna"
-    - Closed and open shrubland:
-      - "Emissions (CO2eq) from CH4 (Burning - savanna) Closed and open shrubland"
-    - Closed shrubland:
-      - "Emissions (CO2eq) from CH4 (Burning - savanna) Closed shrubland"
-  - Emissions (CO2eq) from CH4 (Burning crop residues):
-    - Maize:
-      - "Emissions (CO2eq) from CH4 (Burning crop residues) Maize"
-    - All Crops:
-      - "Emissions (CO2eq) from CH4 (Burning crop residues) All Crops"
-  - Emissions (CO2eq) from CH4 (Manure management):
-    - Chickens, broilers:
-      - "emissions (co2eq) from ch4 (manure management) broiler chickens"
-    - Cattle:
-      - "Emissions (CO2eq) from CH4 (Manure management) Cattle"
-    - Goats:
-      - "Emissions (CO2eq) from CH4 (Manure management) Goats"
-    - Poultry Birds:
-      - "Emissions (CO2eq) from CH4 (Manure management) Poultry Birds"
-    - Sheep:
-      - "Emissions (CO2eq) from CH4 (Manure management) Sheep"
-    - Chickens, layers:
-      - "emissions (co2eq) from ch4 (manure management) layer chickens"
-    - Mules and Asses:
-      - "Emissions (CO2eq) from CH4 (Manure management) Mules and Asses"
-    - All Animals:
-      - "Emissions (CO2eq) from CH4 (Manure management) All Animals"
-    - Asses:
-      - "Emissions (CO2eq) from CH4 (Manure management) Asses"
-    - Cattle, dairy:
-      - "emissions (co2eq) from ch4 (manure management) dairy cattle"
-    - Chickens:
-      - "Emissions (CO2eq) from CH4 (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (co2eq) from ch4 (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (CO2eq) from CH4 (Manure management) Sheep and Goats"
-  - Emissions (CO2eq) from N2O:
-    - Crop Residues:
-      - "Emissions (CO2eq) from N2O Crop Residues"
-    - Cultivation of Organic Soils:
-      - "Emissions (CO2eq) from N2O Cultivation of Organic Soils"
-    - Agriculture total:
-      - "Emissions (CO2eq) from N2O Agriculture total"
-    - Manure left on Pasture:
-      - "Emissions (CO2eq) from N2O Manure left on Pasture"
-    - Manure Management:
-      - "Emissions (CO2eq) from N2O Manure Management"
-    - Manure applied to Soils:
-      - "Emissions (CO2eq) from N2O Manure applied to Soils"
-    - Burning - Crop residues:
-      - "Emissions (CO2eq) from N2O Burning - Crop residues"
-    - Agricultural Soils:
-      - "Emissions (CO2eq) from N2O Agricultural Soils"
-    - Burning - Savanna:
-      - "Emissions (CO2eq) from N2O Burning - Savanna"
-  - Emissions (CO2eq) from N2O (Burning - savanna):
-    - Savanna:
-      - "Emissions (CO2eq) from N2O (Burning - savanna) Savanna"
-    - Burning - all categories:
-      - "Emissions (CO2eq) from N2O (Burning - savanna) Burning - all categories"
-    - Woody savanna:
-      - "Emissions (CO2eq) from N2O (Burning - savanna) Woody savanna"
-    - Grassland:
-      - "Emissions (CO2eq) from N2O (Burning - savanna) Grassland"
-    - Open shrubland:
-      - "Emissions (CO2eq) from N2O (Burning - savanna) Open shrubland"
-    - Savanna and woody savanna:
-      - "Emissions (CO2eq) from N2O (Burning - savanna) Savanna and woody savanna"
-    - Closed and open shrubland:
-      - "Emissions (CO2eq) from N2O (Burning - savanna) Closed and open shrubland"
-    - Closed shrubland:
-      - "Emissions (CO2eq) from N2O (Burning - savanna) Closed shrubland"
-  - Emissions (CO2eq) from N2O (Burning crop residues):
-    - Maize:
-      - "Emissions (CO2eq) from N2O (Burning crop residues) Maize"
-    - All Crops:
-      - "Emissions (CO2eq) from N2O (Burning crop residues) All Crops"
-  - Emissions (CO2eq) from N2O (Manure management):
-    - Chickens, broilers:
-      - "emissions (co2eq) from n2o (manure management) broiler chickens"
-    - Cattle:
-      - "Emissions (CO2eq) from N2O (Manure management) Cattle"
-    - Goats:
-      - "Emissions (CO2eq) from N2O (Manure management) Goats"
-    - Poultry Birds:
-      - "Emissions (CO2eq) from N2O (Manure management) Poultry Birds"
-    - Sheep:
-      - "Emissions (CO2eq) from N2O (Manure management) Sheep"
-    - Chickens, layers:
-      - "emissions (co2eq) from n2o (manure management) layer chickens"
-    - Mules and Asses:
-      - "Emissions (CO2eq) from N2O (Manure management) Mules and Asses"
-    - All Animals:
-      - "Emissions (CO2eq) from N2O (Manure management) All Animals"
-    - Asses:
-      - "Emissions (CO2eq) from N2O (Manure management) Asses"
-    - Cattle, dairy:
-      - "emissions (co2eq) from n2o (manure management) dairy cattle"
-    - Chickens:
-      - "Emissions (CO2eq) from N2O (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (co2eq) from n2o (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (CO2eq) from N2O (Manure management) Sheep and Goats"
-  - Emissions (N2O) (Burning - savanna):
-    - Savanna:
-      - "Emissions (N2O) (Burning - savanna) Savanna"
-    - Burning - all categories:
-      - "Emissions (N2O) (Burning - savanna) Burning - all categories"
-    - Woody savanna:
-      - "Emissions (N2O) (Burning - savanna) Woody savanna"
-    - Grassland:
-      - "Emissions (N2O) (Burning - savanna) Grassland"
-    - Open shrubland:
-      - "Emissions (N2O) (Burning - savanna) Open shrubland"
-    - Savanna and woody savanna:
-      - "Emissions (N2O) (Burning - savanna) Savanna and woody savanna"
-    - Closed and open shrubland:
-      - "Emissions (N2O) (Burning - savanna) Closed and open shrubland"
-    - Closed shrubland:
-      - "Emissions (N2O) (Burning - savanna) Closed shrubland"
-  - Emissions (N2O) (Burning crop residues):
-    - Maize:
-      - "Emissions (N2O) (Burning crop residues) Maize"
-    - All Crops:
-      - "Emissions (N2O) (Burning crop residues) All Crops"
-  - Emissions (N2O) (Crop residues):
-    - Beans, dry:
-      - "emissions (n2o) (crop residues) dry beans"
-    - Sorghum:
-      - "Emissions (N2O) (Crop residues) Sorghum"
-    - Millet:
-      - "Emissions (N2O) (Crop residues) Millet"
-    - Maize:
-      - "Emissions (N2O) (Crop residues) Maize"
-    - All Crops:
-      - "Emissions (N2O) (Crop residues) All Crops"
-  - Emissions (N2O) (Cultivation of organic soils):
-    - Grassland organic soils:
-      - "Emissions (N2O) (Cultivation of organic soils) Grassland organic soils"
-    - Cropland and grassland organic soils:
-      - "Emissions (N2O) (Cultivation of organic soils) Cropland and grassland organic\
-        \ soils"
-    - Cropland organic soils:
-      - "Emissions (N2O) (Cultivation of organic soils) Cropland organic soils"
-  - Emissions (N2O) (Manure applied):
-    - Chickens, broilers:
-      - "emissions (n2o) (manure applied) broiler chickens"
-    - Cattle:
-      - "Emissions (N2O) (Manure applied) Cattle"
-    - Goats:
-      - "Emissions (N2O) (Manure applied) Goats"
-    - Poultry Birds:
-      - "Emissions (N2O) (Manure applied) Poultry Birds"
-    - Sheep:
-      - "Emissions (N2O) (Manure applied) Sheep"
-    - Chickens, layers:
-      - "emissions (n2o) (manure applied) layer chickens"
-    - Mules and Asses:
-      - "Emissions (N2O) (Manure applied) Mules and Asses"
-    - All Animals:
-      - "Emissions (N2O) (Manure applied) All Animals"
-    - Asses:
-      - "Emissions (N2O) (Manure applied) Asses"
-    - Cattle, dairy:
-      - "emissions (n2o) (manure applied) dairy cattle"
-    - Chickens:
-      - "Emissions (N2O) (Manure applied) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (n2o) (manure applied) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (N2O) (Manure applied) Sheep and Goats"
-  - Emissions (N2O) (Manure management):
-    - Chickens, broilers:
-      - "emissions (n2o) (manure management) broiler chickens"
-    - Cattle:
-      - "Emissions (N2O) (Manure management) Cattle"
-    - Goats:
-      - "Emissions (N2O) (Manure management) Goats"
-    - Poultry Birds:
-      - "Emissions (N2O) (Manure management) Poultry Birds"
-    - Sheep:
-      - "Emissions (N2O) (Manure management) Sheep"
-    - Chickens, layers:
-      - "emissions (n2o) (manure management) layer chickens"
-    - Mules and Asses:
-      - "Emissions (N2O) (Manure management) Mules and Asses"
-    - All Animals:
-      - "Emissions (N2O) (Manure management) All Animals"
-    - Asses:
-      - "Emissions (N2O) (Manure management) Asses"
-    - Cattle, dairy:
-      - "emissions (n2o) (manure management) dairy cattle"
-    - Chickens:
-      - "Emissions (N2O) (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (n2o) (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (N2O) (Manure management) Sheep and Goats"
-  - Emissions (N2O) (Manure on pasture):
-    - Chickens, broilers:
-      - "emissions (n2o) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Emissions (N2O) (Manure on pasture) Cattle"
-    - Goats:
-      - "Emissions (N2O) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Emissions (N2O) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Emissions (N2O) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "emissions (n2o) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Emissions (N2O) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Emissions (N2O) (Manure on pasture) All Animals"
-    - Asses:
-      - "Emissions (N2O) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "emissions (n2o) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Emissions (N2O) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "emissions (n2o) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Emissions (N2O) (Manure on pasture) Sheep and Goats"
-  - Emissions intensity:
-    - Milk, whole fresh goat:
-      - "Emissions intensity Milk, whole fresh goat"
-    - Meat, chicken:
-      - "emissions intensity chicken meat"
-    - Meat, cattle:
-      - "emissions intensity cattle meat"
-    - Milk, whole fresh sheep:
-      - "Emissions intensity Milk, whole fresh sheep"
-    - Meat, sheep:
-      - "emissions intensity sheep meat"
-    - Cereals excluding rice:
-      - "Emissions intensity Cereals excluding rice"
-    - Milk, whole fresh cow:
-      - "Emissions intensity Milk, whole fresh cow"
-    - Meat, goat:
-      - "emissions intensity goat meat"
-  - Export Quantity:
-    - Industrial roundwood:
-      - "Export Quantity Industrial roundwood"
-    - Industrial roundwood, non-coniferous tropical (export/import):
-      - "Export Quantity Industrial roundwood, non-coniferous tropical (export/import)"
-    - Industrial roundwood, non-coniferous:
-      - "Export Quantity Industrial roundwood, non-coniferous"
-    - Sawnwood:
-      - "Export Quantity Sawnwood"
-    - Roundwood:
-      - "Export Quantity Roundwood"
-    - Sawnwood, non-coniferous all:
-      - "Export Quantity Sawnwood, non-coniferous all"
-  - Export Value:
-    - Industrial roundwood:
-      - "Export Value Industrial roundwood"
-    - Industrial roundwood, non-coniferous tropical (export/import):
-      - "Export Value Industrial roundwood, non-coniferous tropical (export/import)"
-    - Industrial roundwood, non-coniferous:
-      - "Export Value Industrial roundwood, non-coniferous"
-    - Sawnwood:
-      - "Export Value Sawnwood"
-    - Roundwood:
-      - "Export Value Roundwood"
-    - Sawnwood, non-coniferous all:
-      - "Export Value Sawnwood, non-coniferous all"
-    - Forest products (export/import):
-      - "Export Value Forest products (export/import)"
-  - Food aid shipments:
-    - Edible Fat Total:
-      - "Food aid shipments Edible Fat Total"
-    - Other Non-Cereals:
-      - "Food aid shipments Other Non-Cereals"
-    - Milk,Total:
-      - "Food aid shipments Milk,Total"
-    - Cereals:
-      - "Food aid shipments Cereals"
-    - Non-Cereals:
-      - "Food aid shipments Non-Cereals"
-    - Coarse Grains:
-      - "Food aid shipments Coarse Grains"
-    - Blended And Mix:
-      - "Food aid shipments Blended And Mix"
-    - Rice Total:
-      - "Food aid shipments Rice Total"
-    - Vegetable Oils:
-      - "Food aid shipments Vegetable Oils"
-    - Sugar Total:
-      - "Food aid shipments Sugar Total"
-    - Pulses,Total:
-      - "Food aid shipments Pulses,Total"
-  - Gross Production Value (constant 2004-2006 1000 I$):
-    - Pineapples:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Pineapples"
-    - Tangerines, mandarins, clementines, satsumas:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Tangerines, mandarins,\
-        \ clementines, satsumas"
-    - Pulses, nes:
-      - "gross production value (constant 2004-2006 1000 i$) ne pulses"
-    - Oilcrops Primary:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Oilcrops Primary"
-    - Cereals,Total:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Cereals,Total"
-    - Livestock (PIN):
-      - "Gross Production Value (constant 2004-2006 1000 I$) Livestock (PIN)"
-    - Fruit, fresh nes:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Fruit, fresh nes"
-    - Meat, game:
-      - "gross production value (constant 2004-2006 1000 i$) game meat"
-    - Onions, shallots, green:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Onions, shallots, green"
-    - Maize:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Maize"
-    - Food (PIN):
-      - "Gross Production Value (constant 2004-2006 1000 I$) Food (PIN)"
-    - Honey, natural:
-      - "gross production value (constant 2004-2006 1000 i$) natural honey"
-    - Meat indigenous, total:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Meat indigenous, total"
-    - Melonseed:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Melonseed"
-    - Milk,Total:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Milk,Total"
-    - Sesame seed:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Sesame seed"
-    - Beeswax:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Beeswax"
-    - Oilseeds nes:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Oilseeds nes"
-    - Melons, other (inc.cantaloupes):
-      - "Gross Production Value (constant 2004-2006 1000 I$) Melons, other (inc.cantaloupes)"
-    - Beans, green:
-      - "gross production value (constant 2004-2006 1000 i$) green beans"
-    - Non Food (PIN):
-      - "Gross Production Value (constant 2004-2006 1000 I$) Non Food (PIN)"
-    - Pumpkins, squash and gourds:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Pumpkins, squash and\
-        \ gourds"
-    - Milk, whole fresh cow:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Milk, whole fresh cow"
-    - Peas, green:
-      - "gross production value (constant 2004-2006 1000 i$) green peas"
-    - Crops (PIN):
-      - "Gross Production Value (constant 2004-2006 1000 I$) Crops (PIN)"
-    - Milk, whole fresh goat:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Milk, whole fresh goat"
-    - Agriculture (PIN):
-      - "Gross Production Value (constant 2004-2006 1000 I$) Agriculture (PIN)"
-    - Vegetables and Fruit Primary:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Vegetables and Fruit\
-        \ Primary"
-    - Roots and Tubers,Total:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Roots and Tubers,Total"
-    - Sunflower seed:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Sunflower seed"
-    - Jute:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Jute"
-    - Millet:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Millet"
-    - Cottonseed:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Cottonseed"
-    - Chillies and peppers, dry:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Chillies and peppers,\
-        \ dry"
-    - Fruit, tropical fresh nes:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Fruit, tropical fresh\
-        \ nes"
-    - Groundnuts, with shell:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Groundnuts, with shell"
-    - Yams:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Yams"
-    - Cotton lint:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Cotton lint"
-    - Beans, dry:
-      - "gross production value (constant 2004-2006 1000 i$) dry beans"
-    - Cassava:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Cassava"
-    - Sorghum:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Sorghum"
-    - Milk, whole fresh sheep:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Milk, whole fresh sheep"
-    - Vegetables, fresh nes:
-      - "Gross Production Value (constant 2004-2006 1000 I$) Vegetables, fresh nes"
-  - Implied emission factor for CH4 (Burning - savanna):
-    - Savanna:
-      - "Implied emission factor for CH4 (Burning - savanna) Savanna"
-    - Woody savanna:
-      - "Implied emission factor for CH4 (Burning - savanna) Woody savanna"
-    - Grassland:
-      - "Implied emission factor for CH4 (Burning - savanna) Grassland"
-    - Open shrubland:
-      - "Implied emission factor for CH4 (Burning - savanna) Open shrubland"
-    - Closed shrubland:
-      - "Implied emission factor for CH4 (Burning - savanna) Closed shrubland"
-  - Implied emission factor for CH4 (Burning crop residues):
-    - Maize:
-      - "Implied emission factor for CH4 (Burning crop residues) Maize"
-  - Implied emission factor for CH4 (Enteric):
-    - Goats:
-      - "Implied emission factor for CH4 (Enteric) Goats"
-    - Sheep:
-      - "Implied emission factor for CH4 (Enteric) Sheep"
-    - Asses:
-      - "Implied emission factor for CH4 (Enteric) Asses"
-    - Cattle, dairy:
-      - "implied emission factor for ch4 (enteric) dairy cattle"
-    - Cattle, non-dairy:
-      - "implied emission factor for ch4 (enteric) non-dairy cattle"
-  - Implied emission factor for CH4 (Manure management):
-    - Chickens, broilers:
-      - "implied emission factor for ch4 (manure management) broiler chickens"
-    - Goats:
-      - "Implied emission factor for CH4 (Manure management) Goats"
-    - Sheep:
-      - "Implied emission factor for CH4 (Manure management) Sheep"
-    - Chickens, layers:
-      - "implied emission factor for ch4 (manure management) layer chickens"
-    - Asses:
-      - "Implied emission factor for CH4 (Manure management) Asses"
-    - Cattle, dairy:
-      - "implied emission factor for ch4 (manure management) dairy cattle"
-    - Cattle, non-dairy:
-      - "implied emission factor for ch4 (manure management) non-dairy cattle"
-  - Implied emission factor for N2O (Burning - savanna):
-    - Savanna:
-      - "Implied emission factor for N2O (Burning - savanna) Savanna"
-    - Woody savanna:
-      - "Implied emission factor for N2O (Burning - savanna) Woody savanna"
-    - Grassland:
-      - "Implied emission factor for N2O (Burning - savanna) Grassland"
-    - Open shrubland:
-      - "Implied emission factor for N2O (Burning - savanna) Open shrubland"
-    - Closed shrubland:
-      - "Implied emission factor for N2O (Burning - savanna) Closed shrubland"
-  - Implied emission factor for N2O (Burning crop residues):
-    - Maize:
-      - "Implied emission factor for N2O (Burning crop residues) Maize"
-  - Implied emission factor for N2O (Crop residues):
-    - Millet:
-      - "Implied emission factor for N2O (Crop residues) Millet"
-    - Maize:
-      - "Implied emission factor for N2O (Crop residues) Maize"
-    - Sorghum:
-      - "Implied emission factor for N2O (Crop residues) Sorghum"
-    - Beans, dry:
-      - "implied emission factor for n2o (crop residues) dry beans"
-  - Implied emission factor for N2O (Cultivation of organic soils):
-    - Grassland organic soils:
-      - "Implied emission factor for N2O (Cultivation of organic soils) Grassland\
-        \ organic soils"
-    - Cropland organic soils:
-      - "Implied emission factor for N2O (Cultivation of organic soils) Cropland organic\
-        \ soils"
-  - Implied emission factor for N2O (Manure applied):
-    - Chickens, broilers:
-      - "implied emission factor for n2o (manure applied) broiler chickens"
-    - Goats:
-      - "Implied emission factor for N2O (Manure applied) Goats"
-    - Sheep:
-      - "Implied emission factor for N2O (Manure applied) Sheep"
-    - Chickens, layers:
-      - "implied emission factor for n2o (manure applied) layer chickens"
-    - Asses:
-      - "Implied emission factor for N2O (Manure applied) Asses"
-    - Cattle, dairy:
-      - "implied emission factor for n2o (manure applied) dairy cattle"
-    - Cattle, non-dairy:
-      - "implied emission factor for n2o (manure applied) non-dairy cattle"
-  - Implied emission factor for N2O (Manure management):
-    - Chickens, broilers:
-      - "implied emission factor for n2o (manure management) broiler chickens"
-    - Goats:
-      - "Implied emission factor for N2O (Manure management) Goats"
-    - Sheep:
-      - "Implied emission factor for N2O (Manure management) Sheep"
-    - Chickens, layers:
-      - "implied emission factor for n2o (manure management) layer chickens"
-    - Asses:
-      - "Implied emission factor for N2O (Manure management) Asses"
-    - Cattle, dairy:
-      - "implied emission factor for n2o (manure management) dairy cattle"
-    - Cattle, non-dairy:
-      - "implied emission factor for n2o (manure management) non-dairy cattle"
-  - Implied emission factor for N2O (Manure on pasture):
-    - Chickens, broilers:
-      - "implied emission factor for n2o (manure on pasture) broiler chickens"
-    - Goats:
-      - "Implied emission factor for N2O (Manure on pasture) Goats"
-    - Sheep:
-      - "Implied emission factor for N2O (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "implied emission factor for n2o (manure on pasture) layer chickens"
-    - Asses:
-      - "Implied emission factor for N2O (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "implied emission factor for n2o (manure on pasture) dairy cattle"
-    - Cattle, non-dairy:
-      - "implied emission factor for n2o (manure on pasture) non-dairy cattle"
-  - Import Quantity:
-    - Paper and paperboard:
-      - "Import Quantity Paper and paperboard"
-    - Graphic papers:
-      - "Import Quantity Graphic papers"
-    - Plywood:
-      - "Import Quantity Plywood"
-    - Other paper and paperboard n.e.s. (not elsewhere specified):
-      - "Import Quantity Other paper and paperboard n.e.s. (not elsewhere specified)"
-    - Printing and writing papers, uncoated, wood free:
-      - "Import Quantity Printing and writing papers, uncoated, wood free"
-    - Printing and writing papers, coated:
-      - "Import Quantity Printing and writing papers, coated"
-    - Other paper and paperboard:
-      - "Import Quantity Other paper and paperboard"
-    - Sawnwood:
-      - "Import Quantity Sawnwood"
-    - Household and sanitary papers:
-      - "Import Quantity Household and sanitary papers"
-    - Wood-based panels:
-      - "Import Quantity Wood-based panels"
-    - Fibreboard:
-      - "Import Quantity Fibreboard"
-    - Sawnwood, coniferous:
-      - "import quantity coniferou sawnwood"
-    - Printing and writing papers, uncoated, mechanical:
-      - "Import Quantity Printing and writing papers, uncoated, mechanical"
-    - Paper and paperboard, excluding newsprint:
-      - "Import Quantity Paper and paperboard, excluding newsprint"
-    - MDF/HDF:
-      - "Import Quantity MDF/HDF"
-    - Printing and writing papers:
-      - "Import Quantity Printing and writing papers"
-  - Import Value:
-    - Paper and paperboard:
-      - "Import Value Paper and paperboard"
-    - Graphic papers:
-      - "Import Value Graphic papers"
-    - Plywood:
-      - "Import Value Plywood"
-    - Other paper and paperboard n.e.s. (not elsewhere specified):
-      - "Import Value Other paper and paperboard n.e.s. (not elsewhere specified)"
-    - Printing and writing papers, uncoated, wood free:
-      - "Import Value Printing and writing papers, uncoated, wood free"
-    - Printing and writing papers, coated:
-      - "Import Value Printing and writing papers, coated"
-    - Other paper and paperboard:
-      - "Import Value Other paper and paperboard"
-    - Sawnwood:
-      - "Import Value Sawnwood"
-    - Household and sanitary papers:
-      - "Import Value Household and sanitary papers"
-    - Wood-based panels:
-      - "Import Value Wood-based panels"
-    - Fibreboard:
-      - "Import Value Fibreboard"
-    - Sawnwood, coniferous:
-      - "import value coniferou sawnwood"
-    - Printing and writing papers, uncoated, mechanical:
-      - "Import Value Printing and writing papers, uncoated, mechanical"
-    - Paper and paperboard, excluding newsprint:
-      - "Import Value Paper and paperboard, excluding newsprint"
-    - MDF/HDF:
-      - "Import Value MDF/HDF"
-    - Forest products (export/import):
-      - "Import Value Forest products (export/import)"
-    - Printing and writing papers:
-      - "Import Value Printing and writing papers"
-  - Indirect emissions (CO2eq) (Crop residues):
-    - Beans, dry:
-      - "indirect emissions (co2eq) (crop residues) dry beans"
-    - Sorghum:
-      - "Indirect emissions (CO2eq) (Crop residues) Sorghum"
-    - Millet:
-      - "Indirect emissions (CO2eq) (Crop residues) Millet"
-    - Maize:
-      - "Indirect emissions (CO2eq) (Crop residues) Maize"
-    - All Crops:
-      - "Indirect emissions (CO2eq) (Crop residues) All Crops"
-  - Indirect emissions (CO2eq) (Manure applied):
-    - Chickens, broilers:
-      - "indirect emissions (co2eq) (manure applied) broiler chickens"
-    - Cattle:
-      - "Indirect emissions (CO2eq) (Manure applied) Cattle"
-    - Goats:
-      - "Indirect emissions (CO2eq) (Manure applied) Goats"
-    - Poultry Birds:
-      - "Indirect emissions (CO2eq) (Manure applied) Poultry Birds"
-    - Sheep:
-      - "Indirect emissions (CO2eq) (Manure applied) Sheep"
-    - Chickens, layers:
-      - "indirect emissions (co2eq) (manure applied) layer chickens"
-    - Mules and Asses:
-      - "Indirect emissions (CO2eq) (Manure applied) Mules and Asses"
-    - All Animals:
-      - "Indirect emissions (CO2eq) (Manure applied) All Animals"
-    - Asses:
-      - "Indirect emissions (CO2eq) (Manure applied) Asses"
-    - Cattle, dairy:
-      - "indirect emissions (co2eq) (manure applied) dairy cattle"
-    - Chickens:
-      - "Indirect emissions (CO2eq) (Manure applied) Chickens"
-    - Cattle, non-dairy:
-      - "indirect emissions (co2eq) (manure applied) non-dairy cattle"
-    - Sheep and Goats:
-      - "Indirect emissions (CO2eq) (Manure applied) Sheep and Goats"
-  - Indirect emissions (CO2eq) (Manure management):
-    - Chickens, broilers:
-      - "indirect emissions (co2eq) (manure management) broiler chickens"
-    - Cattle:
-      - "Indirect emissions (CO2eq) (Manure management) Cattle"
-    - Goats:
-      - "Indirect emissions (CO2eq) (Manure management) Goats"
-    - Poultry Birds:
-      - "Indirect emissions (CO2eq) (Manure management) Poultry Birds"
-    - Sheep:
-      - "Indirect emissions (CO2eq) (Manure management) Sheep"
-    - Chickens, layers:
-      - "indirect emissions (co2eq) (manure management) layer chickens"
-    - Mules and Asses:
-      - "Indirect emissions (CO2eq) (Manure management) Mules and Asses"
-    - All Animals:
-      - "Indirect emissions (CO2eq) (Manure management) All Animals"
-    - Asses:
-      - "Indirect emissions (CO2eq) (Manure management) Asses"
-    - Cattle, dairy:
-      - "indirect emissions (co2eq) (manure management) dairy cattle"
-    - Chickens:
-      - "Indirect emissions (CO2eq) (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "indirect emissions (co2eq) (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Indirect emissions (CO2eq) (Manure management) Sheep and Goats"
-  - Indirect emissions (CO2eq) (Manure on pasture):
-    - Chickens, broilers:
-      - "indirect emissions (co2eq) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Indirect emissions (CO2eq) (Manure on pasture) Cattle"
-    - Goats:
-      - "Indirect emissions (CO2eq) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Indirect emissions (CO2eq) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Indirect emissions (CO2eq) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "indirect emissions (co2eq) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Indirect emissions (CO2eq) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Indirect emissions (CO2eq) (Manure on pasture) All Animals"
-    - Asses:
-      - "Indirect emissions (CO2eq) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "indirect emissions (co2eq) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Indirect emissions (CO2eq) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "indirect emissions (co2eq) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Indirect emissions (CO2eq) (Manure on pasture) Sheep and Goats"
-  - Indirect emissions (N2O that leaches) (Manure on pasture):
-    - Chickens, broilers:
-      - "indirect emissions (n2o that leaches) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) Cattle"
-    - Goats:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "indirect emissions (n2o that leaches) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) All Animals"
-    - Asses:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "indirect emissions (n2o that leaches) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "indirect emissions (n2o that leaches) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Indirect emissions (N2O that leaches) (Manure on pasture) Sheep and Goats"
-  - Indirect emissions (N2O that volatilises) (Manure on pasture):
-    - Chickens, broilers:
-      - "indirect emissions (n2o that volatilises) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) Cattle"
-    - Goats:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "indirect emissions (n2o that volatilises) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) All Animals"
-    - Asses:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "indirect emissions (n2o that volatilises) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "indirect emissions (n2o that volatilises) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Indirect emissions (N2O that volatilises) (Manure on pasture) Sheep and Goats"
-  - Indirect emissions (N2O) (Crop residues):
-    - Beans, dry:
-      - "indirect emissions (n2o) (crop residues) dry beans"
-    - Sorghum:
-      - "Indirect emissions (N2O) (Crop residues) Sorghum"
-    - Millet:
-      - "Indirect emissions (N2O) (Crop residues) Millet"
-    - Maize:
-      - "Indirect emissions (N2O) (Crop residues) Maize"
-    - All Crops:
-      - "Indirect emissions (N2O) (Crop residues) All Crops"
-  - Indirect emissions (N2O) (Manure applied):
-    - Chickens, broilers:
-      - "indirect emissions (n2o) (manure applied) broiler chickens"
-    - Cattle:
-      - "Indirect emissions (N2O) (Manure applied) Cattle"
-    - Goats:
-      - "Indirect emissions (N2O) (Manure applied) Goats"
-    - Poultry Birds:
-      - "Indirect emissions (N2O) (Manure applied) Poultry Birds"
-    - Sheep:
-      - "Indirect emissions (N2O) (Manure applied) Sheep"
-    - Chickens, layers:
-      - "indirect emissions (n2o) (manure applied) layer chickens"
-    - Mules and Asses:
-      - "Indirect emissions (N2O) (Manure applied) Mules and Asses"
-    - All Animals:
-      - "Indirect emissions (N2O) (Manure applied) All Animals"
-    - Asses:
-      - "Indirect emissions (N2O) (Manure applied) Asses"
-    - Cattle, dairy:
-      - "indirect emissions (n2o) (manure applied) dairy cattle"
-    - Chickens:
-      - "Indirect emissions (N2O) (Manure applied) Chickens"
-    - Cattle, non-dairy:
-      - "indirect emissions (n2o) (manure applied) non-dairy cattle"
-    - Sheep and Goats:
-      - "Indirect emissions (N2O) (Manure applied) Sheep and Goats"
-  - Indirect emissions (N2O) (Manure management):
-    - Chickens, broilers:
-      - "indirect emissions (n2o) (manure management) broiler chickens"
-    - Cattle:
-      - "Indirect emissions (N2O) (Manure management) Cattle"
-    - Goats:
-      - "Indirect emissions (N2O) (Manure management) Goats"
-    - Poultry Birds:
-      - "Indirect emissions (N2O) (Manure management) Poultry Birds"
-    - Sheep:
-      - "Indirect emissions (N2O) (Manure management) Sheep"
-    - Chickens, layers:
-      - "indirect emissions (n2o) (manure management) layer chickens"
-    - Mules and Asses:
-      - "Indirect emissions (N2O) (Manure management) Mules and Asses"
-    - All Animals:
-      - "Indirect emissions (N2O) (Manure management) All Animals"
-    - Asses:
-      - "Indirect emissions (N2O) (Manure management) Asses"
-    - Cattle, dairy:
-      - "indirect emissions (n2o) (manure management) dairy cattle"
-    - Chickens:
-      - "Indirect emissions (N2O) (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "indirect emissions (n2o) (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Indirect emissions (N2O) (Manure management) Sheep and Goats"
-  - Indirect emissions (N2O) (Manure on pasture):
-    - Chickens, broilers:
-      - "indirect emissions (n2o) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Indirect emissions (N2O) (Manure on pasture) Cattle"
-    - Goats:
-      - "Indirect emissions (N2O) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Indirect emissions (N2O) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Indirect emissions (N2O) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "indirect emissions (n2o) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Indirect emissions (N2O) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Indirect emissions (N2O) (Manure on pasture) All Animals"
-    - Asses:
-      - "Indirect emissions (N2O) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "indirect emissions (n2o) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Indirect emissions (N2O) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "indirect emissions (n2o) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Indirect emissions (N2O) (Manure on pasture) Sheep and Goats"
-  - Laying:
-    - Eggs, hen, in shell:
-      - "Laying Eggs, hen, in shell"
-    - Eggs Primary:
-      - "Laying Eggs Primary"
-  - Losses from manure treated (N content):
-    - Chickens, broilers:
-      - "losses from manure treated (n content) broiler chickens"
-    - Cattle:
-      - "Losses from manure treated (N content) Cattle"
-    - Goats:
-      - "Losses from manure treated (N content) Goats"
-    - Poultry Birds:
-      - "Losses from manure treated (N content) Poultry Birds"
-    - Sheep:
-      - "Losses from manure treated (N content) Sheep"
-    - Chickens, layers:
-      - "losses from manure treated (n content) layer chickens"
-    - Mules and Asses:
-      - "Losses from manure treated (N content) Mules and Asses"
-    - All Animals:
-      - "Losses from manure treated (N content) All Animals"
-    - Asses:
-      - "Losses from manure treated (N content) Asses"
-    - Cattle, dairy:
-      - "losses from manure treated (n content) dairy cattle"
-    - Chickens:
-      - "Losses from manure treated (N content) Chickens"
-    - Cattle, non-dairy:
-      - "losses from manure treated (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Losses from manure treated (N content) Sheep and Goats"
-  - Manure (N content that leaches) (Manure on pasture):
-    - Chickens, broilers:
-      - "manure (n content that leaches) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Manure (N content that leaches) (Manure on pasture) Cattle"
-    - Goats:
-      - "Manure (N content that leaches) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Manure (N content that leaches) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Manure (N content that leaches) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "manure (n content that leaches) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Manure (N content that leaches) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Manure (N content that leaches) (Manure on pasture) All Animals"
-    - Asses:
-      - "Manure (N content that leaches) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "manure (n content that leaches) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Manure (N content that leaches) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "manure (n content that leaches) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure (N content that leaches) (Manure on pasture) Sheep and Goats"
-  - Manure (N content that volatilises) (Manure on pasture):
-    - Chickens, broilers:
-      - "manure (n content that volatilises) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Manure (N content that volatilises) (Manure on pasture) Cattle"
-    - Goats:
-      - "Manure (N content that volatilises) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Manure (N content that volatilises) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Manure (N content that volatilises) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "manure (n content that volatilises) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Manure (N content that volatilises) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Manure (N content that volatilises) (Manure on pasture) All Animals"
-    - Asses:
-      - "Manure (N content that volatilises) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "manure (n content that volatilises) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Manure (N content that volatilises) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "manure (n content that volatilises) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure (N content that volatilises) (Manure on pasture) Sheep and Goats"
-  - Manure (N content) (Manure applied):
-    - Chickens, broilers:
-      - "manure (n content) (manure applied) broiler chickens"
-    - Cattle:
-      - "Manure (N content) (Manure applied) Cattle"
-    - Goats:
-      - "Manure (N content) (Manure applied) Goats"
-    - Poultry Birds:
-      - "Manure (N content) (Manure applied) Poultry Birds"
-    - Sheep:
-      - "Manure (N content) (Manure applied) Sheep"
-    - Chickens, layers:
-      - "manure (n content) (manure applied) layer chickens"
-    - Mules and Asses:
-      - "Manure (N content) (Manure applied) Mules and Asses"
-    - All Animals:
-      - "Manure (N content) (Manure applied) All Animals"
-    - Asses:
-      - "Manure (N content) (Manure applied) Asses"
-    - Cattle, dairy:
-      - "manure (n content) (manure applied) dairy cattle"
-    - Chickens:
-      - "Manure (N content) (Manure applied) Chickens"
-    - Cattle, non-dairy:
-      - "manure (n content) (manure applied) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure (N content) (Manure applied) Sheep and Goats"
-  - Manure (N content) (Manure management):
-    - Chickens, broilers:
-      - "manure (n content) (manure management) broiler chickens"
-    - Cattle:
-      - "Manure (N content) (Manure management) Cattle"
-    - Goats:
-      - "Manure (N content) (Manure management) Goats"
-    - Poultry Birds:
-      - "Manure (N content) (Manure management) Poultry Birds"
-    - Sheep:
-      - "Manure (N content) (Manure management) Sheep"
-    - Chickens, layers:
-      - "manure (n content) (manure management) layer chickens"
-    - Mules and Asses:
-      - "Manure (N content) (Manure management) Mules and Asses"
-    - All Animals:
-      - "Manure (N content) (Manure management) All Animals"
-    - Asses:
-      - "Manure (N content) (Manure management) Asses"
-    - Cattle, dairy:
-      - "manure (n content) (manure management) dairy cattle"
-    - Chickens:
-      - "Manure (N content) (Manure management) Chickens"
-    - Cattle, non-dairy:
-      - "manure (n content) (manure management) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure (N content) (Manure management) Sheep and Goats"
-  - Manure (N content) (Manure on pasture):
-    - Chickens, broilers:
-      - "manure (n content) (manure on pasture) broiler chickens"
-    - Cattle:
-      - "Manure (N content) (Manure on pasture) Cattle"
-    - Goats:
-      - "Manure (N content) (Manure on pasture) Goats"
-    - Poultry Birds:
-      - "Manure (N content) (Manure on pasture) Poultry Birds"
-    - Sheep:
-      - "Manure (N content) (Manure on pasture) Sheep"
-    - Chickens, layers:
-      - "manure (n content) (manure on pasture) layer chickens"
-    - Mules and Asses:
-      - "Manure (N content) (Manure on pasture) Mules and Asses"
-    - All Animals:
-      - "Manure (N content) (Manure on pasture) All Animals"
-    - Asses:
-      - "Manure (N content) (Manure on pasture) Asses"
-    - Cattle, dairy:
-      - "manure (n content) (manure on pasture) dairy cattle"
-    - Chickens:
-      - "Manure (N content) (Manure on pasture) Chickens"
-    - Cattle, non-dairy:
-      - "manure (n content) (manure on pasture) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure (N content) (Manure on pasture) Sheep and Goats"
-  - Manure applied to soils (N content):
-    - Chickens, broilers:
-      - "manure applied to soils (n content) broiler chickens"
-    - Cattle:
-      - "Manure applied to soils (N content) Cattle"
-    - Goats:
-      - "Manure applied to soils (N content) Goats"
-    - Poultry Birds:
-      - "Manure applied to soils (N content) Poultry Birds"
-    - Sheep:
-      - "Manure applied to soils (N content) Sheep"
-    - Chickens, layers:
-      - "manure applied to soils (n content) layer chickens"
-    - Mules and Asses:
-      - "Manure applied to soils (N content) Mules and Asses"
-    - All Animals:
-      - "Manure applied to soils (N content) All Animals"
-    - Asses:
-      - "Manure applied to soils (N content) Asses"
-    - Cattle, dairy:
-      - "manure applied to soils (n content) dairy cattle"
-    - Chickens:
-      - "Manure applied to soils (N content) Chickens"
-    - Cattle, non-dairy:
-      - "manure applied to soils (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure applied to soils (N content) Sheep and Goats"
-  - Manure applied to soils that leaches (N content):
-    - Chickens, broilers:
-      - "manure applied to soils that leaches (n content) broiler chickens"
-    - Cattle:
-      - "Manure applied to soils that leaches (N content) Cattle"
-    - Goats:
-      - "Manure applied to soils that leaches (N content) Goats"
-    - Poultry Birds:
-      - "Manure applied to soils that leaches (N content) Poultry Birds"
-    - Sheep:
-      - "Manure applied to soils that leaches (N content) Sheep"
-    - Chickens, layers:
-      - "manure applied to soils that leaches (n content) layer chickens"
-    - Mules and Asses:
-      - "Manure applied to soils that leaches (N content) Mules and Asses"
-    - All Animals:
-      - "Manure applied to soils that leaches (N content) All Animals"
-    - Asses:
-      - "Manure applied to soils that leaches (N content) Asses"
-    - Cattle, dairy:
-      - "manure applied to soils that leaches (n content) dairy cattle"
-    - Chickens:
-      - "Manure applied to soils that leaches (N content) Chickens"
-    - Cattle, non-dairy:
-      - "manure applied to soils that leaches (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure applied to soils that leaches (N content) Sheep and Goats"
-  - Manure applied to soils that volatilises (N content):
-    - Chickens, broilers:
-      - "manure applied to soils that volatilises (n content) broiler chickens"
-    - Cattle:
-      - "Manure applied to soils that volatilises (N content) Cattle"
-    - Goats:
-      - "Manure applied to soils that volatilises (N content) Goats"
-    - Poultry Birds:
-      - "Manure applied to soils that volatilises (N content) Poultry Birds"
-    - Sheep:
-      - "Manure applied to soils that volatilises (N content) Sheep"
-    - Chickens, layers:
-      - "manure applied to soils that volatilises (n content) layer chickens"
-    - Mules and Asses:
-      - "Manure applied to soils that volatilises (N content) Mules and Asses"
-    - All Animals:
-      - "Manure applied to soils that volatilises (N content) All Animals"
-    - Asses:
-      - "Manure applied to soils that volatilises (N content) Asses"
-    - Cattle, dairy:
-      - "manure applied to soils that volatilises (n content) dairy cattle"
-    - Chickens:
-      - "Manure applied to soils that volatilises (N content) Chickens"
-    - Cattle, non-dairy:
-      - "manure applied to soils that volatilises (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure applied to soils that volatilises (N content) Sheep and Goats"
-  - Manure left on pasture (N content):
-    - Chickens, broilers:
-      - "manure left on pasture (n content) broiler chickens"
-    - Cattle:
-      - "Manure left on pasture (N content) Cattle"
-    - Goats:
-      - "Manure left on pasture (N content) Goats"
-    - Poultry Birds:
-      - "Manure left on pasture (N content) Poultry Birds"
-    - Sheep:
-      - "Manure left on pasture (N content) Sheep"
-    - Chickens, layers:
-      - "manure left on pasture (n content) layer chickens"
-    - Mules and Asses:
-      - "Manure left on pasture (N content) Mules and Asses"
-    - All Animals:
-      - "Manure left on pasture (N content) All Animals"
-    - Asses:
-      - "Manure left on pasture (N content) Asses"
-    - Cattle, dairy:
-      - "manure left on pasture (n content) dairy cattle"
-    - Chickens:
-      - "Manure left on pasture (N content) Chickens"
-    - Cattle, non-dairy:
-      - "manure left on pasture (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure left on pasture (N content) Sheep and Goats"
-  - Manure left on pasture that leaches (N content):
-    - Chickens, broilers:
-      - "manure left on pasture that leaches (n content) broiler chickens"
-    - Cattle:
-      - "Manure left on pasture that leaches (N content) Cattle"
-    - Goats:
-      - "Manure left on pasture that leaches (N content) Goats"
-    - Poultry Birds:
-      - "Manure left on pasture that leaches (N content) Poultry Birds"
-    - Sheep:
-      - "Manure left on pasture that leaches (N content) Sheep"
-    - Chickens, layers:
-      - "manure left on pasture that leaches (n content) layer chickens"
-    - Mules and Asses:
-      - "Manure left on pasture that leaches (N content) Mules and Asses"
-    - All Animals:
-      - "Manure left on pasture that leaches (N content) All Animals"
-    - Asses:
-      - "Manure left on pasture that leaches (N content) Asses"
-    - Cattle, dairy:
-      - "manure left on pasture that leaches (n content) dairy cattle"
-    - Chickens:
-      - "Manure left on pasture that leaches (N content) Chickens"
-    - Cattle, non-dairy:
-      - "manure left on pasture that leaches (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure left on pasture that leaches (N content) Sheep and Goats"
-  - Manure left on pasture that volatilises (N content):
-    - Chickens, broilers:
-      - "manure left on pasture that volatilises (n content) broiler chickens"
-    - Cattle:
-      - "Manure left on pasture that volatilises (N content) Cattle"
-    - Goats:
-      - "Manure left on pasture that volatilises (N content) Goats"
-    - Poultry Birds:
-      - "Manure left on pasture that volatilises (N content) Poultry Birds"
-    - Sheep:
-      - "Manure left on pasture that volatilises (N content) Sheep"
-    - Chickens, layers:
-      - "manure left on pasture that volatilises (n content) layer chickens"
-    - Mules and Asses:
-      - "Manure left on pasture that volatilises (N content) Mules and Asses"
-    - All Animals:
-      - "Manure left on pasture that volatilises (N content) All Animals"
-    - Asses:
-      - "Manure left on pasture that volatilises (N content) Asses"
-    - Cattle, dairy:
-      - "manure left on pasture that volatilises (n content) dairy cattle"
-    - Chickens:
-      - "Manure left on pasture that volatilises (N content) Chickens"
-    - Cattle, non-dairy:
-      - "manure left on pasture that volatilises (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure left on pasture that volatilises (N content) Sheep and Goats"
-  - Manure treated (N content):
-    - Chickens, broilers:
-      - "manure treated (n content) broiler chickens"
-    - Cattle:
-      - "Manure treated (N content) Cattle"
-    - Goats:
-      - "Manure treated (N content) Goats"
-    - Poultry Birds:
-      - "Manure treated (N content) Poultry Birds"
-    - Sheep:
-      - "Manure treated (N content) Sheep"
-    - Chickens, layers:
-      - "manure treated (n content) layer chickens"
-    - Mules and Asses:
-      - "Manure treated (N content) Mules and Asses"
-    - All Animals:
-      - "Manure treated (N content) All Animals"
-    - Asses:
-      - "Manure treated (N content) Asses"
-    - Cattle, dairy:
-      - "manure treated (n content) dairy cattle"
-    - Chickens:
-      - "Manure treated (N content) Chickens"
-    - Cattle, non-dairy:
-      - "manure treated (n content) non-dairy cattle"
-    - Sheep and Goats:
-      - "Manure treated (N content) Sheep and Goats"
-  - Milk Animals:
-    - Milk, whole fresh camel:
-      - "Milk Animals Milk, whole fresh camel"
-    - Milk, whole fresh goat:
-      - "Milk Animals Milk, whole fresh goat"
-    - Milk,Total:
-      - "Milk Animals Milk,Total"
-    - Milk, whole fresh sheep:
-      - "Milk Animals Milk, whole fresh sheep"
-    - Milk, whole fresh cow:
-      - "Milk Animals Milk, whole fresh cow"
-  - Net Production Value (constant 2004-2006 1000 I$):
-    - Pineapples:
-      - "Net Production Value (constant 2004-2006 1000 I$) Pineapples"
-    - Tangerines, mandarins, clementines, satsumas:
-      - "Net Production Value (constant 2004-2006 1000 I$) Tangerines, mandarins,\
-        \ clementines, satsumas"
-    - Pulses, nes:
-      - "net production value (constant 2004-2006 1000 i$) ne pulses"
-    - Oilcrops Primary:
-      - "Net Production Value (constant 2004-2006 1000 I$) Oilcrops Primary"
-    - Cereals,Total:
-      - "Net Production Value (constant 2004-2006 1000 I$) Cereals,Total"
-    - Livestock (PIN):
-      - "Net Production Value (constant 2004-2006 1000 I$) Livestock (PIN)"
-    - Fruit, fresh nes:
-      - "Net Production Value (constant 2004-2006 1000 I$) Fruit, fresh nes"
-    - Meat, game:
-      - "net production value (constant 2004-2006 1000 i$) game meat"
-    - Onions, shallots, green:
-      - "Net Production Value (constant 2004-2006 1000 I$) Onions, shallots, green"
-    - Maize:
-      - "Net Production Value (constant 2004-2006 1000 I$) Maize"
-    - Food (PIN):
-      - "Net Production Value (constant 2004-2006 1000 I$) Food (PIN)"
-    - Honey, natural:
-      - "net production value (constant 2004-2006 1000 i$) natural honey"
-    - Meat indigenous, total:
-      - "Net Production Value (constant 2004-2006 1000 I$) Meat indigenous, total"
-    - Melonseed:
-      - "Net Production Value (constant 2004-2006 1000 I$) Melonseed"
-    - Milk,Total:
-      - "Net Production Value (constant 2004-2006 1000 I$) Milk,Total"
-    - Sesame seed:
-      - "Net Production Value (constant 2004-2006 1000 I$) Sesame seed"
-    - Beeswax:
-      - "Net Production Value (constant 2004-2006 1000 I$) Beeswax"
-    - Oilseeds nes:
-      - "Net Production Value (constant 2004-2006 1000 I$) Oilseeds nes"
-    - Melons, other (inc.cantaloupes):
-      - "Net Production Value (constant 2004-2006 1000 I$) Melons, other (inc.cantaloupes)"
-    - Beans, green:
-      - "net production value (constant 2004-2006 1000 i$) green beans"
-    - Non Food (PIN):
-      - "Net Production Value (constant 2004-2006 1000 I$) Non Food (PIN)"
-    - Pumpkins, squash and gourds:
-      - "Net Production Value (constant 2004-2006 1000 I$) Pumpkins, squash and gourds"
-    - Milk, whole fresh cow:
-      - "Net Production Value (constant 2004-2006 1000 I$) Milk, whole fresh cow"
-    - Peas, green:
-      - "net production value (constant 2004-2006 1000 i$) green peas"
-    - Crops (PIN):
-      - "Net Production Value (constant 2004-2006 1000 I$) Crops (PIN)"
-    - Milk, whole fresh goat:
-      - "Net Production Value (constant 2004-2006 1000 I$) Milk, whole fresh goat"
-    - Agriculture (PIN):
-      - "Net Production Value (constant 2004-2006 1000 I$) Agriculture (PIN)"
-    - Vegetables and Fruit Primary:
-      - "Net Production Value (constant 2004-2006 1000 I$) Vegetables and Fruit Primary"
-    - Roots and Tubers,Total:
-      - "Net Production Value (constant 2004-2006 1000 I$) Roots and Tubers,Total"
-    - Sunflower seed:
-      - "Net Production Value (constant 2004-2006 1000 I$) Sunflower seed"
-    - Jute:
-      - "Net Production Value (constant 2004-2006 1000 I$) Jute"
-    - Millet:
-      - "Net Production Value (constant 2004-2006 1000 I$) Millet"
-    - Cottonseed:
-      - "Net Production Value (constant 2004-2006 1000 I$) Cottonseed"
-    - Chillies and peppers, dry:
-      - "Net Production Value (constant 2004-2006 1000 I$) Chillies and peppers, dry"
-    - Fruit, tropical fresh nes:
-      - "Net Production Value (constant 2004-2006 1000 I$) Fruit, tropical fresh nes"
-    - Groundnuts, with shell:
-      - "Net Production Value (constant 2004-2006 1000 I$) Groundnuts, with shell"
-    - Yams:
-      - "Net Production Value (constant 2004-2006 1000 I$) Yams"
-    - Cotton lint:
-      - "Net Production Value (constant 2004-2006 1000 I$) Cotton lint"
-    - Beans, dry:
-      - "net production value (constant 2004-2006 1000 i$) dry beans"
-    - Cassava:
-      - "Net Production Value (constant 2004-2006 1000 I$) Cassava"
-    - Sorghum:
-      - "Net Production Value (constant 2004-2006 1000 I$) Sorghum"
-    - Milk, whole fresh sheep:
-      - "Net Production Value (constant 2004-2006 1000 I$) Milk, whole fresh sheep"
-    - Vegetables, fresh nes:
-      - "Net Production Value (constant 2004-2006 1000 I$) Vegetables, fresh nes"
-  - Producing Animals/Slaughtered:
-    - Skins, sheep, with wool:
-      - "Producing Animals/Slaughtered Skins, sheep, with wool"
-    - Skins, goat, fresh:
-      - "Producing Animals/Slaughtered Skins, goat, fresh"
-    - Meat, chicken:
-      - "producing animals/slaughtered chicken meat"
-    - Sheep and Goat Meat:
-      - "Producing Animals/Slaughtered Sheep and Goat Meat"
-    - Meat, Poultry:
-      - "producing animals/slaughtered poultry meat"
-    - Hides, cattle, fresh:
-      - "Producing Animals/Slaughtered Hides, cattle, fresh"
-    - Beef and Buffalo Meat:
-      - "Producing Animals/Slaughtered Beef and Buffalo Meat"
-    - Meat, camel:
-      - "producing animals/slaughtered camel meat"
-    - Meat, cattle:
-      - "producing animals/slaughtered cattle meat"
-    - Meat, sheep:
-      - "producing animals/slaughtered sheep meat"
-    - Skins, sheep, fresh:
-      - "Producing Animals/Slaughtered Skins, sheep, fresh"
-    - Meat, goat:
-      - "producing animals/slaughtered goat meat"
-  - Production:
-    - Vegetables Primary:
-      - "Production Vegetables Primary"
-    - Wool, greasy:
-      - "production greasy wool"
-    - Meat, chicken:
-      - "production chicken meat"
-    - Oilcrops, Oil Equivalent:
-      - "Production Oilcrops, Oil Equivalent"
-    - Meat, game:
-      - "production game meat"
-    - Onions, shallots, green:
-      - "Production Onions, shallots, green"
-    - Maize:
-      - "Production Maize"
-    - Carrots and turnips:
-      - "Production Carrots and turnips"
-    - Wood fuel, non-coniferous (production):
-      - "Production Wood fuel, non-coniferous (production)"
-    - Coarse Grain, Total:
-      - "Production Coarse Grain, Total"
-    - Meat indigenous, goat:
-      - "Production Meat indigenous, goat"
-    - Cheese, sheep milk:
-      - "Production Cheese, sheep milk"
-    - Milk, whole fresh cow:
-      - "Production Milk, whole fresh cow"
-    - Cow peas, dry:
-      - "Production Cow peas, dry"
-    - Hides, cattle, fresh:
-      - "Production Hides, cattle, fresh"
-    - Beer of barley:
-      - "Production Beer of barley"
-    - Cheese of goat mlk:
-      - "Production Cheese of goat mlk"
-    - Millet:
-      - "Production Millet"
-    - Milk, skimmed cow:
-      - "Production Milk, skimmed cow"
-    - Meat, goat:
-      - "production goat meat"
-    - Roundwood, coniferous (production):
-      - "Production Roundwood, coniferous (production)"
-    - Eggplants (aubergines):
-      - "Production Eggplants (aubergines)"
-    - Meat indigenous, chicken:
-      - "Production Meat indigenous, chicken"
-    - Oil, cottonseed:
-      - "production cottonseed oil"
-    - Sorghum:
-      - "Production Sorghum"
-    - Chillies and peppers, green:
-      - "Production Chillies and peppers, green"
-    - Sheep and Goat Meat:
-      - "Production Sheep and Goat Meat"
-    - Garlic:
-      - "Production Garlic"
-    - Meat indigenous, poultry:
-      - "Production Meat indigenous, poultry"
-    - Mangoes, mangosteens, guavas:
-      - "Production Mangoes, mangosteens, guavas"
-    - Pineapples:
-      - "Production Pineapples"
-    - Cabbages and other brassicas:
-      - "Production Cabbages and other brassicas"
-    - Okra:
-      - "Production Okra"
-    - Meat, camel:
-      - "production camel meat"
-    - Meat, cattle:
-      - "production cattle meat"
-    - Citrus Fruit,Total:
-      - "production total citrus fruit"
-    - Roundwood, non-coniferous (production):
-      - "Production Roundwood, non-coniferous (production)"
-    - Cauliflowers and broccoli:
-      - "Production Cauliflowers and broccoli"
-    - Onions, dry:
-      - "production dry onions"
-    - Honey, natural:
-      - "production natural honey"
-    - Oil, sesame:
-      - "production sesame oil"
-    - Meat indigenous, total:
-      - "Production Meat indigenous, total"
-    - Melonseed:
-      - "Production Melonseed"
-    - Oilseeds nes:
-      - "Production Oilseeds nes"
-    - Meat indigenous, camel:
-      - "Production Meat indigenous, camel"
-    - Roundwood:
-      - "Production Roundwood"
-    - Peas, green:
-      - "production green peas"
-    - Sweet potatoes:
-      - "Production Sweet potatoes"
-    - Milk, whole fresh camel:
-      - "Production Milk, whole fresh camel"
-    - Sugar Raw Centrifugal:
-      - "Production Sugar Raw Centrifugal"
-    - Meat, sheep:
-      - "production sheep meat"
-    - Cereals excluding rice:
-      - "Production Cereals excluding rice"
-    - Fibre Crops Primary:
-      - "Production Fibre Crops Primary"
-    - Fruit, tropical fresh nes:
-      - "Production Fruit, tropical fresh nes"
-    - Groundnuts, with shell:
-      - "Production Groundnuts, with shell"
-    - Wood fuel, coniferous (production):
-      - "Production Wood fuel, coniferous (production)"
-    - Pulses,Total:
-      - "Production Pulses,Total"
-    - Vegetables, fresh nes:
-      - "Production Vegetables, fresh nes"
-    - Meat, Total:
-      - "production total meat"
-    - Tangerines, mandarins, clementines, satsumas:
-      - "Production Tangerines, mandarins, clementines, satsumas"
-    - Pulses, nes:
-      - "production ne pulses"
-    - Fruit, fresh nes:
-      - "Production Fruit, fresh nes"
-    - Sugar cane:
-      - "Production Sugar cane"
-    - Eggs Primary:
-      - "Production Eggs Primary"
-    - Tomatoes:
-      - "Production Tomatoes"
-    - Skins, sheep, with wool:
-      - "Production Skins, sheep, with wool"
-    - Butter and Ghee:
-      - "Production Butter and Ghee"
-    - Broad beans, horse beans, dry:
-      - "Production Broad beans, horse beans, dry"
-    - Plantains and others:
-      - "Production Plantains and others"
-    - Milk,Total:
-      - "Production Milk,Total"
-    - Meat, Poultry:
-      - "production poultry meat"
-    - Beeswax:
-      - "Production Beeswax"
-    - Beans, green:
-      - "production green beans"
-    - Seed cotton:
-      - "Production Seed cotton"
-    - Beef and Buffalo Meat:
-      - "Production Beef and Buffalo Meat"
-    - Roots and Tubers,Total:
-      - "Production Roots and Tubers,Total"
-    - Sunflower seed:
-      - "Production Sunflower seed"
-    - Dates:
-      - "Production Dates"
-    - Jute:
-      - "Production Jute"
-    - Butter, cow milk:
-      - "Production Butter, cow milk"
-    - Cottonseed:
-      - "Production Cottonseed"
-    - Meat indigenous, sheep:
-      - "Production Meat indigenous, sheep"
-    - Yams:
-      - "Production Yams"
-    - Milk, whole fresh sheep:
-      - "Production Milk, whole fresh sheep"
-    - Oranges:
-      - "Production Oranges"
-    - Rice, paddy:
-      - "production paddy rice"
-    - Cereals,Total:
-      - "Production Cereals,Total"
-    - Cheese, whole cow milk:
-      - "Production Cheese, whole cow milk"
-    - Skins, sheep, fresh:
-      - "Production Skins, sheep, fresh"
-    - Watermelons:
-      - "Production Watermelons"
-    - Bananas:
-      - "Production Bananas"
-    - Skins, goat, fresh:
-      - "Production Skins, goat, fresh"
-    - Sesame seed:
-      - "Production Sesame seed"
-    - Cheese (All Kinds):
-      - "Production Cheese (All Kinds)"
-    - Molasses:
-      - "Production Molasses"
-    - Wood charcoal:
-      - "Production Wood charcoal"
-    - Melons, other (inc.cantaloupes):
-      - "Production Melons, other (inc.cantaloupes)"
-    - Wood fuel:
-      - "Production Wood fuel"
-    - Potatoes:
-      - "Production Potatoes"
-    - Castor oil seed:
-      - "Production Castor oil seed"
-    - Pumpkins, squash and gourds:
-      - "Production Pumpkins, squash and gourds"
-    - Lemons and limes:
-      - "Production Lemons and limes"
-    - Meat indigenous, cattle:
-      - "Production Meat indigenous, cattle"
-    - Milk, whole fresh goat:
-      - "Production Milk, whole fresh goat"
-    - Oil, sunflower:
-      - "production sunflower oil"
-    - Chick peas:
-      - "Production Chick peas"
-    - Chillies and peppers, dry:
-      - "Production Chillies and peppers, dry"
-    - Cucumbers and gherkins:
-      - "Production Cucumbers and gherkins"
-    - Oil, groundnut:
-      - "production groundnut oil"
-    - Grapefruit (inc. pomelos):
-      - "Production Grapefruit (inc. pomelos)"
-    - Cotton lint:
-      - "Production Cotton lint"
-    - Wheat:
-      - "Production Wheat"
-    - Beans, dry:
-      - "production dry beans"
-    - Cassava:
-      - "Production Cassava"
-    - Oilcrops, Cake Equivalent:
-      - "Production Oilcrops, Cake Equivalent"
-    - Eggs, hen, in shell:
-      - "Production Eggs, hen, in shell"
-  - Ratio:
-    - Gross Fixed Capital Formation as a share of Value Added  (Agriculture, Forestry and Fishing):
-      - "Ratio Gross Fixed Capital Formation as a share of Value Added  (Agriculture,\
-        \ Forestry and Fishing)"
-    - Gross Fixed Capital Formation to GDP ratio:
-      - "Ratio Gross Fixed Capital Formation to GDP ratio"
-  - Ratio, 2005 prices:
-    - Gross Fixed Capital Formation as a share of Value Added  (Agriculture, Forestry and Fishing):
-      - "Ratio, 2005 prices Gross Fixed Capital Formation as a share of Value Added\
-        \  (Agriculture, Forestry and Fishing)"
-    - Gross Fixed Capital Formation to GDP ratio:
-      - "Ratio, 2005 prices Gross Fixed Capital Formation to GDP ratio"
-  - Residues (Crop residues):
-    - Beans, dry:
-      - "residues (crop residues) dry beans"
-    - Sorghum:
-      - "Residues (Crop residues) Sorghum"
-    - Millet:
-      - "Residues (Crop residues) Millet"
-    - Maize:
-      - "Residues (Crop residues) Maize"
-    - All Crops:
-      - "Residues (Crop residues) All Crops"
-  - Rural population:
-    - Population - Est. & Proj.:
-      - "Rural population Population - Est. & Proj."
-  - Share in Agricultural area:
-    - Permanent meadows and pastures:
-      - "Share in Agricultural area Permanent meadows and pastures"
-    - Total area equipped for irrigation:
-      - "Share in Agricultural area Total area equipped for irrigation"
-  - Share in Forest area:
-    - Planted forest:
-      - "Share in Forest area Planted forest"
-    - Primary forest:
-      - "Share in Forest area Primary forest"
-    - Other naturally regenerated forest:
-      - "Share in Forest area Other naturally regenerated forest"
-  - Share in total livestock:
-    - Cattle and Buffaloes:
-      - "Share in total livestock Cattle and Buffaloes"
-    - Cattle:
-      - "Share in total livestock Cattle"
-    - Goats:
-      - "Share in total livestock Goats"
-    - Sheep:
-      - "Share in total livestock Sheep"
-    - Major livestock types:
-      - "Share in total livestock Major livestock types"
-    - Equidae:
-      - "Share in total livestock Equidae"
-    - Asses:
-      - "Share in total livestock Asses"
-    - Chickens:
-      - "Share in total livestock Chickens"
-    - Sheep and Goats:
-      - "Share in total livestock Sheep and Goats"
-  - Share of GDP in Local Currency:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Share of GDP in Local Currency Value Added (Agriculture, Forestry and Fishing)"
-    - Value Added (Total Manufacturing):
-      - "Share of GDP in Local Currency Value Added (Total Manufacturing)"
-    - Gross Fixed Capital Formation:
-      - "Share of GDP in Local Currency Gross Fixed Capital Formation"
-  - Share of GDP in US$:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Share of GDP in US$ Value Added (Agriculture, Forestry and Fishing)"
-    - Value Added (Total Manufacturing):
-      - "Share of GDP in US$ Value Added (Total Manufacturing)"
-    - Gross Fixed Capital Formation:
-      - "Share of GDP in US$ Gross Fixed Capital Formation"
-    - Value Added (Agriculture):
-      - "Share of GDP in US$ Value Added (Agriculture)"
-  - Share of GDP, Local Currency, 2010 prices:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Share of GDP, Local Currency, 2010 prices Value Added (Agriculture, Forestry\
-        \ and Fishing)"
-    - Value Added (Total Manufacturing):
-      - "Share of GDP, Local Currency, 2010 prices Value Added (Total Manufacturing)"
-    - Gross Fixed Capital Formation:
-      - "Share of GDP, Local Currency, 2010 prices Gross Fixed Capital Formation"
-  - Share of GDP, US$, 2010 prices:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Share of GDP, US$, 2010 prices Value Added (Agriculture, Forestry and Fishing)"
-    - Value Added (Total Manufacturing):
-      - "Share of GDP, US$, 2010 prices Value Added (Total Manufacturing)"
-    - Gross Fixed Capital Formation:
-      - "Share of GDP, US$, 2010 prices Gross Fixed Capital Formation"
-  - Share of Gross Output (Agriculture, Forestry and Fisheries):
-    - Gross Output (Agriculture):
-      - "Share of Gross Output (Agriculture, Forestry and Fisheries) Gross Output\
-        \ (Agriculture)"
-  - Share of Total:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Share of Total Value Added (Agriculture, Forestry and Fishing)"
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Share of Total Gross Fixed Capital Formation (Agriculture, Forestry and Fishing)"
-    - DFA Commitment to Agriculture, Forestry and Fishing:
-      - "Share of Total DFA Commitment to Agriculture, Forestry and Fishing"
-  - Share of Value Added:
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Share of Value Added Gross Fixed Capital Formation (Agriculture, Forestry\
-        \ and Fishing)"
-  - Share of Value Added (Agriculture, Forestry and Fishing):
-    - Value Added (Agriculture):
-      - "Share of Value Added (Agriculture, Forestry and Fishing) Value Added (Agriculture)"
-    - Value Added (Total Manufacturing):
-      - "Share of Value Added (Agriculture, Forestry and Fishing) Value Added (Total\
-        \ Manufacturing)"
-  - Share of Value Added US$:
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Share of Value Added US$ Gross Fixed Capital Formation (Agriculture, Forestry\
-        \ and Fishing)"
-  - Share of Value Added US$, 2005 prices:
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Share of Value Added US$, 2005 prices Gross Fixed Capital Formation (Agriculture,\
-        \ Forestry and Fishing)"
-  - Standard local currency units per USD:
-    - South Sudanese Pound:
-      - "Standard local currency units per USD South Sudanese Pound"
-  - Stocks:
-    - Chickens, broilers:
-      - "stocks broiler chickens"
-    - Cattle and Buffaloes:
-      - "Stocks Cattle and Buffaloes"
-    - Cattle:
-      - "Stocks Cattle"
-    - Camels:
-      - "Stocks Camels"
-    - Goats:
-      - "Stocks Goats"
-    - Poultry Birds:
-      - "Stocks Poultry Birds"
-    - Sheep:
-      - "Stocks Sheep"
-    - Chickens, layers:
-      - "stocks layer chickens"
-    - Mules and Asses:
-      - "Stocks Mules and Asses"
-    - Horses:
-      - "Stocks Horses"
-    - Major livestock types:
-      - "Stocks Major livestock types"
-    - Mules:
-      - "Stocks Mules"
-    - Equidae:
-      - "Stocks Equidae"
-    - Asses:
-      - "Stocks Asses"
-    - Cattle, dairy:
-      - "stocks dairy cattle"
-    - Chickens:
-      - "Stocks Chickens"
-    - Cattle, non-dairy:
-      - "stocks non-dairy cattle"
-    - Sheep and Goats:
-      - "Stocks Sheep and Goats"
-  - Total Population - Both sexes:
-    - Population - Est. & Proj.:
-      - "Total Population - Both sexes Population - Est. & Proj."
-  - Total Population - Female:
-    - Population - Est. & Proj.:
-      - "Total Population - Female Population - Est. & Proj."
-  - Total Population - Male:
-    - Population - Est. & Proj.:
-      - "Total Population - Male Population - Est. & Proj."
-  - Urban population:
-    - Population - Est. & Proj.:
-      - "Urban population Population - Est. & Proj."
-  - Value:
-    - Per capita food supply variability (kcal/capita/day):
-      - "Value Per capita food supply variability (kcal/capita/day)"
-    - Average value of food production (constant I$ per person) (3-year average):
-      - "Value Average value of food production (constant I$ per person) (3-year average)"
-    - Number of severely food insecure people:
-      - "Value Number of severely food insecure people"
-    - Prevalence of undernourishment (%) (3-year average):
-      - "Value Prevalence of undernourishment (%) (3-year average)"
-    - Percentage of children under 5 years of age who are overweight:
-      - "Value Percentage of children under 5 years of age who are overweight"
-    - Cereal import dependency ratio (%) (3-year average):
-      - "Value Cereal import dependency ratio (%) (3-year average)"
-    - Average protein supply (g/capita/day) (3-year average):
-      - "Value Average protein supply (g/capita/day) (3-year average)"
-    - Value of food imports over total merchandise exports (%) (3-year average):
-      - "Value Value of food imports over total merchandise exports (%) (3-year average)"
-    - Access to improved water sources (%):
-      - "Value Access to improved water sources (%)"
-    - Depth of the food deficit (kcal/capita/day) (3-year average):
-      - "Value Depth of the food deficit (kcal/capita/day) (3-year average)"
-    - Average supply of protein of animal origin (g/capita/day) (3-year average):
-      - "Value Average supply of protein of animal origin (g/capita/day) (3-year average)"
-    - Share of dietary energy supply derived from cereals, roots and tubers (%) (3-year average):
-      - "Value Share of dietary energy supply derived from cereals, roots and tubers\
-        \ (%) (3-year average)"
-    - Political stability and absence of violence/terrorism (index):
-      - "Value Political stability and absence of violence/terrorism (index)"
-    - Percentage of children under 5 years of age who are stunted (%):
-      - "Value Percentage of children under 5 years of age who are stunted (%)"
-    - Access to improved sanitation facilities (%):
-      - "Value Access to improved sanitation facilities (%)"
-    - Gross domestic product per capita, PPP (constant 2011 international $):
-      - "Value Gross domestic product per capita, PPP (constant 2011 international\
-        \ $)"
-    - Prevalence of anemia among women of reproductive age (15-49 years):
-      - "Value Prevalence of anemia among women of reproductive age (15-49 years)"
-    - Per capita food production variability (I$ per person constant 2004-06):
-      - "Value Per capita food production variability (I$ per person constant 2004-06)"
-    - Prevalence of severe food insecurity in the total population:
-      - "Value Prevalence of severe food insecurity in the total population"
-    - Average dietary energy supply adequacy (%) (3-year average):
-      - "Value Average dietary energy supply adequacy (%) (3-year average)"
-    - Percentage of children under 5 years of age affected by wasting (%):
-      - "Value Percentage of children under 5 years of age affected by wasting (%)"
-    - Number of people undernourished (millions) (3-year average):
-      - "Value Number of people undernourished (millions) (3-year average)"
-    - Percentage of arable land equipped for irrigation (%) (3-year average):
-      - "Value Percentage of arable land equipped for irrigation (%) (3-year average)"
-    - Prevalence of exclusive breastfeeding among infants (0-5 months):
-      - "Value Prevalence of exclusive breastfeeding among infants (0-5 months)"
-    - Rail-lines density (per 100 square km of land area):
-      - "Value Rail-lines density (per 100 square km of land area)"
-  - Value Local Currency:
-    - Gross National Income:
-      - "Value Local Currency Gross National Income"
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Value Local Currency Value Added (Agriculture, Forestry and Fishing)"
-    - Gross Domestic Product:
-      - "Value Local Currency Gross Domestic Product"
-    - Value Added (Agriculture):
-      - "Value Local Currency Value Added (Agriculture)"
-    - Gross Output (Agriculture, Forestry and Fishing):
-      - "Value Local Currency Gross Output (Agriculture, Forestry and Fishing)"
-    - Gross Fixed Capital Formation:
-      - "Value Local Currency Gross Fixed Capital Formation"
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Value Local Currency Gross Fixed Capital Formation (Agriculture, Forestry\
-        \ and Fishing)"
-    - Agriculture, forestry, fishing, Capital (Central Government):
-      - "Value Local Currency Agriculture, forestry, fishing, Capital (Central Government)"
-    - Agriculture, forestry, fishing (Central Government):
-      - "Value Local Currency Agriculture, forestry, fishing (Central Government)"
-    - Gross Output (Agriculture):
-      - "Value Local Currency Gross Output (Agriculture)"
-    - Value Added (Total Manufacturing):
-      - "Value Local Currency Value Added (Total Manufacturing)"
-    - Agriculture, forestry, fishing, Recurrent (Central Government):
-      - "Value Local Currency Agriculture, forestry, fishing, Recurrent (Central Government)"
-  - Value Local Currency, 2010 base year:
-    - Gross Fixed Capital Formation Deflator:
-      - "Value Local Currency, 2010 base year Gross Fixed Capital Formation Deflator"
-    - GDP Deflator:
-      - "Value Local Currency, 2010 base year GDP Deflator"
-    - Value Added Deflator (Manufacturing):
-      - "Value Local Currency, 2010 base year Value Added Deflator (Manufacturing)"
-    - Value Added Deflator (Agriculture, forestry and fishery):
-      - "Value Local Currency, 2010 base year Value Added Deflator (Agriculture, forestry\
-        \ and fishery)"
-  - Value Local Currency, 2010 prices:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Value Local Currency, 2010 prices Value Added (Agriculture, Forestry and\
-        \ Fishing)"
-    - Gross Domestic Product:
-      - "Value Local Currency, 2010 prices Gross Domestic Product"
-    - Value Added (Total Manufacturing):
-      - "Value Local Currency, 2010 prices Value Added (Total Manufacturing)"
-    - Gross Fixed Capital Formation:
-      - "Value Local Currency, 2010 prices Gross Fixed Capital Formation"
-  - Value US$:
-    - Gross National Income:
-      - "Value US$ Gross National Income"
-    - DFA Commitment to Agriculture, Forestry and Fishing:
-      - "Value US$ DFA Commitment to Agriculture, Forestry and Fishing"
-    - Total FDI inflows:
-      - "Value US$ Total FDI inflows"
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Value US$ Value Added (Agriculture, Forestry and Fishing)"
-    - Gross Domestic Product:
-      - "Value US$ Gross Domestic Product"
-    - Value Added (Agriculture):
-      - "Value US$ Value Added (Agriculture)"
-    - Gross Output (Agriculture, Forestry and Fishing):
-      - "Value US$ Gross Output (Agriculture, Forestry and Fishing)"
-    - Gross Fixed Capital Formation:
-      - "Value US$ Gross Fixed Capital Formation"
-    - Gross Domestic Product per capita:
-      - "Value US$ Gross Domestic Product per capita"
-    - Gross National Income per capita:
-      - "Value US$ Gross National Income per capita"
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Value US$ Gross Fixed Capital Formation (Agriculture, Forestry and Fishing)"
-    - Agriculture, forestry, fishing, Capital (Central Government):
-      - "Value US$ Agriculture, forestry, fishing, Capital (Central Government)"
-    - Agriculture, forestry, fishing (Central Government):
-      - "Value US$ Agriculture, forestry, fishing (Central Government)"
-    - Gross Output (Agriculture):
-      - "Value US$ Gross Output (Agriculture)"
-    - Value Added (Total Manufacturing):
-      - "Value US$ Value Added (Total Manufacturing)"
-    - Agriculture, forestry, fishing, Recurrent (Central Government):
-      - "Value US$ Agriculture, forestry, fishing, Recurrent (Central Government)"
-  - Value US$, 2005 prices:
-    - Total FDI inflows:
-      - "Value US$, 2005 prices Total FDI inflows"
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Value US$, 2005 prices Value Added (Agriculture, Forestry and Fishing)"
-    - Gross Domestic Product:
-      - "Value US$, 2005 prices Gross Domestic Product"
-    - Value Added (Agriculture):
-      - "Value US$, 2005 prices Value Added (Agriculture)"
-    - Gross Output (Agriculture, Forestry and Fishing):
-      - "Value US$, 2005 prices Gross Output (Agriculture, Forestry and Fishing)"
-    - Gross Fixed Capital Formation:
-      - "Value US$, 2005 prices Gross Fixed Capital Formation"
-    - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
-      - "Value US$, 2005 prices Gross Fixed Capital Formation (Agriculture, Forestry\
-        \ and Fishing)"
-    - Agriculture, forestry, fishing, Capital (Central Government):
-      - "Value US$, 2005 prices Agriculture, forestry, fishing, Capital (Central Government)"
-    - Agriculture, forestry, fishing (Central Government):
-      - "Value US$, 2005 prices Agriculture, forestry, fishing (Central Government)"
-    - Gross Output (Agriculture):
-      - "Value US$, 2005 prices Gross Output (Agriculture)"
-    - Value Added (Total Manufacturing):
-      - "Value US$, 2005 prices Value Added (Total Manufacturing)"
-    - Agriculture, forestry, fishing, Recurrent (Central Government):
-      - "Value US$, 2005 prices Agriculture, forestry, fishing, Recurrent (Central\
-        \ Government)"
-  - Value US$, 2010 base year:
-    - Gross Fixed Capital Formation Deflator:
-      - "Value US$, 2010 base year Gross Fixed Capital Formation Deflator"
-    - GDP Deflator:
-      - "Value US$, 2010 base year GDP Deflator"
-    - Value Added Deflator (Manufacturing):
-      - "Value US$, 2010 base year Value Added Deflator (Manufacturing)"
-    - Value Added Deflator (Agriculture, forestry and fishery):
-      - "Value US$, 2010 base year Value Added Deflator (Agriculture, forestry and\
-        \ fishery)"
-  - Value US$, 2010 prices:
-    - Value Added (Agriculture, Forestry and Fishing):
-      - "Value US$, 2010 prices Value Added (Agriculture, Forestry and Fishing)"
-    - Gross Domestic Product:
-      - "Value US$, 2010 prices Gross Domestic Product"
-    - Gross Fixed Capital Formation:
-      - "Value US$, 2010 prices Gross Fixed Capital Formation"
-    - Gross Domestic Product per capita:
-      - "Value US$, 2010 prices Gross Domestic Product per capita"
-    - Value Added (Total Manufacturing):
-      - "Value US$, 2010 prices Value Added (Total Manufacturing)"
-  - Yield:
-    - Vegetables Primary:
-      - "Yield Vegetables Primary"
-    - Pineapples:
-      - "Yield Pineapples"
-    - Tangerines, mandarins, clementines, satsumas:
-      - "Yield Tangerines, mandarins, clementines, satsumas"
-    - Pulses, nes:
-      - "yield ne pulses"
-    - Cereals,Total:
-      - "Yield Cereals,Total"
-    - Fruit, fresh nes:
-      - "Yield Fruit, fresh nes"
-    - Citrus Fruit,Total:
-      - "yield total citrus fruit"
-    - Skins, sheep, fresh:
-      - "Yield Skins, sheep, fresh"
-    - Maize:
-      - "Yield Maize"
-    - Skins, sheep, with wool:
-      - "Yield Skins, sheep, with wool"
-    - Coarse Grain, Total:
-      - "Yield Coarse Grain, Total"
-    - Melonseed:
-      - "Yield Melonseed"
-    - Sesame seed:
-      - "Yield Sesame seed"
-    - Milk,Total:
-      - "Yield Milk,Total"
-    - Melons, other (inc.cantaloupes):
-      - "Yield Melons, other (inc.cantaloupes)"
-    - Beans, green:
-      - "yield green beans"
-    - Pumpkins, squash and gourds:
-      - "Yield Pumpkins, squash and gourds"
-    - Milk, whole fresh cow:
-      - "Yield Milk, whole fresh cow"
-    - Milk, whole fresh goat:
-      - "Yield Milk, whole fresh goat"
-    - Hides, cattle, fresh:
-      - "Yield Hides, cattle, fresh"
-    - Roots and Tubers,Total:
-      - "Yield Roots and Tubers,Total"
-    - Sunflower seed:
-      - "Yield Sunflower seed"
-    - Millet:
-      - "Yield Millet"
-    - Chillies and peppers, dry:
-      - "Yield Chillies and peppers, dry"
-    - Fruit, tropical fresh nes:
-      - "Yield Fruit, tropical fresh nes"
-    - Groundnuts, with shell:
-      - "Yield Groundnuts, with shell"
-    - Yams:
-      - "Yield Yams"
-    - Cassava:
-      - "Yield Cassava"
-    - Beans, dry:
-      - "yield dry beans"
-    - Sorghum:
-      - "Yield Sorghum"
-    - Pulses,Total:
-      - "Yield Pulses,Total"
-    - Milk, whole fresh sheep:
-      - "Yield Milk, whole fresh sheep"
-    - Vegetables, fresh nes:
-      - "Yield Vegetables, fresh nes"
-  - Yield/Carcass Weight:
-    - Meat, chicken:
-      - "yield/carcass weight chicken meat"
-    - Sheep and Goat Meat:
-      - "Yield/Carcass Weight Sheep and Goat Meat"
-    - Meat, Poultry:
-      - "yield/carcass weight poultry meat"
-    - Beef and Buffalo Meat:
-      - "Yield/Carcass Weight Beef and Buffalo Meat"
-    - Meat, cattle:
-      - "yield/carcass weight cattle meat"
-    - Meat, sheep:
-      - "yield/carcass weight sheep meat"
-    - Meat, goat:
-      - "yield/carcass weight goat meat"
+- FAO:
+  - events:
+    - Agriculture orientation index:
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Agriculture orientation index Gross Fixed Capital Formation (Agriculture,\
+          \ Forestry and Fishing)"
+      - DFA Commitment to Agriculture, Forestry and Fishing:
+        - description:
+          - "Agriculture orientation index DFA Commitment to Agriculture, Forestry and\
+          \ Fishing"
+    - Agriculture orientation index US$, 2005 prices:
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Agriculture orientation index US$, 2005 prices Gross Fixed Capital Formation\
+          \ (Agriculture, Forestry and Fishing)"
+    - Amount excreted in manure (N content):
+      - Chickens, broilers:
+        - description:
+          - "amount excreted in manure (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Amount excreted in manure (N content) Cattle"
+      - Goats:
+        - description:
+          - "Amount excreted in manure (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Amount excreted in manure (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Amount excreted in manure (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "amount excreted in manure (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Amount excreted in manure (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Amount excreted in manure (N content) All Animals"
+      - Asses:
+        - description:
+          - "Amount excreted in manure (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "amount excreted in manure (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Amount excreted in manure (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "amount excreted in manure (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Amount excreted in manure (N content) Sheep and Goats"
+    - Annual growth Local Currency:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Annual growth Local Currency Value Added (Agriculture, Forestry and Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Annual growth Local Currency Gross Domestic Product"
+      - Value Added (Agriculture):
+        - description:
+          - "Annual growth Local Currency Value Added (Agriculture)"
+      - Gross Output (Agriculture, Forestry and Fishing):
+        - description:
+          - "Annual growth Local Currency Gross Output (Agriculture, Forestry and Fishing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Annual growth Local Currency Gross Fixed Capital Formation"
+      - Gross Output (Agriculture):
+        - description:
+          - "Annual growth Local Currency Gross Output (Agriculture)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Annual growth Local Currency Value Added (Total Manufacturing)"
+    - Annual growth US$:
+      - Gross National Income:
+        - description:
+          - "Annual growth US$ Gross National Income"
+      - DFA Commitment to Agriculture, Forestry and Fishing:
+        - description:
+          - "Annual growth US$ DFA Commitment to Agriculture, Forestry and Fishing"
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Annual growth US$ Value Added (Agriculture, Forestry and Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Annual growth US$ Gross Domestic Product"
+      - Value Added (Agriculture):
+        - description:
+          - "Annual growth US$ Value Added (Agriculture)"
+      - Gross Output (Agriculture, Forestry and Fishing):
+        - description:
+          - "Annual growth US$ Gross Output (Agriculture, Forestry and Fishing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Annual growth US$ Gross Fixed Capital Formation"
+      - Gross Domestic Product per capita:
+        - description:
+          - "Annual growth US$ Gross Domestic Product per capita"
+      - Agriculture, forestry, fishing (Central Government):
+        - description:
+          - "Annual growth US$ Agriculture, forestry, fishing (Central Government)"
+      - Gross Output (Agriculture):
+        - description:
+          - "Annual growth US$ Gross Output (Agriculture)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Annual growth US$ Value Added (Total Manufacturing)"
+    - Annual growth US$, 2005 prices:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Annual growth US$, 2005 prices Value Added (Agriculture, Forestry and Fishing)"
+    - Annual growth, Local Currency, 2010 prices:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Annual growth, Local Currency, 2010 prices Value Added (Agriculture, Forestry\
+          \ and Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Annual growth, Local Currency, 2010 prices Gross Domestic Product"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Annual growth, Local Currency, 2010 prices Value Added (Total Manufacturing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Annual growth, Local Currency, 2010 prices Gross Fixed Capital Formation"
+    - Annual growth, US$, 2010 prices:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Annual growth, US$, 2010 prices Value Added (Agriculture, Forestry and Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Annual growth, US$, 2010 prices Gross Domestic Product"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Annual growth, US$, 2010 prices Gross Fixed Capital Formation"
+      - Gross Domestic Product per capita:
+        - description:
+          - "Annual growth, US$, 2010 prices Gross Domestic Product per capita"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Annual growth, US$, 2010 prices Value Added (Total Manufacturing)"
+    - Area:
+      - Planted forest:
+        - description:
+          - "Area Planted forest"
+      - Cropland and grassland organic soils:
+        - description:
+          - "Area Cropland and grassland organic soils"
+      - Total area equipped for irrigation:
+        - description:
+          - "Area Total area equipped for irrigation"
+      - Arable land and Permanent crops:
+        - description:
+          - "Area Arable land and Permanent crops"
+      - Agricultural area organic, total:
+        - description:
+          - "Area Agricultural area organic, total"
+      - Other naturally regenerated forest:
+        - description:
+          - "Area Other naturally regenerated forest"
+      - Primary forest:
+        - description:
+          - "Area Primary forest"
+      - Grassland organic soils:
+        - description:
+          - "Area Grassland organic soils"
+      - Agricultural area certified organic:
+        - description:
+          - "Area Agricultural area certified organic"
+      - Permanent meadows and pastures:
+        - description:
+          - "Area Permanent meadows and pastures"
+      - Agricultural area:
+        - description:
+          - "Area Agricultural area"
+      - Cropland organic soils:
+        - description:
+          - "Area Cropland organic soils"
+      - Agricultural area in conversion to organic:
+        - description:
+          - "Area Agricultural area in conversion to organic"
+      - Forest:
+        - description:
+          - "Area Forest"
+    - Area harvested:
+      - Vegetables Primary:
+        - description:
+          - "Area harvested Vegetables Primary"
+      - Mangoes, mangosteens, guavas:
+        - description:
+          - "Area harvested Mangoes, mangosteens, guavas"
+      - Pineapples:
+        - description:
+          - "Area harvested Pineapples"
+      - Rice, paddy:
+        - description:
+          - "area harvested paddy rice"
+      - Pulses, nes:
+        - description:
+          - "area harvested ne pulses"
+      - Cabbages and other brassicas:
+        - description:
+          - "Area harvested Cabbages and other brassicas"
+      - Tangerines, mandarins, clementines, satsumas:
+        - description:
+          - "Area harvested Tangerines, mandarins, clementines, satsumas"
+      - Okra:
+        - description:
+          - "Area harvested Okra"
+      - Cereals,Total:
+        - description:
+          - "Area harvested Cereals,Total"
+      - Fruit, fresh nes:
+        - description:
+          - "Area harvested Fruit, fresh nes"
+      - Sugar cane:
+        - description:
+          - "Area harvested Sugar cane"
+      - Citrus Fruit,Total:
+        - description:
+          - "area harvested total citrus fruit"
+      - Tomatoes:
+        - description:
+          - "Area harvested Tomatoes"
+      - Maize:
+        - description:
+          - "Area harvested Maize"
+      - Carrots and turnips:
+        - description:
+          - "Area harvested Carrots and turnips"
+      - Cauliflowers and broccoli:
+        - description:
+          - "Area harvested Cauliflowers and broccoli"
+      - Onions, dry:
+        - description:
+          - "area harvested dry onions"
+      - Watermelons:
+        - description:
+          - "Area harvested Watermelons"
+      - Broad beans, horse beans, dry:
+        - description:
+          - "Area harvested Broad beans, horse beans, dry"
+      - Bananas:
+        - description:
+          - "Area harvested Bananas"
+      - Coarse Grain, Total:
+        - description:
+          - "Area harvested Coarse Grain, Total"
+      - Melonseed:
+        - description:
+          - "Area harvested Melonseed"
+      - Sesame seed:
+        - description:
+          - "Area harvested Sesame seed"
+      - Melons, other (inc.cantaloupes):
+        - description:
+          - "Area harvested Melons, other (inc.cantaloupes)"
+      - Beans, green:
+        - description:
+          - "area harvested green beans"
+      - Potatoes:
+        - description:
+          - "Area harvested Potatoes"
+      - Pumpkins, squash and gourds:
+        - description:
+          - "Area harvested Pumpkins, squash and gourds"
+      - Castor oil seed:
+        - description:
+          - "Area harvested Castor oil seed"
+      - Cow peas, dry:
+        - description:
+          - "Area harvested Cow peas, dry"
+      - Lemons and limes:
+        - description:
+          - "Area harvested Lemons and limes"
+      - Peas, green:
+        - description:
+          - "area harvested green peas"
+      - Seed cotton:
+        - description:
+          - "Area harvested Seed cotton"
+      - Sweet potatoes:
+        - description:
+          - "Area harvested Sweet potatoes"
+      - Cereals (Rice Milled Eqv):
+        - description:
+          - "Area harvested Cereals (Rice Milled Eqv)"
+      - Chick peas:
+        - description:
+          - "Area harvested Chick peas"
+      - Roots and Tubers,Total:
+        - description:
+          - "Area harvested Roots and Tubers,Total"
+      - Sunflower seed:
+        - description:
+          - "Area harvested Sunflower seed"
+      - Dates:
+        - description:
+          - "Area harvested Dates"
+      - Millet:
+        - description:
+          - "Area harvested Millet"
+      - Chillies and peppers, dry:
+        - description:
+          - "Area harvested Chillies and peppers, dry"
+      - Cucumbers and gherkins:
+        - description:
+          - "Area harvested Cucumbers and gherkins"
+      - Fruit, tropical fresh nes:
+        - description:
+          - "Area harvested Fruit, tropical fresh nes"
+      - Groundnuts, with shell:
+        - description:
+          - "Area harvested Groundnuts, with shell"
+      - Grapefruit (inc. pomelos):
+        - description:
+          - "Area harvested Grapefruit (inc. pomelos)"
+      - Eggplants (aubergines):
+        - description:
+          - "Area harvested Eggplants (aubergines)"
+      - Yams:
+        - description:
+          - "Area harvested Yams"
+      - Wheat:
+        - description:
+          - "Area harvested Wheat"
+      - Beans, dry:
+        - description:
+          - "area harvested dry beans"
+      - Cassava:
+        - description:
+          - "Area harvested Cassava"
+      - Sorghum:
+        - description:
+          - "Area harvested Sorghum"
+      - Pulses,Total:
+        - description:
+          - "Area harvested Pulses,Total"
+      - Chillies and peppers, green:
+        - description:
+          - "Area harvested Chillies and peppers, green"
+      - Garlic:
+        - description:
+          - "Area harvested Garlic"
+      - Oranges:
+        - description:
+          - "Area harvested Oranges"
+      - Vegetables, fresh nes:
+        - description:
+          - "Area harvested Vegetables, fresh nes"
+    - Biomass burned (dry matter):
+      - Savanna:
+        - description:
+          - "Biomass burned (dry matter) Savanna"
+      - Burning - all categories:
+        - description:
+          - "Biomass burned (dry matter) Burning - all categories"
+      - Woody savanna:
+        - description:
+          - "Biomass burned (dry matter) Woody savanna"
+      - Grassland:
+        - description:
+          - "Biomass burned (dry matter) Grassland"
+      - Open shrubland:
+        - description:
+          - "Biomass burned (dry matter) Open shrubland"
+      - Savanna and woody savanna:
+        - description:
+          - "Biomass burned (dry matter) Savanna and woody savanna"
+      - Closed and open shrubland:
+        - description:
+          - "Biomass burned (dry matter) Closed and open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Biomass burned (dry matter) Closed shrubland"
+      - Maize:
+        - description:
+          - "Biomass burned (dry matter) Maize"
+      - All Crops:
+        - description:
+          - "Biomass burned (dry matter) All Crops"
+    - Burned Area:
+      - Savanna:
+        - description:
+          - "Burned Area Savanna"
+      - Burning - all categories:
+        - description:
+          - "Burned Area Burning - all categories"
+      - Woody savanna:
+        - description:
+          - "Burned Area Woody savanna"
+      - Grassland:
+        - description:
+          - "Burned Area Grassland"
+      - Open shrubland:
+        - description:
+          - "Burned Area Open shrubland"
+      - Savanna and woody savanna:
+        - description:
+          - "Burned Area Savanna and woody savanna"
+      - Closed and open shrubland:
+        - description:
+          - "Burned Area Closed and open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Burned Area Closed shrubland"
+    - Carbon stock in living biomass:
+      - Forest:
+        - description:
+          - "Carbon stock in living biomass Forest"
+    - Density of livestock in the agricultural area:
+      - Cattle and Buffaloes:
+        - description:
+          - "Density of livestock in the agricultural area Cattle and Buffaloes"
+      - Cattle:
+        - description:
+          - "Density of livestock in the agricultural area Cattle"
+      - Goats:
+        - description:
+          - "Density of livestock in the agricultural area Goats"
+      - Sheep:
+        - description:
+          - "Density of livestock in the agricultural area Sheep"
+      - Major livestock types:
+        - description:
+          - "Density of livestock in the agricultural area Major livestock types"
+      - Equidae:
+        - description:
+          - "Density of livestock in the agricultural area Equidae"
+      - Asses:
+        - description:
+          - "Density of livestock in the agricultural area Asses"
+      - Chickens:
+        - description:
+          - "Density of livestock in the agricultural area Chickens"
+      - Sheep and Goats:
+        - description:
+          - "Density of livestock in the agricultural area Sheep and Goats"
+    - Direct emissions (CO2eq) (Crop residues):
+      - Beans, dry:
+        - description:
+          - "direct emissions (co2eq) (crop residues) dry beans"
+      - Sorghum:
+        - description:
+          - "Direct emissions (CO2eq) (Crop residues) Sorghum"
+      - Millet:
+        - description:
+          - "Direct emissions (CO2eq) (Crop residues) Millet"
+      - Maize:
+        - description:
+          - "Direct emissions (CO2eq) (Crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Direct emissions (CO2eq) (Crop residues) All Crops"
+    - Direct emissions (CO2eq) (Manure applied):
+      - Chickens, broilers:
+        - description:
+          - "direct emissions (co2eq) (manure applied) broiler chickens"
+      - Cattle:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) Cattle"
+      - Goats:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) Goats"
+      - Poultry Birds:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) Sheep"
+      - Chickens, layers:
+        - description:
+          - "direct emissions (co2eq) (manure applied) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) All Animals"
+      - Asses:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) Asses"
+      - Cattle, dairy:
+        - description:
+          - "direct emissions (co2eq) (manure applied) dairy cattle"
+      - Chickens:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "direct emissions (co2eq) (manure applied) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Direct emissions (CO2eq) (Manure applied) Sheep and Goats"
+    - Direct emissions (CO2eq) (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "direct emissions (co2eq) (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "direct emissions (co2eq) (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "direct emissions (co2eq) (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "direct emissions (co2eq) (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Direct emissions (CO2eq) (Manure management) Sheep and Goats"
+    - Direct emissions (CO2eq) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "direct emissions (co2eq) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "direct emissions (co2eq) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "direct emissions (co2eq) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "direct emissions (co2eq) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Direct emissions (CO2eq) (Manure on pasture) Sheep and Goats"
+    - Direct emissions (N2O) (Crop residues):
+      - Beans, dry:
+        - description:
+          - "direct emissions (n2o) (crop residues) dry beans"
+      - Sorghum:
+        - description:
+          - "Direct emissions (N2O) (Crop residues) Sorghum"
+      - Millet:
+        - description:
+          - "Direct emissions (N2O) (Crop residues) Millet"
+      - Maize:
+        - description:
+          - "Direct emissions (N2O) (Crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Direct emissions (N2O) (Crop residues) All Crops"
+    - Direct emissions (N2O) (Manure applied):
+      - Chickens, broilers:
+        - description:
+          - "direct emissions (n2o) (manure applied) broiler chickens"
+      - Cattle:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) Cattle"
+      - Goats:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) Goats"
+      - Poultry Birds:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) Sheep"
+      - Chickens, layers:
+        - description:
+          - "direct emissions (n2o) (manure applied) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) All Animals"
+      - Asses:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) Asses"
+      - Cattle, dairy:
+        - description:
+          - "direct emissions (n2o) (manure applied) dairy cattle"
+      - Chickens:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "direct emissions (n2o) (manure applied) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Direct emissions (N2O) (Manure applied) Sheep and Goats"
+    - Direct emissions (N2O) (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "direct emissions (n2o) (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Direct emissions (N2O) (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Direct emissions (N2O) (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Direct emissions (N2O) (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Direct emissions (N2O) (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "direct emissions (n2o) (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Direct emissions (N2O) (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Direct emissions (N2O) (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Direct emissions (N2O) (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "direct emissions (n2o) (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Direct emissions (N2O) (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "direct emissions (n2o) (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Direct emissions (N2O) (Manure management) Sheep and Goats"
+    - Direct emissions (N2O) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "direct emissions (n2o) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "direct emissions (n2o) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "direct emissions (n2o) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "direct emissions (n2o) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Direct emissions (N2O) (Manure on pasture) Sheep and Goats"
+    - Emissions (CH4) (Burning - savanna):
+      - Savanna:
+        - description:
+          - "Emissions (CH4) (Burning - savanna) Savanna"
+      - Burning - all categories:
+        - description:
+          - "Emissions (CH4) (Burning - savanna) Burning - all categories"
+      - Woody savanna:
+        - description:
+          - "Emissions (CH4) (Burning - savanna) Woody savanna"
+      - Grassland:
+        - description:
+          - "Emissions (CH4) (Burning - savanna) Grassland"
+      - Open shrubland:
+        - description:
+          - "Emissions (CH4) (Burning - savanna) Open shrubland"
+      - Savanna and woody savanna:
+        - description:
+          - "Emissions (CH4) (Burning - savanna) Savanna and woody savanna"
+      - Closed and open shrubland:
+        - description:
+          - "Emissions (CH4) (Burning - savanna) Closed and open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Emissions (CH4) (Burning - savanna) Closed shrubland"
+    - Emissions (CH4) (Burning crop residues):
+      - Maize:
+        - description:
+          - "Emissions (CH4) (Burning crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Emissions (CH4) (Burning crop residues) All Crops"
+    - Emissions (CH4) (Enteric):
+      - Cattle:
+        - description:
+          - "Emissions (CH4) (Enteric) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (CH4) (Enteric) Goats"
+      - Sheep:
+        - description:
+          - "Emissions (CH4) (Enteric) Sheep"
+      - Mules and Asses:
+        - description:
+          - "Emissions (CH4) (Enteric) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (CH4) (Enteric) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (CH4) (Enteric) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (ch4) (enteric) dairy cattle"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (ch4) (enteric) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (CH4) (Enteric) Sheep and Goats"
+    - Emissions (CH4) (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "emissions (ch4) (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (CH4) (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (CH4) (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (CH4) (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (CH4) (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (ch4) (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (CH4) (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (CH4) (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (CH4) (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (ch4) (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (CH4) (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (ch4) (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (CH4) (Manure management) Sheep and Goats"
+    - Emissions (CO2eq):
+      - Milk, whole fresh goat:
+        - description:
+          - "Emissions (CO2eq) Milk, whole fresh goat"
+      - Meat, chicken:
+        - description:
+          - "emissions (co2eq) chicken meat"
+      - Crop Residues:
+        - description:
+          - "Emissions (CO2eq) Crop Residues"
+      - Enteric Fermentation:
+        - description:
+          - "Emissions (CO2eq) Enteric Fermentation"
+      - Cultivation of Organic Soils:
+        - description:
+          - "Emissions (CO2eq) Cultivation of Organic Soils"
+      - Agriculture total:
+        - description:
+          - "Emissions (CO2eq) Agriculture total"
+      - Meat, sheep:
+        - description:
+          - "emissions (co2eq) sheep meat"
+      - Manure left on Pasture:
+        - description:
+          - "Emissions (CO2eq) Manure left on Pasture"
+      - Manure Management:
+        - description:
+          - "Emissions (CO2eq) Manure Management"
+      - Manure applied to Soils:
+        - description:
+          - "Emissions (CO2eq) Manure applied to Soils"
+      - Burning - Crop residues:
+        - description:
+          - "Emissions (CO2eq) Burning - Crop residues"
+      - Agricultural Soils:
+        - description:
+          - "Emissions (CO2eq) Agricultural Soils"
+      - Meat, cattle:
+        - description:
+          - "emissions (co2eq) cattle meat"
+      - Cereals excluding rice:
+        - description:
+          - "Emissions (CO2eq) Cereals excluding rice"
+      - Burning - Savanna:
+        - description:
+          - "Emissions (CO2eq) Burning - Savanna"
+      - Milk, whole fresh sheep:
+        - description:
+          - "Emissions (CO2eq) Milk, whole fresh sheep"
+      - Milk, whole fresh cow:
+        - description:
+          - "Emissions (CO2eq) Milk, whole fresh cow"
+      - Meat, goat:
+        - description:
+          - "emissions (co2eq) goat meat"
+    - Emissions (CO2eq) (Burning - savanna):
+      - Savanna:
+        - description:
+          - "Emissions (CO2eq) (Burning - savanna) Savanna"
+      - Burning - all categories:
+        - description:
+          - "Emissions (CO2eq) (Burning - savanna) Burning - all categories"
+      - Woody savanna:
+        - description:
+          - "Emissions (CO2eq) (Burning - savanna) Woody savanna"
+      - Grassland:
+        - description:
+          - "Emissions (CO2eq) (Burning - savanna) Grassland"
+      - Open shrubland:
+        - description:
+          - "Emissions (CO2eq) (Burning - savanna) Open shrubland"
+      - Savanna and woody savanna:
+        - description:
+          - "Emissions (CO2eq) (Burning - savanna) Savanna and woody savanna"
+      - Closed and open shrubland:
+        - description:
+          - "Emissions (CO2eq) (Burning - savanna) Closed and open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Emissions (CO2eq) (Burning - savanna) Closed shrubland"
+    - Emissions (CO2eq) (Burning crop residues):
+      - Maize:
+        - description:
+          - "Emissions (CO2eq) (Burning crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Emissions (CO2eq) (Burning crop residues) All Crops"
+    - Emissions (CO2eq) (Crop residues):
+      - Beans, dry:
+        - description:
+          - "emissions (co2eq) (crop residues) dry beans"
+      - Sorghum:
+        - description:
+          - "Emissions (CO2eq) (Crop residues) Sorghum"
+      - Millet:
+        - description:
+          - "Emissions (CO2eq) (Crop residues) Millet"
+      - Maize:
+        - description:
+          - "Emissions (CO2eq) (Crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Emissions (CO2eq) (Crop residues) All Crops"
+    - Emissions (CO2eq) (Cultivation of organic soils):
+      - Grassland organic soils:
+        - description:
+          - "Emissions (CO2eq) (Cultivation of organic soils) Grassland organic soils"
+      - Cropland and grassland organic soils:
+        - description:
+          - "Emissions (CO2eq) (Cultivation of organic soils) Cropland and grassland organic\
+          \ soils"
+      - Cropland organic soils:
+        - description:
+          - "Emissions (CO2eq) (Cultivation of organic soils) Cropland organic soils"
+    - Emissions (CO2eq) (Enteric):
+      - Cattle:
+        - description:
+          - "Emissions (CO2eq) (Enteric) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (CO2eq) (Enteric) Goats"
+      - Sheep:
+        - description:
+          - "Emissions (CO2eq) (Enteric) Sheep"
+      - Mules and Asses:
+        - description:
+          - "Emissions (CO2eq) (Enteric) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (CO2eq) (Enteric) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (CO2eq) (Enteric) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (co2eq) (enteric) dairy cattle"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (co2eq) (enteric) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (CO2eq) (Enteric) Sheep and Goats"
+    - Emissions (CO2eq) (Manure applied):
+      - Chickens, broilers:
+        - description:
+          - "emissions (co2eq) (manure applied) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (co2eq) (manure applied) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (co2eq) (manure applied) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (co2eq) (manure applied) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (CO2eq) (Manure applied) Sheep and Goats"
+    - Emissions (CO2eq) (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "emissions (co2eq) (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (CO2eq) (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (CO2eq) (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (CO2eq) (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (CO2eq) (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (co2eq) (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (CO2eq) (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (CO2eq) (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (CO2eq) (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (co2eq) (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (CO2eq) (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (co2eq) (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (CO2eq) (Manure management) Sheep and Goats"
+    - Emissions (CO2eq) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "emissions (co2eq) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (co2eq) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (co2eq) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (co2eq) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (CO2eq) (Manure on pasture) Sheep and Goats"
+    - Emissions (CO2eq) from CH4:
+      - Enteric Fermentation:
+        - description:
+          - "Emissions (CO2eq) from CH4 Enteric Fermentation"
+      - Agriculture total:
+        - description:
+          - "Emissions (CO2eq) from CH4 Agriculture total"
+      - Manure Management:
+        - description:
+          - "Emissions (CO2eq) from CH4 Manure Management"
+      - Burning - Crop residues:
+        - description:
+          - "Emissions (CO2eq) from CH4 Burning - Crop residues"
+      - Burning - Savanna:
+        - description:
+          - "Emissions (CO2eq) from CH4 Burning - Savanna"
+    - Emissions (CO2eq) from CH4 (Burning - savanna):
+      - Savanna:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning - savanna) Savanna"
+      - Burning - all categories:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning - savanna) Burning - all categories"
+      - Woody savanna:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning - savanna) Woody savanna"
+      - Grassland:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning - savanna) Grassland"
+      - Open shrubland:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning - savanna) Open shrubland"
+      - Savanna and woody savanna:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning - savanna) Savanna and woody savanna"
+      - Closed and open shrubland:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning - savanna) Closed and open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning - savanna) Closed shrubland"
+    - Emissions (CO2eq) from CH4 (Burning crop residues):
+      - Maize:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Burning crop residues) All Crops"
+    - Emissions (CO2eq) from CH4 (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "emissions (co2eq) from ch4 (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (co2eq) from ch4 (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (co2eq) from ch4 (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (co2eq) from ch4 (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (CO2eq) from CH4 (Manure management) Sheep and Goats"
+    - Emissions (CO2eq) from N2O:
+      - Crop Residues:
+        - description:
+          - "Emissions (CO2eq) from N2O Crop Residues"
+      - Cultivation of Organic Soils:
+        - description:
+          - "Emissions (CO2eq) from N2O Cultivation of Organic Soils"
+      - Agriculture total:
+        - description:
+          - "Emissions (CO2eq) from N2O Agriculture total"
+      - Manure left on Pasture:
+        - description:
+          - "Emissions (CO2eq) from N2O Manure left on Pasture"
+      - Manure Management:
+        - description:
+          - "Emissions (CO2eq) from N2O Manure Management"
+      - Manure applied to Soils:
+        - description:
+          - "Emissions (CO2eq) from N2O Manure applied to Soils"
+      - Burning - Crop residues:
+        - description:
+          - "Emissions (CO2eq) from N2O Burning - Crop residues"
+      - Agricultural Soils:
+        - description:
+          - "Emissions (CO2eq) from N2O Agricultural Soils"
+      - Burning - Savanna:
+        - description:
+          - "Emissions (CO2eq) from N2O Burning - Savanna"
+    - Emissions (CO2eq) from N2O (Burning - savanna):
+      - Savanna:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning - savanna) Savanna"
+      - Burning - all categories:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning - savanna) Burning - all categories"
+      - Woody savanna:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning - savanna) Woody savanna"
+      - Grassland:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning - savanna) Grassland"
+      - Open shrubland:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning - savanna) Open shrubland"
+      - Savanna and woody savanna:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning - savanna) Savanna and woody savanna"
+      - Closed and open shrubland:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning - savanna) Closed and open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning - savanna) Closed shrubland"
+    - Emissions (CO2eq) from N2O (Burning crop residues):
+      - Maize:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Emissions (CO2eq) from N2O (Burning crop residues) All Crops"
+    - Emissions (CO2eq) from N2O (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "emissions (co2eq) from n2o (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (co2eq) from n2o (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (co2eq) from n2o (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (co2eq) from n2o (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (CO2eq) from N2O (Manure management) Sheep and Goats"
+    - Emissions (N2O) (Burning - savanna):
+      - Savanna:
+        - description:
+          - "Emissions (N2O) (Burning - savanna) Savanna"
+      - Burning - all categories:
+        - description:
+          - "Emissions (N2O) (Burning - savanna) Burning - all categories"
+      - Woody savanna:
+        - description:
+          - "Emissions (N2O) (Burning - savanna) Woody savanna"
+      - Grassland:
+        - description:
+          - "Emissions (N2O) (Burning - savanna) Grassland"
+      - Open shrubland:
+        - description:
+          - "Emissions (N2O) (Burning - savanna) Open shrubland"
+      - Savanna and woody savanna:
+        - description:
+          - "Emissions (N2O) (Burning - savanna) Savanna and woody savanna"
+      - Closed and open shrubland:
+        - description:
+          - "Emissions (N2O) (Burning - savanna) Closed and open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Emissions (N2O) (Burning - savanna) Closed shrubland"
+    - Emissions (N2O) (Burning crop residues):
+      - Maize:
+        - description:
+          - "Emissions (N2O) (Burning crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Emissions (N2O) (Burning crop residues) All Crops"
+    - Emissions (N2O) (Crop residues):
+      - Beans, dry:
+        - description:
+          - "emissions (n2o) (crop residues) dry beans"
+      - Sorghum:
+        - description:
+          - "Emissions (N2O) (Crop residues) Sorghum"
+      - Millet:
+        - description:
+          - "Emissions (N2O) (Crop residues) Millet"
+      - Maize:
+        - description:
+          - "Emissions (N2O) (Crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Emissions (N2O) (Crop residues) All Crops"
+    - Emissions (N2O) (Cultivation of organic soils):
+      - Grassland organic soils:
+        - description:
+          - "Emissions (N2O) (Cultivation of organic soils) Grassland organic soils"
+      - Cropland and grassland organic soils:
+        - description:
+          - "Emissions (N2O) (Cultivation of organic soils) Cropland and grassland organic\
+          \ soils"
+      - Cropland organic soils:
+        - description:
+          - "Emissions (N2O) (Cultivation of organic soils) Cropland organic soils"
+    - Emissions (N2O) (Manure applied):
+      - Chickens, broilers:
+        - description:
+          - "emissions (n2o) (manure applied) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (N2O) (Manure applied) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (N2O) (Manure applied) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (N2O) (Manure applied) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (N2O) (Manure applied) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (n2o) (manure applied) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (N2O) (Manure applied) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (N2O) (Manure applied) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (N2O) (Manure applied) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (n2o) (manure applied) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (N2O) (Manure applied) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (n2o) (manure applied) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (N2O) (Manure applied) Sheep and Goats"
+    - Emissions (N2O) (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "emissions (n2o) (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (N2O) (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (N2O) (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (N2O) (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (N2O) (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (n2o) (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (N2O) (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (N2O) (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (N2O) (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (n2o) (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (N2O) (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (n2o) (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (N2O) (Manure management) Sheep and Goats"
+    - Emissions (N2O) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "emissions (n2o) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "emissions (n2o) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "emissions (n2o) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "emissions (n2o) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Emissions (N2O) (Manure on pasture) Sheep and Goats"
+    - Emissions intensity:
+      - Milk, whole fresh goat:
+        - description:
+          - "Emissions intensity Milk, whole fresh goat"
+      - Meat, chicken:
+        - description:
+          - "emissions intensity chicken meat"
+      - Meat, cattle:
+        - description:
+          - "emissions intensity cattle meat"
+      - Milk, whole fresh sheep:
+        - description:
+          - "Emissions intensity Milk, whole fresh sheep"
+      - Meat, sheep:
+        - description:
+          - "emissions intensity sheep meat"
+      - Cereals excluding rice:
+        - description:
+          - "Emissions intensity Cereals excluding rice"
+      - Milk, whole fresh cow:
+        - description:
+          - "Emissions intensity Milk, whole fresh cow"
+      - Meat, goat:
+        - description:
+          - "emissions intensity goat meat"
+    - Export Quantity:
+      - Industrial roundwood:
+        - description:
+          - "Export Quantity Industrial roundwood"
+      - Industrial roundwood, non-coniferous tropical (export/import):
+        - description:
+          - "Export Quantity Industrial roundwood, non-coniferous tropical (export/import)"
+      - Industrial roundwood, non-coniferous:
+        - description:
+          - "Export Quantity Industrial roundwood, non-coniferous"
+      - Sawnwood:
+        - description:
+          - "Export Quantity Sawnwood"
+      - Roundwood:
+        - description:
+          - "Export Quantity Roundwood"
+      - Sawnwood, non-coniferous all:
+        - description:
+          - "Export Quantity Sawnwood, non-coniferous all"
+    - Export Value:
+      - Industrial roundwood:
+        - description:
+          - "Export Value Industrial roundwood"
+      - Industrial roundwood, non-coniferous tropical (export/import):
+        - description:
+          - "Export Value Industrial roundwood, non-coniferous tropical (export/import)"
+      - Industrial roundwood, non-coniferous:
+        - description:
+          - "Export Value Industrial roundwood, non-coniferous"
+      - Sawnwood:
+        - description:
+          - "Export Value Sawnwood"
+      - Roundwood:
+        - description:
+          - "Export Value Roundwood"
+      - Sawnwood, non-coniferous all:
+        - description:
+          - "Export Value Sawnwood, non-coniferous all"
+      - Forest products (export/import):
+        - description:
+          - "Export Value Forest products (export/import)"
+    - Food aid shipments:
+      - Edible Fat Total:
+        - description:
+          - "Food aid shipments Edible Fat Total"
+      - Other Non-Cereals:
+        - description:
+          - "Food aid shipments Other Non-Cereals"
+      - Milk,Total:
+        - description:
+          - "Food aid shipments Milk,Total"
+      - Cereals:
+        - description:
+          - "Food aid shipments Cereals"
+      - Non-Cereals:
+        - description:
+          - "Food aid shipments Non-Cereals"
+      - Coarse Grains:
+        - description:
+          - "Food aid shipments Coarse Grains"
+      - Blended And Mix:
+        - description:
+          - "Food aid shipments Blended And Mix"
+      - Rice Total:
+        - description:
+          - "Food aid shipments Rice Total"
+      - Vegetable Oils:
+        - description:
+          - "Food aid shipments Vegetable Oils"
+      - Sugar Total:
+        - description:
+          - "Food aid shipments Sugar Total"
+      - Pulses,Total:
+        - description:
+          - "Food aid shipments Pulses,Total"
+    - Gross Production Value (constant 2004-2006 1000 I$):
+      - Pineapples:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Pineapples"
+      - Tangerines, mandarins, clementines, satsumas:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Tangerines, mandarins,\
+          \ clementines, satsumas"
+      - Pulses, nes:
+        - description:
+          - "gross production value (constant 2004-2006 1000 i$) ne pulses"
+      - Oilcrops Primary:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Oilcrops Primary"
+      - Cereals,Total:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Cereals,Total"
+      - Livestock (PIN):
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Livestock (PIN)"
+      - Fruit, fresh nes:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Fruit, fresh nes"
+      - Meat, game:
+        - description:
+          - "gross production value (constant 2004-2006 1000 i$) game meat"
+      - Onions, shallots, green:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Onions, shallots, green"
+      - Maize:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Maize"
+      - Food (PIN):
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Food (PIN)"
+      - Honey, natural:
+        - description:
+          - "gross production value (constant 2004-2006 1000 i$) natural honey"
+      - Meat indigenous, total:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Meat indigenous, total"
+      - Melonseed:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Melonseed"
+      - Milk,Total:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Milk,Total"
+      - Sesame seed:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Sesame seed"
+      - Beeswax:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Beeswax"
+      - Oilseeds nes:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Oilseeds nes"
+      - Melons, other (inc.cantaloupes):
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Melons, other (inc.cantaloupes)"
+      - Beans, green:
+        - description:
+          - "gross production value (constant 2004-2006 1000 i$) green beans"
+      - Non Food (PIN):
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Non Food (PIN)"
+      - Pumpkins, squash and gourds:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Pumpkins, squash and\
+          \ gourds"
+      - Milk, whole fresh cow:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Milk, whole fresh cow"
+      - Peas, green:
+        - description:
+          - "gross production value (constant 2004-2006 1000 i$) green peas"
+      - Crops (PIN):
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Crops (PIN)"
+      - Milk, whole fresh goat:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Milk, whole fresh goat"
+      - Agriculture (PIN):
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Agriculture (PIN)"
+      - Vegetables and Fruit Primary:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Vegetables and Fruit\
+          \ Primary"
+      - Roots and Tubers,Total:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Roots and Tubers,Total"
+      - Sunflower seed:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Sunflower seed"
+      - Jute:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Jute"
+      - Millet:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Millet"
+      - Cottonseed:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Cottonseed"
+      - Chillies and peppers, dry:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Chillies and peppers,\
+          \ dry"
+      - Fruit, tropical fresh nes:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Fruit, tropical fresh\
+          \ nes"
+      - Groundnuts, with shell:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Groundnuts, with shell"
+      - Yams:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Yams"
+      - Cotton lint:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Cotton lint"
+      - Beans, dry:
+        - description:
+          - "gross production value (constant 2004-2006 1000 i$) dry beans"
+      - Cassava:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Cassava"
+      - Sorghum:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Sorghum"
+      - Milk, whole fresh sheep:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Milk, whole fresh sheep"
+      - Vegetables, fresh nes:
+        - description:
+          - "Gross Production Value (constant 2004-2006 1000 I$) Vegetables, fresh nes"
+    - Implied emission factor for CH4 (Burning - savanna):
+      - Savanna:
+        - description:
+          - "Implied emission factor for CH4 (Burning - savanna) Savanna"
+      - Woody savanna:
+        - description:
+          - "Implied emission factor for CH4 (Burning - savanna) Woody savanna"
+      - Grassland:
+        - description:
+          - "Implied emission factor for CH4 (Burning - savanna) Grassland"
+      - Open shrubland:
+        - description:
+          - "Implied emission factor for CH4 (Burning - savanna) Open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Implied emission factor for CH4 (Burning - savanna) Closed shrubland"
+    - Implied emission factor for CH4 (Burning crop residues):
+      - Maize:
+        - description:
+          - "Implied emission factor for CH4 (Burning crop residues) Maize"
+    - Implied emission factor for CH4 (Enteric):
+      - Goats:
+        - description:
+          - "Implied emission factor for CH4 (Enteric) Goats"
+      - Sheep:
+        - description:
+          - "Implied emission factor for CH4 (Enteric) Sheep"
+      - Asses:
+        - description:
+          - "Implied emission factor for CH4 (Enteric) Asses"
+      - Cattle, dairy:
+        - description:
+          - "implied emission factor for ch4 (enteric) dairy cattle"
+      - Cattle, non-dairy:
+        - description:
+          - "implied emission factor for ch4 (enteric) non-dairy cattle"
+    - Implied emission factor for CH4 (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "implied emission factor for ch4 (manure management) broiler chickens"
+      - Goats:
+        - description:
+          - "Implied emission factor for CH4 (Manure management) Goats"
+      - Sheep:
+        - description:
+          - "Implied emission factor for CH4 (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "implied emission factor for ch4 (manure management) layer chickens"
+      - Asses:
+        - description:
+          - "Implied emission factor for CH4 (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "implied emission factor for ch4 (manure management) dairy cattle"
+      - Cattle, non-dairy:
+        - description:
+          - "implied emission factor for ch4 (manure management) non-dairy cattle"
+    - Implied emission factor for N2O (Burning - savanna):
+      - Savanna:
+        - description:
+          - "Implied emission factor for N2O (Burning - savanna) Savanna"
+      - Woody savanna:
+        - description:
+          - "Implied emission factor for N2O (Burning - savanna) Woody savanna"
+      - Grassland:
+        - description:
+          - "Implied emission factor for N2O (Burning - savanna) Grassland"
+      - Open shrubland:
+        - description:
+          - "Implied emission factor for N2O (Burning - savanna) Open shrubland"
+      - Closed shrubland:
+        - description:
+          - "Implied emission factor for N2O (Burning - savanna) Closed shrubland"
+    - Implied emission factor for N2O (Burning crop residues):
+      - Maize:
+        - description:
+          - "Implied emission factor for N2O (Burning crop residues) Maize"
+    - Implied emission factor for N2O (Crop residues):
+      - Millet:
+        - description:
+          - "Implied emission factor for N2O (Crop residues) Millet"
+      - Maize:
+        - description:
+          - "Implied emission factor for N2O (Crop residues) Maize"
+      - Sorghum:
+        - description:
+          - "Implied emission factor for N2O (Crop residues) Sorghum"
+      - Beans, dry:
+        - description:
+          - "implied emission factor for n2o (crop residues) dry beans"
+    - Implied emission factor for N2O (Cultivation of organic soils):
+      - Grassland organic soils:
+        - description:
+          - "Implied emission factor for N2O (Cultivation of organic soils) Grassland\
+          \ organic soils"
+      - Cropland organic soils:
+        - description:
+          - "Implied emission factor for N2O (Cultivation of organic soils) Cropland organic\
+          \ soils"
+    - Implied emission factor for N2O (Manure applied):
+      - Chickens, broilers:
+        - description:
+          - "implied emission factor for n2o (manure applied) broiler chickens"
+      - Goats:
+        - description:
+          - "Implied emission factor for N2O (Manure applied) Goats"
+      - Sheep:
+        - description:
+          - "Implied emission factor for N2O (Manure applied) Sheep"
+      - Chickens, layers:
+        - description:
+          - "implied emission factor for n2o (manure applied) layer chickens"
+      - Asses:
+        - description:
+          - "Implied emission factor for N2O (Manure applied) Asses"
+      - Cattle, dairy:
+        - description:
+          - "implied emission factor for n2o (manure applied) dairy cattle"
+      - Cattle, non-dairy:
+        - description:
+          - "implied emission factor for n2o (manure applied) non-dairy cattle"
+    - Implied emission factor for N2O (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "implied emission factor for n2o (manure management) broiler chickens"
+      - Goats:
+        - description:
+          - "Implied emission factor for N2O (Manure management) Goats"
+      - Sheep:
+        - description:
+          - "Implied emission factor for N2O (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "implied emission factor for n2o (manure management) layer chickens"
+      - Asses:
+        - description:
+          - "Implied emission factor for N2O (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "implied emission factor for n2o (manure management) dairy cattle"
+      - Cattle, non-dairy:
+        - description:
+          - "implied emission factor for n2o (manure management) non-dairy cattle"
+    - Implied emission factor for N2O (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "implied emission factor for n2o (manure on pasture) broiler chickens"
+      - Goats:
+        - description:
+          - "Implied emission factor for N2O (Manure on pasture) Goats"
+      - Sheep:
+        - description:
+          - "Implied emission factor for N2O (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "implied emission factor for n2o (manure on pasture) layer chickens"
+      - Asses:
+        - description:
+          - "Implied emission factor for N2O (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "implied emission factor for n2o (manure on pasture) dairy cattle"
+      - Cattle, non-dairy:
+        - description:
+          - "implied emission factor for n2o (manure on pasture) non-dairy cattle"
+    - Import Quantity:
+      - Paper and paperboard:
+        - description:
+          - "Import Quantity Paper and paperboard"
+      - Graphic papers:
+        - description:
+          - "Import Quantity Graphic papers"
+      - Plywood:
+        - description:
+          - "Import Quantity Plywood"
+      - Other paper and paperboard n.e.s. (not elsewhere specified):
+        - description:
+          - "Import Quantity Other paper and paperboard n.e.s. (not elsewhere specified)"
+      - Printing and writing papers, uncoated, wood free:
+        - description:
+          - "Import Quantity Printing and writing papers, uncoated, wood free"
+      - Printing and writing papers, coated:
+        - description:
+          - "Import Quantity Printing and writing papers, coated"
+      - Other paper and paperboard:
+        - description:
+          - "Import Quantity Other paper and paperboard"
+      - Sawnwood:
+        - description:
+          - "Import Quantity Sawnwood"
+      - Household and sanitary papers:
+        - description:
+          - "Import Quantity Household and sanitary papers"
+      - Wood-based panels:
+        - description:
+          - "Import Quantity Wood-based panels"
+      - Fibreboard:
+        - description:
+          - "Import Quantity Fibreboard"
+      - Sawnwood, coniferous:
+        - description:
+          - "import quantity coniferou sawnwood"
+      - Printing and writing papers, uncoated, mechanical:
+        - description:
+          - "Import Quantity Printing and writing papers, uncoated, mechanical"
+      - Paper and paperboard, excluding newsprint:
+        - description:
+          - "Import Quantity Paper and paperboard, excluding newsprint"
+      - MDF/HDF:
+        - description:
+          - "Import Quantity MDF/HDF"
+      - Printing and writing papers:
+        - description:
+          - "Import Quantity Printing and writing papers"
+    - Import Value:
+      - Paper and paperboard:
+        - description:
+          - "Import Value Paper and paperboard"
+      - Graphic papers:
+        - description:
+          - "Import Value Graphic papers"
+      - Plywood:
+        - description:
+          - "Import Value Plywood"
+      - Other paper and paperboard n.e.s. (not elsewhere specified):
+        - description:
+          - "Import Value Other paper and paperboard n.e.s. (not elsewhere specified)"
+      - Printing and writing papers, uncoated, wood free:
+        - description:
+          - "Import Value Printing and writing papers, uncoated, wood free"
+      - Printing and writing papers, coated:
+        - description:
+          - "Import Value Printing and writing papers, coated"
+      - Other paper and paperboard:
+        - description:
+          - "Import Value Other paper and paperboard"
+      - Sawnwood:
+        - description:
+          - "Import Value Sawnwood"
+      - Household and sanitary papers:
+        - description:
+          - "Import Value Household and sanitary papers"
+      - Wood-based panels:
+        - description:
+          - "Import Value Wood-based panels"
+      - Fibreboard:
+        - description:
+          - "Import Value Fibreboard"
+      - Sawnwood, coniferous:
+        - description:
+          - "import value coniferou sawnwood"
+      - Printing and writing papers, uncoated, mechanical:
+        - description:
+          - "Import Value Printing and writing papers, uncoated, mechanical"
+      - Paper and paperboard, excluding newsprint:
+        - description:
+          - "Import Value Paper and paperboard, excluding newsprint"
+      - MDF/HDF:
+        - description:
+          - "Import Value MDF/HDF"
+      - Forest products (export/import):
+        - description:
+          - "Import Value Forest products (export/import)"
+      - Printing and writing papers:
+        - description:
+          - "Import Value Printing and writing papers"
+    - Indirect emissions (CO2eq) (Crop residues):
+      - Beans, dry:
+        - description:
+          - "indirect emissions (co2eq) (crop residues) dry beans"
+      - Sorghum:
+        - description:
+          - "Indirect emissions (CO2eq) (Crop residues) Sorghum"
+      - Millet:
+        - description:
+          - "Indirect emissions (CO2eq) (Crop residues) Millet"
+      - Maize:
+        - description:
+          - "Indirect emissions (CO2eq) (Crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Indirect emissions (CO2eq) (Crop residues) All Crops"
+    - Indirect emissions (CO2eq) (Manure applied):
+      - Chickens, broilers:
+        - description:
+          - "indirect emissions (co2eq) (manure applied) broiler chickens"
+      - Cattle:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) Cattle"
+      - Goats:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) Goats"
+      - Poultry Birds:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) Sheep"
+      - Chickens, layers:
+        - description:
+          - "indirect emissions (co2eq) (manure applied) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) All Animals"
+      - Asses:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) Asses"
+      - Cattle, dairy:
+        - description:
+          - "indirect emissions (co2eq) (manure applied) dairy cattle"
+      - Chickens:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "indirect emissions (co2eq) (manure applied) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure applied) Sheep and Goats"
+    - Indirect emissions (CO2eq) (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "indirect emissions (co2eq) (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "indirect emissions (co2eq) (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "indirect emissions (co2eq) (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "indirect emissions (co2eq) (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure management) Sheep and Goats"
+    - Indirect emissions (CO2eq) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "indirect emissions (co2eq) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "indirect emissions (co2eq) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "indirect emissions (co2eq) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "indirect emissions (co2eq) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Indirect emissions (CO2eq) (Manure on pasture) Sheep and Goats"
+    - Indirect emissions (N2O that leaches) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "indirect emissions (n2o that leaches) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "indirect emissions (n2o that leaches) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "indirect emissions (n2o that leaches) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "indirect emissions (n2o that leaches) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Indirect emissions (N2O that leaches) (Manure on pasture) Sheep and Goats"
+    - Indirect emissions (N2O that volatilises) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "indirect emissions (n2o that volatilises) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "indirect emissions (n2o that volatilises) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "indirect emissions (n2o that volatilises) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "indirect emissions (n2o that volatilises) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Indirect emissions (N2O that volatilises) (Manure on pasture) Sheep and Goats"
+    - Indirect emissions (N2O) (Crop residues):
+      - Beans, dry:
+        - description:
+          - "indirect emissions (n2o) (crop residues) dry beans"
+      - Sorghum:
+        - description:
+          - "Indirect emissions (N2O) (Crop residues) Sorghum"
+      - Millet:
+        - description:
+          - "Indirect emissions (N2O) (Crop residues) Millet"
+      - Maize:
+        - description:
+          - "Indirect emissions (N2O) (Crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Indirect emissions (N2O) (Crop residues) All Crops"
+    - Indirect emissions (N2O) (Manure applied):
+      - Chickens, broilers:
+        - description:
+          - "indirect emissions (n2o) (manure applied) broiler chickens"
+      - Cattle:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) Cattle"
+      - Goats:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) Goats"
+      - Poultry Birds:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) Sheep"
+      - Chickens, layers:
+        - description:
+          - "indirect emissions (n2o) (manure applied) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) All Animals"
+      - Asses:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) Asses"
+      - Cattle, dairy:
+        - description:
+          - "indirect emissions (n2o) (manure applied) dairy cattle"
+      - Chickens:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "indirect emissions (n2o) (manure applied) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Indirect emissions (N2O) (Manure applied) Sheep and Goats"
+    - Indirect emissions (N2O) (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "indirect emissions (n2o) (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "indirect emissions (n2o) (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "indirect emissions (n2o) (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "indirect emissions (n2o) (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Indirect emissions (N2O) (Manure management) Sheep and Goats"
+    - Indirect emissions (N2O) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "indirect emissions (n2o) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "indirect emissions (n2o) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "indirect emissions (n2o) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "indirect emissions (n2o) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Indirect emissions (N2O) (Manure on pasture) Sheep and Goats"
+    - Laying:
+      - Eggs, hen, in shell:
+        - description:
+          - "Laying Eggs, hen, in shell"
+      - Eggs Primary:
+        - description:
+          - "Laying Eggs Primary"
+    - Losses from manure treated (N content):
+      - Chickens, broilers:
+        - description:
+          - "losses from manure treated (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Losses from manure treated (N content) Cattle"
+      - Goats:
+        - description:
+          - "Losses from manure treated (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Losses from manure treated (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Losses from manure treated (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "losses from manure treated (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Losses from manure treated (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Losses from manure treated (N content) All Animals"
+      - Asses:
+        - description:
+          - "Losses from manure treated (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "losses from manure treated (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Losses from manure treated (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "losses from manure treated (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Losses from manure treated (N content) Sheep and Goats"
+    - Manure (N content that leaches) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "manure (n content that leaches) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure (n content that leaches) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure (n content that leaches) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure (n content that leaches) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure (N content that leaches) (Manure on pasture) Sheep and Goats"
+    - Manure (N content that volatilises) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "manure (n content that volatilises) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure (n content that volatilises) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure (n content that volatilises) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure (n content that volatilises) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure (N content that volatilises) (Manure on pasture) Sheep and Goats"
+    - Manure (N content) (Manure applied):
+      - Chickens, broilers:
+        - description:
+          - "manure (n content) (manure applied) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure (N content) (Manure applied) Cattle"
+      - Goats:
+        - description:
+          - "Manure (N content) (Manure applied) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure (N content) (Manure applied) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure (N content) (Manure applied) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure (n content) (manure applied) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure (N content) (Manure applied) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure (N content) (Manure applied) All Animals"
+      - Asses:
+        - description:
+          - "Manure (N content) (Manure applied) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure (n content) (manure applied) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure (N content) (Manure applied) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure (n content) (manure applied) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure (N content) (Manure applied) Sheep and Goats"
+    - Manure (N content) (Manure management):
+      - Chickens, broilers:
+        - description:
+          - "manure (n content) (manure management) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure (N content) (Manure management) Cattle"
+      - Goats:
+        - description:
+          - "Manure (N content) (Manure management) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure (N content) (Manure management) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure (N content) (Manure management) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure (n content) (manure management) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure (N content) (Manure management) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure (N content) (Manure management) All Animals"
+      - Asses:
+        - description:
+          - "Manure (N content) (Manure management) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure (n content) (manure management) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure (N content) (Manure management) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure (n content) (manure management) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure (N content) (Manure management) Sheep and Goats"
+    - Manure (N content) (Manure on pasture):
+      - Chickens, broilers:
+        - description:
+          - "manure (n content) (manure on pasture) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure (N content) (Manure on pasture) Cattle"
+      - Goats:
+        - description:
+          - "Manure (N content) (Manure on pasture) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure (N content) (Manure on pasture) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure (N content) (Manure on pasture) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure (n content) (manure on pasture) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure (N content) (Manure on pasture) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure (N content) (Manure on pasture) All Animals"
+      - Asses:
+        - description:
+          - "Manure (N content) (Manure on pasture) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure (n content) (manure on pasture) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure (N content) (Manure on pasture) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure (n content) (manure on pasture) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure (N content) (Manure on pasture) Sheep and Goats"
+    - Manure applied to soils (N content):
+      - Chickens, broilers:
+        - description:
+          - "manure applied to soils (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure applied to soils (N content) Cattle"
+      - Goats:
+        - description:
+          - "Manure applied to soils (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure applied to soils (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure applied to soils (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure applied to soils (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure applied to soils (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure applied to soils (N content) All Animals"
+      - Asses:
+        - description:
+          - "Manure applied to soils (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure applied to soils (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure applied to soils (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure applied to soils (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure applied to soils (N content) Sheep and Goats"
+    - Manure applied to soils that leaches (N content):
+      - Chickens, broilers:
+        - description:
+          - "manure applied to soils that leaches (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure applied to soils that leaches (N content) Cattle"
+      - Goats:
+        - description:
+          - "Manure applied to soils that leaches (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure applied to soils that leaches (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure applied to soils that leaches (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure applied to soils that leaches (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure applied to soils that leaches (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure applied to soils that leaches (N content) All Animals"
+      - Asses:
+        - description:
+          - "Manure applied to soils that leaches (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure applied to soils that leaches (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure applied to soils that leaches (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure applied to soils that leaches (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure applied to soils that leaches (N content) Sheep and Goats"
+    - Manure applied to soils that volatilises (N content):
+      - Chickens, broilers:
+        - description:
+          - "manure applied to soils that volatilises (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure applied to soils that volatilises (N content) Cattle"
+      - Goats:
+        - description:
+          - "Manure applied to soils that volatilises (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure applied to soils that volatilises (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure applied to soils that volatilises (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure applied to soils that volatilises (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure applied to soils that volatilises (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure applied to soils that volatilises (N content) All Animals"
+      - Asses:
+        - description:
+          - "Manure applied to soils that volatilises (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure applied to soils that volatilises (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure applied to soils that volatilises (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure applied to soils that volatilises (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure applied to soils that volatilises (N content) Sheep and Goats"
+    - Manure left on pasture (N content):
+      - Chickens, broilers:
+        - description:
+          - "manure left on pasture (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure left on pasture (N content) Cattle"
+      - Goats:
+        - description:
+          - "Manure left on pasture (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure left on pasture (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure left on pasture (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure left on pasture (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure left on pasture (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure left on pasture (N content) All Animals"
+      - Asses:
+        - description:
+          - "Manure left on pasture (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure left on pasture (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure left on pasture (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure left on pasture (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure left on pasture (N content) Sheep and Goats"
+    - Manure left on pasture that leaches (N content):
+      - Chickens, broilers:
+        - description:
+          - "manure left on pasture that leaches (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure left on pasture that leaches (N content) Cattle"
+      - Goats:
+        - description:
+          - "Manure left on pasture that leaches (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure left on pasture that leaches (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure left on pasture that leaches (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure left on pasture that leaches (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure left on pasture that leaches (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure left on pasture that leaches (N content) All Animals"
+      - Asses:
+        - description:
+          - "Manure left on pasture that leaches (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure left on pasture that leaches (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure left on pasture that leaches (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure left on pasture that leaches (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure left on pasture that leaches (N content) Sheep and Goats"
+    - Manure left on pasture that volatilises (N content):
+      - Chickens, broilers:
+        - description:
+          - "manure left on pasture that volatilises (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure left on pasture that volatilises (N content) Cattle"
+      - Goats:
+        - description:
+          - "Manure left on pasture that volatilises (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure left on pasture that volatilises (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure left on pasture that volatilises (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure left on pasture that volatilises (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure left on pasture that volatilises (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure left on pasture that volatilises (N content) All Animals"
+      - Asses:
+        - description:
+          - "Manure left on pasture that volatilises (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure left on pasture that volatilises (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure left on pasture that volatilises (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure left on pasture that volatilises (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure left on pasture that volatilises (N content) Sheep and Goats"
+    - Manure treated (N content):
+      - Chickens, broilers:
+        - description:
+          - "manure treated (n content) broiler chickens"
+      - Cattle:
+        - description:
+          - "Manure treated (N content) Cattle"
+      - Goats:
+        - description:
+          - "Manure treated (N content) Goats"
+      - Poultry Birds:
+        - description:
+          - "Manure treated (N content) Poultry Birds"
+      - Sheep:
+        - description:
+          - "Manure treated (N content) Sheep"
+      - Chickens, layers:
+        - description:
+          - "manure treated (n content) layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Manure treated (N content) Mules and Asses"
+      - All Animals:
+        - description:
+          - "Manure treated (N content) All Animals"
+      - Asses:
+        - description:
+          - "Manure treated (N content) Asses"
+      - Cattle, dairy:
+        - description:
+          - "manure treated (n content) dairy cattle"
+      - Chickens:
+        - description:
+          - "Manure treated (N content) Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "manure treated (n content) non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Manure treated (N content) Sheep and Goats"
+    - Milk Animals:
+      - Milk, whole fresh camel:
+        - description:
+          - "Milk Animals Milk, whole fresh camel"
+      - Milk, whole fresh goat:
+        - description:
+          - "Milk Animals Milk, whole fresh goat"
+      - Milk,Total:
+        - description:
+          - "Milk Animals Milk,Total"
+      - Milk, whole fresh sheep:
+        - description:
+          - "Milk Animals Milk, whole fresh sheep"
+      - Milk, whole fresh cow:
+        - description:
+          - "Milk Animals Milk, whole fresh cow"
+    - Net Production Value (constant 2004-2006 1000 I$):
+      - Pineapples:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Pineapples"
+      - Tangerines, mandarins, clementines, satsumas:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Tangerines, mandarins,\
+          \ clementines, satsumas"
+      - Pulses, nes:
+        - description:
+          - "net production value (constant 2004-2006 1000 i$) ne pulses"
+      - Oilcrops Primary:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Oilcrops Primary"
+      - Cereals,Total:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Cereals,Total"
+      - Livestock (PIN):
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Livestock (PIN)"
+      - Fruit, fresh nes:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Fruit, fresh nes"
+      - Meat, game:
+        - description:
+          - "net production value (constant 2004-2006 1000 i$) game meat"
+      - Onions, shallots, green:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Onions, shallots, green"
+      - Maize:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Maize"
+      - Food (PIN):
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Food (PIN)"
+      - Honey, natural:
+        - description:
+          - "net production value (constant 2004-2006 1000 i$) natural honey"
+      - Meat indigenous, total:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Meat indigenous, total"
+      - Melonseed:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Melonseed"
+      - Milk,Total:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Milk,Total"
+      - Sesame seed:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Sesame seed"
+      - Beeswax:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Beeswax"
+      - Oilseeds nes:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Oilseeds nes"
+      - Melons, other (inc.cantaloupes):
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Melons, other (inc.cantaloupes)"
+      - Beans, green:
+        - description:
+          - "net production value (constant 2004-2006 1000 i$) green beans"
+      - Non Food (PIN):
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Non Food (PIN)"
+      - Pumpkins, squash and gourds:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Pumpkins, squash and gourds"
+      - Milk, whole fresh cow:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Milk, whole fresh cow"
+      - Peas, green:
+        - description:
+          - "net production value (constant 2004-2006 1000 i$) green peas"
+      - Crops (PIN):
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Crops (PIN)"
+      - Milk, whole fresh goat:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Milk, whole fresh goat"
+      - Agriculture (PIN):
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Agriculture (PIN)"
+      - Vegetables and Fruit Primary:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Vegetables and Fruit Primary"
+      - Roots and Tubers,Total:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Roots and Tubers,Total"
+      - Sunflower seed:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Sunflower seed"
+      - Jute:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Jute"
+      - Millet:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Millet"
+      - Cottonseed:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Cottonseed"
+      - Chillies and peppers, dry:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Chillies and peppers, dry"
+      - Fruit, tropical fresh nes:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Fruit, tropical fresh nes"
+      - Groundnuts, with shell:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Groundnuts, with shell"
+      - Yams:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Yams"
+      - Cotton lint:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Cotton lint"
+      - Beans, dry:
+        - description:
+          - "net production value (constant 2004-2006 1000 i$) dry beans"
+      - Cassava:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Cassava"
+      - Sorghum:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Sorghum"
+      - Milk, whole fresh sheep:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Milk, whole fresh sheep"
+      - Vegetables, fresh nes:
+        - description:
+          - "Net Production Value (constant 2004-2006 1000 I$) Vegetables, fresh nes"
+    - Producing Animals/Slaughtered:
+      - Skins, sheep, with wool:
+        - description:
+          - "Producing Animals/Slaughtered Skins, sheep, with wool"
+      - Skins, goat, fresh:
+        - description:
+          - "Producing Animals/Slaughtered Skins, goat, fresh"
+      - Meat, chicken:
+        - description:
+          - "producing animals/slaughtered chicken meat"
+      - Sheep and Goat Meat:
+        - description:
+          - "Producing Animals/Slaughtered Sheep and Goat Meat"
+      - Meat, Poultry:
+        - description:
+          - "producing animals/slaughtered poultry meat"
+      - Hides, cattle, fresh:
+        - description:
+          - "Producing Animals/Slaughtered Hides, cattle, fresh"
+      - Beef and Buffalo Meat:
+        - description:
+          - "Producing Animals/Slaughtered Beef and Buffalo Meat"
+      - Meat, camel:
+        - description:
+          - "producing animals/slaughtered camel meat"
+      - Meat, cattle:
+        - description:
+          - "producing animals/slaughtered cattle meat"
+      - Meat, sheep:
+        - description:
+          - "producing animals/slaughtered sheep meat"
+      - Skins, sheep, fresh:
+        - description:
+          - "Producing Animals/Slaughtered Skins, sheep, fresh"
+      - Meat, goat:
+        - description:
+          - "producing animals/slaughtered goat meat"
+    - Production:
+      - Vegetables Primary:
+        - description:
+          - "Production Vegetables Primary"
+      - Wool, greasy:
+        - description:
+          - "production greasy wool"
+      - Meat, chicken:
+        - description:
+          - "production chicken meat"
+      - Oilcrops, Oil Equivalent:
+        - description:
+          - "Production Oilcrops, Oil Equivalent"
+      - Meat, game:
+        - description:
+          - "production game meat"
+      - Onions, shallots, green:
+        - description:
+          - "Production Onions, shallots, green"
+      - Maize:
+        - description:
+          - "Production Maize"
+      - Carrots and turnips:
+        - description:
+          - "Production Carrots and turnips"
+      - Wood fuel, non-coniferous (production):
+        - description:
+          - "Production Wood fuel, non-coniferous (production)"
+      - Coarse Grain, Total:
+        - description:
+          - "Production Coarse Grain, Total"
+      - Meat indigenous, goat:
+        - description:
+          - "Production Meat indigenous, goat"
+      - Cheese, sheep milk:
+        - description:
+          - "Production Cheese, sheep milk"
+      - Milk, whole fresh cow:
+        - description:
+          - "Production Milk, whole fresh cow"
+      - Cow peas, dry:
+        - description:
+          - "Production Cow peas, dry"
+      - Hides, cattle, fresh:
+        - description:
+          - "Production Hides, cattle, fresh"
+      - Beer of barley:
+        - description:
+          - "Production Beer of barley"
+      - Cheese of goat mlk:
+        - description:
+          - "Production Cheese of goat mlk"
+      - Millet:
+        - description:
+          - "Production Millet"
+      - Milk, skimmed cow:
+        - description:
+          - "Production Milk, skimmed cow"
+      - Meat, goat:
+        - description:
+          - "production goat meat"
+      - Roundwood, coniferous (production):
+        - description:
+          - "Production Roundwood, coniferous (production)"
+      - Eggplants (aubergines):
+        - description:
+          - "Production Eggplants (aubergines)"
+      - Meat indigenous, chicken:
+        - description:
+          - "Production Meat indigenous, chicken"
+      - Oil, cottonseed:
+        - description:
+          - "production cottonseed oil"
+      - Sorghum:
+        - description:
+          - "Production Sorghum"
+      - Chillies and peppers, green:
+        - description:
+          - "Production Chillies and peppers, green"
+      - Sheep and Goat Meat:
+        - description:
+          - "Production Sheep and Goat Meat"
+      - Garlic:
+        - description:
+          - "Production Garlic"
+      - Meat indigenous, poultry:
+        - description:
+          - "Production Meat indigenous, poultry"
+      - Mangoes, mangosteens, guavas:
+        - description:
+          - "Production Mangoes, mangosteens, guavas"
+      - Pineapples:
+        - description:
+          - "Production Pineapples"
+      - Cabbages and other brassicas:
+        - description:
+          - "Production Cabbages and other brassicas"
+      - Okra:
+        - description:
+          - "Production Okra"
+      - Meat, camel:
+        - description:
+          - "production camel meat"
+      - Meat, cattle:
+        - description:
+          - "production cattle meat"
+      - Citrus Fruit,Total:
+        - description:
+          - "production total citrus fruit"
+      - Roundwood, non-coniferous (production):
+        - description:
+          - "Production Roundwood, non-coniferous (production)"
+      - Cauliflowers and broccoli:
+        - description:
+          - "Production Cauliflowers and broccoli"
+      - Onions, dry:
+        - description:
+          - "production dry onions"
+      - Honey, natural:
+        - description:
+          - "production natural honey"
+      - Oil, sesame:
+        - description:
+          - "production sesame oil"
+      - Meat indigenous, total:
+        - description:
+          - "Production Meat indigenous, total"
+      - Melonseed:
+        - description:
+          - "Production Melonseed"
+      - Oilseeds nes:
+        - description:
+          - "Production Oilseeds nes"
+      - Meat indigenous, camel:
+        - description:
+          - "Production Meat indigenous, camel"
+      - Roundwood:
+        - description:
+          - "Production Roundwood"
+      - Peas, green:
+        - description:
+          - "production green peas"
+      - Sweet potatoes:
+        - description:
+          - "Production Sweet potatoes"
+      - Milk, whole fresh camel:
+        - description:
+          - "Production Milk, whole fresh camel"
+      - Sugar Raw Centrifugal:
+        - description:
+          - "Production Sugar Raw Centrifugal"
+      - Meat, sheep:
+        - description:
+          - "production sheep meat"
+      - Cereals excluding rice:
+        - description:
+          - "Production Cereals excluding rice"
+      - Fibre Crops Primary:
+        - description:
+          - "Production Fibre Crops Primary"
+      - Fruit, tropical fresh nes:
+        - description:
+          - "Production Fruit, tropical fresh nes"
+      - Groundnuts, with shell:
+        - description:
+          - "Production Groundnuts, with shell"
+      - Wood fuel, coniferous (production):
+        - description:
+          - "Production Wood fuel, coniferous (production)"
+      - Pulses,Total:
+        - description:
+          - "Production Pulses,Total"
+      - Vegetables, fresh nes:
+        - description:
+          - "Production Vegetables, fresh nes"
+      - Meat, Total:
+        - description:
+          - "production total meat"
+      - Tangerines, mandarins, clementines, satsumas:
+        - description:
+          - "Production Tangerines, mandarins, clementines, satsumas"
+      - Pulses, nes:
+        - description:
+          - "production ne pulses"
+      - Fruit, fresh nes:
+        - description:
+          - "Production Fruit, fresh nes"
+      - Sugar cane:
+        - description:
+          - "Production Sugar cane"
+      - Eggs Primary:
+        - description:
+          - "Production Eggs Primary"
+      - Tomatoes:
+        - description:
+          - "Production Tomatoes"
+      - Skins, sheep, with wool:
+        - description:
+          - "Production Skins, sheep, with wool"
+      - Butter and Ghee:
+        - description:
+          - "Production Butter and Ghee"
+      - Broad beans, horse beans, dry:
+        - description:
+          - "Production Broad beans, horse beans, dry"
+      - Plantains and others:
+        - description:
+          - "Production Plantains and others"
+      - Milk,Total:
+        - description:
+          - "Production Milk,Total"
+      - Meat, Poultry:
+        - description:
+          - "production poultry meat"
+      - Beeswax:
+        - description:
+          - "Production Beeswax"
+      - Beans, green:
+        - description:
+          - "production green beans"
+      - Seed cotton:
+        - description:
+          - "Production Seed cotton"
+      - Beef and Buffalo Meat:
+        - description:
+          - "Production Beef and Buffalo Meat"
+      - Roots and Tubers,Total:
+        - description:
+          - "Production Roots and Tubers,Total"
+      - Sunflower seed:
+        - description:
+          - "Production Sunflower seed"
+      - Dates:
+        - description:
+          - "Production Dates"
+      - Jute:
+        - description:
+          - "Production Jute"
+      - Butter, cow milk:
+        - description:
+          - "Production Butter, cow milk"
+      - Cottonseed:
+        - description:
+          - "Production Cottonseed"
+      - Meat indigenous, sheep:
+        - description:
+          - "Production Meat indigenous, sheep"
+      - Yams:
+        - description:
+          - "Production Yams"
+      - Milk, whole fresh sheep:
+        - description:
+          - "Production Milk, whole fresh sheep"
+      - Oranges:
+        - description:
+          - "Production Oranges"
+      - Rice, paddy:
+        - description:
+          - "production paddy rice"
+      - Cereals,Total:
+        - description:
+          - "Production Cereals,Total"
+      - Cheese, whole cow milk:
+        - description:
+          - "Production Cheese, whole cow milk"
+      - Skins, sheep, fresh:
+        - description:
+          - "Production Skins, sheep, fresh"
+      - Watermelons:
+        - description:
+          - "Production Watermelons"
+      - Bananas:
+        - description:
+          - "Production Bananas"
+      - Skins, goat, fresh:
+        - description:
+          - "Production Skins, goat, fresh"
+      - Sesame seed:
+        - description:
+          - "Production Sesame seed"
+      - Cheese (All Kinds):
+        - description:
+          - "Production Cheese (All Kinds)"
+      - Molasses:
+        - description:
+          - "Production Molasses"
+      - Wood charcoal:
+        - description:
+          - "Production Wood charcoal"
+      - Melons, other (inc.cantaloupes):
+        - description:
+          - "Production Melons, other (inc.cantaloupes)"
+      - Wood fuel:
+        - description:
+          - "Production Wood fuel"
+      - Potatoes:
+        - description:
+          - "Production Potatoes"
+      - Castor oil seed:
+        - description:
+          - "Production Castor oil seed"
+      - Pumpkins, squash and gourds:
+        - description:
+          - "Production Pumpkins, squash and gourds"
+      - Lemons and limes:
+        - description:
+          - "Production Lemons and limes"
+      - Meat indigenous, cattle:
+        - description:
+          - "Production Meat indigenous, cattle"
+      - Milk, whole fresh goat:
+        - description:
+          - "Production Milk, whole fresh goat"
+      - Oil, sunflower:
+        - description:
+          - "production sunflower oil"
+      - Chick peas:
+        - description:
+          - "Production Chick peas"
+      - Chillies and peppers, dry:
+        - description:
+          - "Production Chillies and peppers, dry"
+      - Cucumbers and gherkins:
+        - description:
+          - "Production Cucumbers and gherkins"
+      - Oil, groundnut:
+        - description:
+          - "production groundnut oil"
+      - Grapefruit (inc. pomelos):
+        - description:
+          - "Production Grapefruit (inc. pomelos)"
+      - Cotton lint:
+        - description:
+          - "Production Cotton lint"
+      - Wheat:
+        - description:
+          - "Production Wheat"
+      - Beans, dry:
+        - description:
+          - "production dry beans"
+      - Cassava:
+        - description:
+          - "Production Cassava"
+      - Oilcrops, Cake Equivalent:
+        - description:
+          - "Production Oilcrops, Cake Equivalent"
+      - Eggs, hen, in shell:
+        - description:
+          - "Production Eggs, hen, in shell"
+    - Ratio:
+      - Gross Fixed Capital Formation as a share of Value Added  (Agriculture, Forestry and Fishing):
+        - description:
+          - "Ratio Gross Fixed Capital Formation as a share of Value Added  (Agriculture,\
+          \ Forestry and Fishing)"
+      - Gross Fixed Capital Formation to GDP ratio:
+        - description:
+          - "Ratio Gross Fixed Capital Formation to GDP ratio"
+    - Ratio, 2005 prices:
+      - Gross Fixed Capital Formation as a share of Value Added  (Agriculture, Forestry and Fishing):
+        - description:
+          - "Ratio, 2005 prices Gross Fixed Capital Formation as a share of Value Added\
+          \  (Agriculture, Forestry and Fishing)"
+      - Gross Fixed Capital Formation to GDP ratio:
+        - description:
+          - "Ratio, 2005 prices Gross Fixed Capital Formation to GDP ratio"
+    - Residues (Crop residues):
+      - Beans, dry:
+        - description:
+          - "residues (crop residues) dry beans"
+      - Sorghum:
+        - description:
+          - "Residues (Crop residues) Sorghum"
+      - Millet:
+        - description:
+          - "Residues (Crop residues) Millet"
+      - Maize:
+        - description:
+          - "Residues (Crop residues) Maize"
+      - All Crops:
+        - description:
+          - "Residues (Crop residues) All Crops"
+    - Rural population:
+      - Population - Est. & Proj.:
+        - description:
+          - "Rural population Population - Est. & Proj."
+    - Share in Agricultural area:
+      - Permanent meadows and pastures:
+        - description:
+          - "Share in Agricultural area Permanent meadows and pastures"
+      - Total area equipped for irrigation:
+        - description:
+          - "Share in Agricultural area Total area equipped for irrigation"
+    - Share in Forest area:
+      - Planted forest:
+        - description:
+          - "Share in Forest area Planted forest"
+      - Primary forest:
+        - description:
+          - "Share in Forest area Primary forest"
+      - Other naturally regenerated forest:
+        - description:
+          - "Share in Forest area Other naturally regenerated forest"
+    - Share in total livestock:
+      - Cattle and Buffaloes:
+        - description:
+          - "Share in total livestock Cattle and Buffaloes"
+      - Cattle:
+        - description:
+          - "Share in total livestock Cattle"
+      - Goats:
+        - description:
+          - "Share in total livestock Goats"
+      - Sheep:
+        - description:
+          - "Share in total livestock Sheep"
+      - Major livestock types:
+        - description:
+          - "Share in total livestock Major livestock types"
+      - Equidae:
+        - description:
+          - "Share in total livestock Equidae"
+      - Asses:
+        - description:
+          - "Share in total livestock Asses"
+      - Chickens:
+        - description:
+          - "Share in total livestock Chickens"
+      - Sheep and Goats:
+        - description:
+          - "Share in total livestock Sheep and Goats"
+    - Share of GDP in Local Currency:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of GDP in Local Currency Value Added (Agriculture, Forestry and Fishing)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Share of GDP in Local Currency Value Added (Total Manufacturing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Share of GDP in Local Currency Gross Fixed Capital Formation"
+    - Share of GDP in US$:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of GDP in US$ Value Added (Agriculture, Forestry and Fishing)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Share of GDP in US$ Value Added (Total Manufacturing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Share of GDP in US$ Gross Fixed Capital Formation"
+      - Value Added (Agriculture):
+        - description:
+          - "Share of GDP in US$ Value Added (Agriculture)"
+    - Share of GDP, Local Currency, 2010 prices:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of GDP, Local Currency, 2010 prices Value Added (Agriculture, Forestry\
+          \ and Fishing)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Share of GDP, Local Currency, 2010 prices Value Added (Total Manufacturing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Share of GDP, Local Currency, 2010 prices Gross Fixed Capital Formation"
+    - Share of GDP, US$, 2010 prices:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of GDP, US$, 2010 prices Value Added (Agriculture, Forestry and Fishing)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Share of GDP, US$, 2010 prices Value Added (Total Manufacturing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Share of GDP, US$, 2010 prices Gross Fixed Capital Formation"
+    - Share of Gross Output (Agriculture, Forestry and Fisheries):
+      - Gross Output (Agriculture):
+        - description:
+          - "Share of Gross Output (Agriculture, Forestry and Fisheries) Gross Output\
+          \ (Agriculture)"
+    - Share of Total:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of Total Value Added (Agriculture, Forestry and Fishing)"
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of Total Gross Fixed Capital Formation (Agriculture, Forestry and Fishing)"
+      - DFA Commitment to Agriculture, Forestry and Fishing:
+        - description:
+          - "Share of Total DFA Commitment to Agriculture, Forestry and Fishing"
+    - Share of Value Added:
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of Value Added Gross Fixed Capital Formation (Agriculture, Forestry\
+          \ and Fishing)"
+    - Share of Value Added (Agriculture, Forestry and Fishing):
+      - Value Added (Agriculture):
+        - description:
+          - "Share of Value Added (Agriculture, Forestry and Fishing) Value Added (Agriculture)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Share of Value Added (Agriculture, Forestry and Fishing) Value Added (Total\
+          \ Manufacturing)"
+    - Share of Value Added US$:
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of Value Added US$ Gross Fixed Capital Formation (Agriculture, Forestry\
+          \ and Fishing)"
+    - Share of Value Added US$, 2005 prices:
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Share of Value Added US$, 2005 prices Gross Fixed Capital Formation (Agriculture,\
+          \ Forestry and Fishing)"
+    - Standard local currency units per USD:
+      - South Sudanese Pound:
+        - description:
+          - "Standard local currency units per USD South Sudanese Pound"
+    - Stocks:
+      - Chickens, broilers:
+        - description:
+          - "stocks broiler chickens"
+      - Cattle and Buffaloes:
+        - description:
+          - "Stocks Cattle and Buffaloes"
+      - Cattle:
+        - description:
+          - "Stocks Cattle"
+      - Camels:
+        - description:
+          - "Stocks Camels"
+      - Goats:
+        - description:
+          - "Stocks Goats"
+      - Poultry Birds:
+        - description:
+          - "Stocks Poultry Birds"
+      - Sheep:
+        - description:
+          - "Stocks Sheep"
+      - Chickens, layers:
+        - description:
+          - "stocks layer chickens"
+      - Mules and Asses:
+        - description:
+          - "Stocks Mules and Asses"
+      - Horses:
+        - description:
+          - "Stocks Horses"
+      - Major livestock types:
+        - description:
+          - "Stocks Major livestock types"
+      - Mules:
+        - description:
+          - "Stocks Mules"
+      - Equidae:
+        - description:
+          - "Stocks Equidae"
+      - Asses:
+        - description:
+          - "Stocks Asses"
+      - Cattle, dairy:
+        - description:
+          - "stocks dairy cattle"
+      - Chickens:
+        - description:
+          - "Stocks Chickens"
+      - Cattle, non-dairy:
+        - description:
+          - "stocks non-dairy cattle"
+      - Sheep and Goats:
+        - description:
+          - "Stocks Sheep and Goats"
+    - Total Population - Both sexes:
+      - Population - Est. & Proj.:
+        - description:
+          - "Total Population - Both sexes Population - Est. & Proj."
+    - Total Population - Female:
+      - Population - Est. & Proj.:
+        - description:
+          - "Total Population - Female Population - Est. & Proj."
+    - Total Population - Male:
+      - Population - Est. & Proj.:
+        - description:
+          - "Total Population - Male Population - Est. & Proj."
+    - Urban population:
+      - Population - Est. & Proj.:
+        - description:
+          - "Urban population Population - Est. & Proj."
+    - Value:
+      - Per capita food supply variability (kcal/capita/day):
+        - description:
+          - "Value Per capita food supply variability (kcal/capita/day)"
+      - Average value of food production (constant I$ per person) (3-year average):
+        - description:
+          - "Value Average value of food production (constant I$ per person) (3-year average)"
+      - Number of severely food insecure people:
+        - description:
+          - "Value Number of severely food insecure people"
+      - Prevalence of undernourishment (%) (3-year average):
+        - description:
+          - "Value Prevalence of undernourishment (%) (3-year average)"
+      - Percentage of children under 5 years of age who are overweight:
+        - description:
+          - "Value Percentage of children under 5 years of age who are overweight"
+      - Cereal import dependency ratio (%) (3-year average):
+        - description:
+          - "Value Cereal import dependency ratio (%) (3-year average)"
+      - Average protein supply (g/capita/day) (3-year average):
+        - description:
+          - "Value Average protein supply (g/capita/day) (3-year average)"
+      - Value of food imports over total merchandise exports (%) (3-year average):
+        - description:
+          - "Value Value of food imports over total merchandise exports (%) (3-year average)"
+      - Access to improved water sources (%):
+        - description:
+          - "Value Access to improved water sources (%)"
+      - Depth of the food deficit (kcal/capita/day) (3-year average):
+        - description:
+          - "Value Depth of the food deficit (kcal/capita/day) (3-year average)"
+      - Average supply of protein of animal origin (g/capita/day) (3-year average):
+        - description:
+          - "Value Average supply of protein of animal origin (g/capita/day) (3-year average)"
+      - Share of dietary energy supply derived from cereals, roots and tubers (%) (3-year average):
+        - description:
+          - "Value Share of dietary energy supply derived from cereals, roots and tubers\
+          \ (%) (3-year average)"
+      - Political stability and absence of violence/terrorism (index):
+        - description:
+          - "Value Political stability and absence of violence/terrorism (index)"
+      - Percentage of children under 5 years of age who are stunted (%):
+        - description:
+          - "Value Percentage of children under 5 years of age who are stunted (%)"
+      - Access to improved sanitation facilities (%):
+        - description:
+          - "Value Access to improved sanitation facilities (%)"
+      - Gross domestic product per capita, PPP (constant 2011 international $):
+        - description:
+          - "Value Gross domestic product per capita, PPP (constant 2011 international\
+          \ $)"
+      - Prevalence of anemia among women of reproductive age (15-49 years):
+        - description:
+          - "Value Prevalence of anemia among women of reproductive age (15-49 years)"
+      - Per capita food production variability (I$ per person constant 2004-06):
+        - description:
+          - "Value Per capita food production variability (I$ per person constant 2004-06)"
+      - Prevalence of severe food insecurity in the total population:
+        - description:
+          - "Value Prevalence of severe food insecurity in the total population"
+      - Average dietary energy supply adequacy (%) (3-year average):
+        - description:
+          - "Value Average dietary energy supply adequacy (%) (3-year average)"
+      - Percentage of children under 5 years of age affected by wasting (%):
+        - description:
+          - "Value Percentage of children under 5 years of age affected by wasting (%)"
+      - Number of people undernourished (millions) (3-year average):
+        - description:
+          - "Value Number of people undernourished (millions) (3-year average)"
+      - Percentage of arable land equipped for irrigation (%) (3-year average):
+        - description:
+          - "Value Percentage of arable land equipped for irrigation (%) (3-year average)"
+      - Prevalence of exclusive breastfeeding among infants (0-5 months):
+        - description:
+          - "Value Prevalence of exclusive breastfeeding among infants (0-5 months)"
+      - Rail-lines density (per 100 square km of land area):
+        - description:
+          - "Value Rail-lines density (per 100 square km of land area)"
+    - Value Local Currency:
+      - Gross National Income:
+        - description:
+          - "Value Local Currency Gross National Income"
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value Local Currency Value Added (Agriculture, Forestry and Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Value Local Currency Gross Domestic Product"
+      - Value Added (Agriculture):
+        - description:
+          - "Value Local Currency Value Added (Agriculture)"
+      - Gross Output (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value Local Currency Gross Output (Agriculture, Forestry and Fishing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Value Local Currency Gross Fixed Capital Formation"
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value Local Currency Gross Fixed Capital Formation (Agriculture, Forestry\
+          \ and Fishing)"
+      - Agriculture, forestry, fishing, Capital (Central Government):
+        - description:
+          - "Value Local Currency Agriculture, forestry, fishing, Capital (Central Government)"
+      - Agriculture, forestry, fishing (Central Government):
+        - description:
+          - "Value Local Currency Agriculture, forestry, fishing (Central Government)"
+      - Gross Output (Agriculture):
+        - description:
+          - "Value Local Currency Gross Output (Agriculture)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Value Local Currency Value Added (Total Manufacturing)"
+      - Agriculture, forestry, fishing, Recurrent (Central Government):
+        - description:
+          - "Value Local Currency Agriculture, forestry, fishing, Recurrent (Central Government)"
+    - Value Local Currency, 2010 base year:
+      - Gross Fixed Capital Formation Deflator:
+        - description:
+          - "Value Local Currency, 2010 base year Gross Fixed Capital Formation Deflator"
+      - GDP Deflator:
+        - description:
+          - "Value Local Currency, 2010 base year GDP Deflator"
+      - Value Added Deflator (Manufacturing):
+        - description:
+          - "Value Local Currency, 2010 base year Value Added Deflator (Manufacturing)"
+      - Value Added Deflator (Agriculture, forestry and fishery):
+        - description:
+          - "Value Local Currency, 2010 base year Value Added Deflator (Agriculture, forestry\
+          \ and fishery)"
+    - Value Local Currency, 2010 prices:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value Local Currency, 2010 prices Value Added (Agriculture, Forestry and\
+          \ Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Value Local Currency, 2010 prices Gross Domestic Product"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Value Local Currency, 2010 prices Value Added (Total Manufacturing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Value Local Currency, 2010 prices Gross Fixed Capital Formation"
+    - Value US$:
+      - Gross National Income:
+        - description:
+          - "Value US$ Gross National Income"
+      - DFA Commitment to Agriculture, Forestry and Fishing:
+        - description:
+          - "Value US$ DFA Commitment to Agriculture, Forestry and Fishing"
+      - Total FDI inflows:
+        - description:
+          - "Value US$ Total FDI inflows"
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value US$ Value Added (Agriculture, Forestry and Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Value US$ Gross Domestic Product"
+      - Value Added (Agriculture):
+        - description:
+          - "Value US$ Value Added (Agriculture)"
+      - Gross Output (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value US$ Gross Output (Agriculture, Forestry and Fishing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Value US$ Gross Fixed Capital Formation"
+      - Gross Domestic Product per capita:
+        - description:
+          - "Value US$ Gross Domestic Product per capita"
+      - Gross National Income per capita:
+        - description:
+          - "Value US$ Gross National Income per capita"
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value US$ Gross Fixed Capital Formation (Agriculture, Forestry and Fishing)"
+      - Agriculture, forestry, fishing, Capital (Central Government):
+        - description:
+          - "Value US$ Agriculture, forestry, fishing, Capital (Central Government)"
+      - Agriculture, forestry, fishing (Central Government):
+        - description:
+          - "Value US$ Agriculture, forestry, fishing (Central Government)"
+      - Gross Output (Agriculture):
+        - description:
+          - "Value US$ Gross Output (Agriculture)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Value US$ Value Added (Total Manufacturing)"
+      - Agriculture, forestry, fishing, Recurrent (Central Government):
+        - description:
+          - "Value US$ Agriculture, forestry, fishing, Recurrent (Central Government)"
+    - Value US$, 2005 prices:
+      - Total FDI inflows:
+        - description:
+          - "Value US$, 2005 prices Total FDI inflows"
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value US$, 2005 prices Value Added (Agriculture, Forestry and Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Value US$, 2005 prices Gross Domestic Product"
+      - Value Added (Agriculture):
+        - description:
+          - "Value US$, 2005 prices Value Added (Agriculture)"
+      - Gross Output (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value US$, 2005 prices Gross Output (Agriculture, Forestry and Fishing)"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Value US$, 2005 prices Gross Fixed Capital Formation"
+      - Gross Fixed Capital Formation (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value US$, 2005 prices Gross Fixed Capital Formation (Agriculture, Forestry\
+          \ and Fishing)"
+      - Agriculture, forestry, fishing, Capital (Central Government):
+        - description:
+          - "Value US$, 2005 prices Agriculture, forestry, fishing, Capital (Central Government)"
+      - Agriculture, forestry, fishing (Central Government):
+        - description:
+          - "Value US$, 2005 prices Agriculture, forestry, fishing (Central Government)"
+      - Gross Output (Agriculture):
+        - description:
+          - "Value US$, 2005 prices Gross Output (Agriculture)"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Value US$, 2005 prices Value Added (Total Manufacturing)"
+      - Agriculture, forestry, fishing, Recurrent (Central Government):
+        - description:
+          - "Value US$, 2005 prices Agriculture, forestry, fishing, Recurrent (Central\
+          \ Government)"
+    - Value US$, 2010 base year:
+      - Gross Fixed Capital Formation Deflator:
+        - description:
+          - "Value US$, 2010 base year Gross Fixed Capital Formation Deflator"
+      - GDP Deflator:
+        - description:
+          - "Value US$, 2010 base year GDP Deflator"
+      - Value Added Deflator (Manufacturing):
+        - description:
+          - "Value US$, 2010 base year Value Added Deflator (Manufacturing)"
+      - Value Added Deflator (Agriculture, forestry and fishery):
+        - description:
+          - "Value US$, 2010 base year Value Added Deflator (Agriculture, forestry and\
+          \ fishery)"
+    - Value US$, 2010 prices:
+      - Value Added (Agriculture, Forestry and Fishing):
+        - description:
+          - "Value US$, 2010 prices Value Added (Agriculture, Forestry and Fishing)"
+      - Gross Domestic Product:
+        - description:
+          - "Value US$, 2010 prices Gross Domestic Product"
+      - Gross Fixed Capital Formation:
+        - description:
+          - "Value US$, 2010 prices Gross Fixed Capital Formation"
+      - Gross Domestic Product per capita:
+        - description:
+          - "Value US$, 2010 prices Gross Domestic Product per capita"
+      - Value Added (Total Manufacturing):
+        - description:
+          - "Value US$, 2010 prices Value Added (Total Manufacturing)"
+    - Yield:
+      - Vegetables Primary:
+        - description:
+          - "Yield Vegetables Primary"
+      - Pineapples:
+        - description:
+          - "Yield Pineapples"
+      - Tangerines, mandarins, clementines, satsumas:
+        - description:
+          - "Yield Tangerines, mandarins, clementines, satsumas"
+      - Pulses, nes:
+        - description:
+          - "yield ne pulses"
+      - Cereals,Total:
+        - description:
+          - "Yield Cereals,Total"
+      - Fruit, fresh nes:
+        - description:
+          - "Yield Fruit, fresh nes"
+      - Citrus Fruit,Total:
+        - description:
+          - "yield total citrus fruit"
+      - Skins, sheep, fresh:
+        - description:
+          - "Yield Skins, sheep, fresh"
+      - Maize:
+        - description:
+          - "Yield Maize"
+      - Skins, sheep, with wool:
+        - description:
+          - "Yield Skins, sheep, with wool"
+      - Coarse Grain, Total:
+        - description:
+          - "Yield Coarse Grain, Total"
+      - Melonseed:
+        - description:
+          - "Yield Melonseed"
+      - Sesame seed:
+        - description:
+          - "Yield Sesame seed"
+      - Milk,Total:
+        - description:
+          - "Yield Milk,Total"
+      - Melons, other (inc.cantaloupes):
+        - description:
+          - "Yield Melons, other (inc.cantaloupes)"
+      - Beans, green:
+        - description:
+          - "yield green beans"
+      - Pumpkins, squash and gourds:
+        - description:
+          - "Yield Pumpkins, squash and gourds"
+      - Milk, whole fresh cow:
+        - description:
+          - "Yield Milk, whole fresh cow"
+      - Milk, whole fresh goat:
+        - description:
+          - "Yield Milk, whole fresh goat"
+      - Hides, cattle, fresh:
+        - description:
+          - "Yield Hides, cattle, fresh"
+      - Roots and Tubers,Total:
+        - description:
+          - "Yield Roots and Tubers,Total"
+      - Sunflower seed:
+        - description:
+          - "Yield Sunflower seed"
+      - Millet:
+        - description:
+          - "Yield Millet"
+      - Chillies and peppers, dry:
+        - description:
+          - "Yield Chillies and peppers, dry"
+      - Fruit, tropical fresh nes:
+        - description:
+          - "Yield Fruit, tropical fresh nes"
+      - Groundnuts, with shell:
+        - description:
+          - "Yield Groundnuts, with shell"
+      - Yams:
+        - description:
+          - "Yield Yams"
+      - Cassava:
+        - description:
+          - "Yield Cassava"
+      - Beans, dry:
+        - description:
+          - "yield dry beans"
+      - Sorghum:
+        - description:
+          - "Yield Sorghum"
+      - Pulses,Total:
+        - description:
+          - "Yield Pulses,Total"
+      - Milk, whole fresh sheep:
+        - description:
+          - "Yield Milk, whole fresh sheep"
+      - Vegetables, fresh nes:
+        - description:
+          - "Yield Vegetables, fresh nes"
+    - Yield/Carcass Weight:
+      - Meat, chicken:
+        - description:
+          - "yield/carcass weight chicken meat"
+      - Sheep and Goat Meat:
+        - description:
+          - "Yield/Carcass Weight Sheep and Goat Meat"
+      - Meat, Poultry:
+        - description:
+          - "yield/carcass weight poultry meat"
+      - Beef and Buffalo Meat:
+        - description:
+          - "Yield/Carcass Weight Beef and Buffalo Meat"
+      - Meat, cattle:
+        - description:
+          - "yield/carcass weight cattle meat"
+      - Meat, sheep:
+        - description:
+          - "yield/carcass weight sheep meat"
+      - Meat, goat:
+        - description:
+          - "yield/carcass weight goat meat"

--- a/src/main/resources/org/clulab/wm/eidos/un_ontology.yml
+++ b/src/main/resources/org/clulab/wm/eidos/un_ontology.yml
@@ -1,5 +1,4 @@
-- UN:
-  #todo: fix out-standing issues in --> https://github.com/clulab/eidos/pull/281
+- UN: #todo: fix out-standing issues in --> https://github.com/clulab/eidos/pull/281
   - events:
     - nature_impact:
       - positive_nature_impact:
@@ -31,8 +30,9 @@
         - crisis
         - emergency
     - natural:
-      - chemical:
-      #todo -- O2, N, CO2 etc ...
+      - chemical: #todo -- O2, N, CO2 etc ...
+        - oxygen
+        - nitrogen
       - biology:
         - ecosystem:
           - examples:

--- a/src/main/resources/org/clulab/wm/eidos/wdi_ontology.yml
+++ b/src/main/resources/org/clulab/wm/eidos/wdi_ontology.yml
@@ -1,3177 +1,4765 @@
 - WDI:
   - 2005_PPP_conversion_factor:
-    - description: "GDP (LCU per international $)"
+    - description:
+      - "GDP (LCU per international $)"
   - 2005_PPP_conversion_factor:
-    - description: "private consumption (LCU per international $)"
+    - description:
+      - "private consumption (LCU per international $)"
   - Access_to_clean_fuels_and_technologies_for_cooking__(%_of_population):
-    - description: "Access to clean fuels and technologies for cooking is the proportion of total population primarily using clean cooking fuels and technologies for cooking. Under WHO guidelines"
+    - description:
+      - "Access to clean fuels and technologies for cooking is the proportion of total population primarily using clean cooking fuels and technologies for cooking. Under WHO guidelines"
   - Access_to_electricity_(%_of_population):
-    - description: "Access to electricity is the percentage of population with access to electricity. Electrification data are collected from industry"
+    - description:
+      - "Access to electricity is the percentage of population with access to electricity. Electrification data are collected from industry"
   - Access_to_electricity:
-    - description: "rural (% of rural population)"
+    - description:
+      - "rural (% of rural population)"
   - Access_to_electricity:
-    - description: "urban (% of urban population)"
+    - description:
+      - "urban (% of urban population)"
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider_(%_of_population_ages_15+):
-    - description: "Account denotes the percentage of respondents who report having an account (by themselves or together with someone else) at a bank or another type of financial institution or report personally using a mobile money service in the past 12 months (% age 15+)."
+    - description:
+      - "Account denotes the percentage of respondents who report having an account (by themselves or together with someone else) at a bank or another type of financial institution or report personally using a mobile money service in the past 12 months (% age 15+)."
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider:
-    - description: "female (% of population ages 15+)"
+    - description:
+      - "female (% of population ages 15+)"
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider:
-    - description: "male (% of population ages 15+)"
+    - description:
+      - "male (% of population ages 15+)"
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider:
-    - description: "older adults (% of population ages 25+)"
+    - description:
+      - "older adults (% of population ages 25+)"
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider:
-    - description: "poorest 40% (% of population ages 15+)"
+    - description:
+      - "poorest 40% (% of population ages 15+)"
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider:
-    - description: "primary education or less (% of population ages 15+)"
+    - description:
+      - "primary education or less (% of population ages 15+)"
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider:
-    - description: "richest 60% (% of population ages 15+)"
+    - description:
+      - "richest 60% (% of population ages 15+)"
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider:
-    - description: "secondary education or more (% of population ages 15+)"
+    - description:
+      - "secondary education or more (% of population ages 15+)"
   - Account_ownership_at_a_financial_institution_or_with_a_mobile-money-service_provider:
-    - description: "young adults (% of population ages 15-24)"
+    - description:
+      - "young adults (% of population ages 15-24)"
   - Adequacy_of_social_insurance_programs_(%_of_total_welfare_of_beneficiary_households):
-    - description: "Adequacy of social insurance programs is measured by the total transfer amount received by the population participating in social insurance programs as a share of their total welfare. Welfare is defined as the total income or total expenditure of beneficiary households. Social insurance programs include old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
+    - description:
+      - "Adequacy of social insurance programs is measured by the total transfer amount received by the population participating in social insurance programs as a share of their total welfare. Welfare is defined as the total income or total expenditure of beneficiary households. Social insurance programs include old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
   - Adequacy_of_social_protection_and_labor_programs_(%_of_total_welfare_of_beneficiary_households):
-    - description: "Adequacy of social protection and labor programs (SPL) is measured by the total transfer amount received by the population participating in social insurance"
+    - description:
+      - "Adequacy of social protection and labor programs (SPL) is measured by the total transfer amount received by the population participating in social insurance"
   - Adequacy_of_social_safety_net_programs_(%_of_total_welfare_of_beneficiary_households):
-    - description: "Adequacy of social safety net programs is measured by the total transfer amount received by the population participating in social safety net programs as a share of their total welfare. Welfare is defined as the total income or total expenditure of beneficiary households. Social safety net programs include cash transfers and last resort programs"
+    - description:
+      - "Adequacy of social safety net programs is measured by the total transfer amount received by the population participating in social safety net programs as a share of their total welfare. Welfare is defined as the total income or total expenditure of beneficiary households. Social safety net programs include cash transfers and last resort programs"
   - Adequacy_of_unemployment_benefits_and_ALMP_(%_of_total_welfare_of_beneficiary_households):
-    - description: "Adequacy of unemployment benefits and active labor market programs (ALMP) is measured by the total transfer amount received by the population participating in unemployment benefits and active labor market programs as a share of their total welfare. Welfare is defined as the total income or total expenditure of beneficiary households. Unemployment benefits and active labor market programs include unemployment compensation"
+    - description:
+      - "Adequacy of unemployment benefits and active labor market programs (ALMP) is measured by the total transfer amount received by the population participating in unemployment benefits and active labor market programs as a share of their total welfare. Welfare is defined as the total income or total expenditure of beneficiary households. Unemployment benefits and active labor market programs include unemployment compensation"
   - Adjusted_net_enrollment_rate:
-    - description: "primary (% of primary school age children)"
+    - description:
+      - "primary (% of primary school age children)"
   - Adjusted_net_enrollment_rate:
-    - description: "primary"
+    - description:
+      - "primary"
   - Adjusted_net_enrollment_rate:
-    - description: "primary"
+    - description:
+      - "primary"
   - Adjusted_net_national_income_(annual_%_growth):
-    - description: "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
+    - description:
+      - "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
   - Adjusted_net_national_income_(constant_2010_US$):
-    - description: "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
+    - description:
+      - "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
   - Adjusted_net_national_income_(current_US$):
-    - description: "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
+    - description:
+      - "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
   - Adjusted_net_national_income_per_capita_(annual_%_growth):
-    - description: "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
+    - description:
+      - "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
   - Adjusted_net_national_income_per_capita_(constant_2010_US$):
-    - description: "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
+    - description:
+      - "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
   - Adjusted_net_national_income_per_capita_(current_US$):
-    - description: "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
+    - description:
+      - "Adjusted net national income is GNI minus consumption of fixed capital and natural resources depletion."
   - Adjusted_net_savings:
-    - description: "excluding particulate emission damage (% of GNI)"
+    - description:
+      - "excluding particulate emission damage (% of GNI)"
   - Adjusted_net_savings:
-    - description: "excluding particulate emission damage (current US$)"
+    - description:
+      - "excluding particulate emission damage (current US$)"
   - Adjusted_net_savings:
-    - description: "including particulate emission damage (% of GNI)"
+    - description:
+      - "including particulate emission damage (% of GNI)"
   - Adjusted_net_savings:
-    - description: "including particulate emission damage (current US$)"
+    - description:
+      - "including particulate emission damage (current US$)"
   - Adjusted_savings:_carbon_dioxide_damage_(%_of_GNI):
-    - description: "Carbon dioxide damage is estimated to be $20 per ton of carbon (the unit damage in 1995 U.S. dollars) times the number of tons of carbon emitted."
+    - description:
+      - "Carbon dioxide damage is estimated to be $20 per ton of carbon (the unit damage in 1995 U.S. dollars) times the number of tons of carbon emitted."
   - Adjusted_savings:_carbon_dioxide_damage_(current_US$):
-    - description: "Carbon dioxide damage is estimated to be $20 per ton of carbon (the unit damage in 1995 U.S. dollars) times the number of tons of carbon emitted."
+    - description:
+      - "Carbon dioxide damage is estimated to be $20 per ton of carbon (the unit damage in 1995 U.S. dollars) times the number of tons of carbon emitted."
   - Adjusted_savings:_consumption_of_fixed_capital_(%_of_GNI):
-    - description: "Consumption of fixed capital represents the replacement value of capital used up in the process of production."
+    - description:
+      - "Consumption of fixed capital represents the replacement value of capital used up in the process of production."
   - Adjusted_savings:_consumption_of_fixed_capital_(current_US$):
-    - description: "Consumption of fixed capital represents the replacement value of capital used up in the process of production."
+    - description:
+      - "Consumption of fixed capital represents the replacement value of capital used up in the process of production."
   - Adjusted_savings:_education_expenditure_(%_of_GNI):
-    - description: "Education expenditure refers to the current operating expenditures in education"
+    - description:
+      - "Education expenditure refers to the current operating expenditures in education"
   - Adjusted_savings:_education_expenditure_(current_US$):
-    - description: "Education expenditure refers to the current operating expenditures in education"
+    - description:
+      - "Education expenditure refers to the current operating expenditures in education"
   - Adjusted_savings:_energy_depletion_(%_of_GNI):
-    - description: "Energy depletion is the ratio of the value of the stock of energy resources to the remaining reserve lifetime (capped at 25 years). It covers coal"
+    - description:
+      - "Energy depletion is the ratio of the value of the stock of energy resources to the remaining reserve lifetime (capped at 25 years). It covers coal"
   - Adjusted_savings:_energy_depletion_(current_US$):
-    - description: "Energy depletion is the ratio of the value of the stock of energy resources to the remaining reserve lifetime (capped at 25 years). It covers coal"
+    - description:
+      - "Energy depletion is the ratio of the value of the stock of energy resources to the remaining reserve lifetime (capped at 25 years). It covers coal"
   - Adjusted_savings:_gross_savings_(%_of_GNI):
-    - description: "Gross savings are the difference between gross national income and public and private consumption"
+    - description:
+      - "Gross savings are the difference between gross national income and public and private consumption"
   - Adjusted_savings:_mineral_depletion_(%_of_GNI):
-    - description: "Mineral depletion is the ratio of the value of the stock of mineral resources to the remaining reserve lifetime (capped at 25 years). It covers tin"
+    - description:
+      - "Mineral depletion is the ratio of the value of the stock of mineral resources to the remaining reserve lifetime (capped at 25 years). It covers tin"
   - Adjusted_savings:_mineral_depletion_(current_US$):
-    - description: "Mineral depletion is the ratio of the value of the stock of mineral resources to the remaining reserve lifetime (capped at 25 years). It covers tin"
+    - description:
+      - "Mineral depletion is the ratio of the value of the stock of mineral resources to the remaining reserve lifetime (capped at 25 years). It covers tin"
   - Adjusted_savings:_natural_resources_depletion_(%_of_GNI):
-    - description: "Natural resource depletion is the sum of net forest depletion"
+    - description:
+      - "Natural resource depletion is the sum of net forest depletion"
   - Adjusted_savings:_net_forest_depletion_(%_of_GNI):
-    - description: "Net forest depletion is calculated as the product of unit resource rents and the excess of roundwood harvest over natural growth."
+    - description:
+      - "Net forest depletion is calculated as the product of unit resource rents and the excess of roundwood harvest over natural growth."
   - Adjusted_savings:_net_forest_depletion_(current_US$):
-    - description: "Net forest depletion is calculated as the product of unit resource rents and the excess of roundwood harvest over natural growth."
+    - description:
+      - "Net forest depletion is calculated as the product of unit resource rents and the excess of roundwood harvest over natural growth."
   - Adjusted_savings:_net_national_savings_(%_of_GNI):
-    - description: "Net national savings are equal to gross national savings less the value of consumption of fixed capital."
+    - description:
+      - "Net national savings are equal to gross national savings less the value of consumption of fixed capital."
   - Adjusted_savings:_net_national_savings_(current_US$):
-    - description: "Net national savings are equal to gross national savings less the value of consumption of fixed capital."
+    - description:
+      - "Net national savings are equal to gross national savings less the value of consumption of fixed capital."
   - Adjusted_savings:_particulate_emission_damage_(%_of_GNI):
-    - description: "Particulate emissions damage is the damage due to exposure of a country's population to ambient concentrations of particulates measuring less than 2.5 microns in diameter (PM2.5)"
+    - description:
+      - "Particulate emissions damage is the damage due to exposure of a country's population to ambient concentrations of particulates measuring less than 2.5 microns in diameter (PM2.5)"
   - Adjusted_savings:_particulate_emission_damage_(current_US$):
-    - description: "Particulate emissions damage is the damage due to exposure of a country's population to ambient concentrations of particulates measuring less than 2.5 microns in diameter (PM2.5)"
+    - description:
+      - "Particulate emissions damage is the damage due to exposure of a country's population to ambient concentrations of particulates measuring less than 2.5 microns in diameter (PM2.5)"
   - Adolescent_fertility_rate_(births_per_1:
-    - description: "000 women ages 15-19)"
+    - description:
+      - "000 women ages 15-19)"
   - Adolescents_out_of_school_(%_of_lower_secondary_school_age):
-    - description: "Adolescents out of school are the percentage of lower secondary school age adolescents who are not enrolled in school."
+    - description:
+      - "Adolescents out of school are the percentage of lower secondary school age adolescents who are not enrolled in school."
   - Adolescents_out_of_school:
-    - description: "female (% of female lower secondary school age)"
+    - description:
+      - "female (% of female lower secondary school age)"
   - Adolescents_out_of_school:
-    - description: "male (% of male lower secondary school age)"
+    - description:
+      - "male (% of male lower secondary school age)"
   - Adults_(ages_15+)_and_children_(ages_0-14)_newly_infected_with_HIV:
-    - description: "Number of adults (ages 15+) and children (ages 0-14) newly infected with HIV."
+    - description:
+      - "Number of adults (ages 15+) and children (ages 0-14) newly infected with HIV."
   - Adults_(ages_15+)_newly_infected_with_HIV:
-    - description: "Number of adults (ages 15+) newly infected with HIV."
+    - description:
+      - "Number of adults (ages 15+) newly infected with HIV."
   - Age_dependency_ratio_(%_of_working-age_population):
-    - description: "Age dependency ratio is the ratio of dependents--people younger than 15 or older than 64--to the working-age population--those ages 15-64. Data are shown as the proportion of dependents per 100 working-age population."
+    - description:
+      - "Age dependency ratio is the ratio of dependents--people younger than 15 or older than 64--to the working-age population--those ages 15-64. Data are shown as the proportion of dependents per 100 working-age population."
   - Age_dependency_ratio:
-    - description: "old (% of working-age population)"
+    - description:
+      - "old (% of working-age population)"
   - Age_dependency_ratio:
-    - description: "young (% of working-age population)"
+    - description:
+      - "young (% of working-age population)"
   - Agricultural_irrigated_land_(%_of_total_agricultural_land):
-    - description: "Agricultural irrigated land refers to agricultural areas purposely provided with water"
+    - description:
+      - "Agricultural irrigated land refers to agricultural areas purposely provided with water"
   - Agricultural_land_(%_of_land_area):
-    - description: "Agricultural land refers to the share of land area that is arable"
+    - description:
+      - "Agricultural land refers to the share of land area that is arable"
   - Agricultural_land_(sq._km):
-    - description: "Agricultural land refers to the share of land area that is arable"
+    - description:
+      - "Agricultural land refers to the share of land area that is arable"
   - Agricultural_machinery:
-    - description: "tractors"
+    - description:
+      - "tractors"
   - Agricultural_machinery:
-    - description: "tractors per 100 sq. km of arable land"
+    - description:
+      - "tractors per 100 sq. km of arable land"
   - Agricultural_methane_emissions_(%_of_total):
-    - description: "Agricultural methane emissions are emissions from animals"
+    - description:
+      - "Agricultural methane emissions are emissions from animals"
   - Agricultural_methane_emissions_(thousand_metric_tons_of_CO2_equivalent):
-    - description: "Agricultural methane emissions are emissions from animals"
+    - description:
+      - "Agricultural methane emissions are emissions from animals"
   - Agricultural_nitrous_oxide_emissions_(%_of_total):
-    - description: "Agricultural nitrous oxide emissions are emissions produced through fertilizer use (synthetic and animal manure)"
+    - description:
+      - "Agricultural nitrous oxide emissions are emissions produced through fertilizer use (synthetic and animal manure)"
   - Agricultural_nitrous_oxide_emissions_(thousand_metric_tons_of_CO2_equivalent):
-    - description: "Agricultural nitrous oxide emissions are emissions produced through fertilizer use (synthetic and animal manure)"
+    - description:
+      - "Agricultural nitrous oxide emissions are emissions produced through fertilizer use (synthetic and animal manure)"
   - Agricultural_raw_materials_exports_(%_of_merchandise_exports):
-    - description: "Agricultural raw materials comprise SITC section 2 (crude materials except fuels) excluding divisions 22"
+    - description:
+      - "Agricultural raw materials comprise SITC section 2 (crude materials except fuels) excluding divisions 22"
   - Agricultural_raw_materials_imports_(%_of_merchandise_imports):
-    - description: "Agricultural raw materials comprise SITC section 2 (crude materials except fuels) excluding divisions 22"
+    - description:
+      - "Agricultural raw materials comprise SITC section 2 (crude materials except fuels) excluding divisions 22"
   - Agriculture:
-    - description: "value added (% of GDP)"
+    - description:
+      - "value added (% of GDP)"
   - Agriculture:
-    - description: "value added (annual % growth)"
+    - description:
+      - "value added (annual % growth)"
   - Agriculture:
-    - description: "value added (constant 2010 US$)"
+    - description:
+      - "value added (constant 2010 US$)"
   - Agriculture:
-    - description: "value added (constant LCU)"
+    - description:
+      - "value added (constant LCU)"
   - Agriculture:
-    - description: "value added (current LCU)"
+    - description:
+      - "value added (current LCU)"
   - Agriculture:
-    - description: "value added (current US$)"
+    - description:
+      - "value added (current US$)"
   - Agriculture:
-    - description: "value added per worker (constant 2010 US$)"
+    - description:
+      - "value added per worker (constant 2010 US$)"
   - Air_transport:
-    - description: "freight (million ton-km)"
+    - description:
+      - "freight (million ton-km)"
   - Air_transport:
-    - description: "passengers carried"
+    - description:
+      - "passengers carried"
   - Air_transport:
-    - description: "registered carrier departures worldwide"
+    - description:
+      - "registered carrier departures worldwide"
   - All_education_staff_compensation:
-    - description: "primary (% of total expenditure in primary public institutions)"
+    - description:
+      - "primary (% of total expenditure in primary public institutions)"
   - All_education_staff_compensation:
-    - description: "secondary (% of total expenditure in secondary public institutions)"
+    - description:
+      - "secondary (% of total expenditure in secondary public institutions)"
   - All_education_staff_compensation:
-    - description: "tertiary (% of total expenditure in tertiary public institutions)"
+    - description:
+      - "tertiary (% of total expenditure in tertiary public institutions)"
   - All_education_staff_compensation:
-    - description: "total (% of total expenditure in public institutions)"
+    - description:
+      - "total (% of total expenditure in public institutions)"
   - Alternative_and_nuclear_energy_(%_of_total_energy_use):
-    - description: "Clean energy is noncarbohydrate energy that does not produce carbon dioxide when generated. It includes hydropower and nuclear"
+    - description:
+      - "Clean energy is noncarbohydrate energy that does not produce carbon dioxide when generated. It includes hydropower and nuclear"
   - Annual_freshwater_withdrawals:
-    - description: "agriculture (% of total freshwater withdrawal)"
+    - description:
+      - "agriculture (% of total freshwater withdrawal)"
   - Annual_freshwater_withdrawals:
-    - description: "domestic (% of total freshwater withdrawal)"
+    - description:
+      - "domestic (% of total freshwater withdrawal)"
   - Annual_freshwater_withdrawals:
-    - description: "industry (% of total freshwater withdrawal)"
+    - description:
+      - "industry (% of total freshwater withdrawal)"
   - Annual_freshwater_withdrawals:
-    - description: "total (% of internal resources)"
+    - description:
+      - "total (% of internal resources)"
   - Annual_freshwater_withdrawals:
-    - description: "total (billion cubic meters)"
+    - description:
+      - "total (billion cubic meters)"
   - Annualized_average_growth_rate_in_per_capita_real_survey_mean_consumption_or_income:
-    - description: "bottom 40% of population (%)"
+    - description:
+      - "bottom 40% of population (%)"
   - World_Bank:
-    - description: "Global Database of Shared Prosperity (GDSP) circa 2010-2015 (http://www.worldbank.org/en/topic/poverty/brief/global-database-of-shared-prosperity)."
+    - description:
+      - "Global Database of Shared Prosperity (GDSP) circa 2010-2015 (http://www.worldbank.org/en/topic/poverty/brief/global-database-of-shared-prosperity)."
   - Annualized_average_growth_rate_in_per_capita_real_survey_mean_consumption_or_income:
-    - description: "total population (%)"
+    - description:
+      - "total population (%)"
   - World_Bank:
-    - description: "Global Database of Shared Prosperity (GDSP) circa 2010-2015  (http://www.worldbank.org/en/topic/poverty/brief/global-database-of-shared-prosperity)."
+    - description:
+      - "Global Database of Shared Prosperity (GDSP) circa 2010-2015  (http://www.worldbank.org/en/topic/poverty/brief/global-database-of-shared-prosperity)."
   - Antiretroviral_therapy_coverage_(%_of_people_living_with_HIV):
-    - description: "Antiretroviral therapy coverage indicates the percentage of all people living with HIV who are receiving antiretroviral therapy."
+    - description:
+      - "Antiretroviral therapy coverage indicates the percentage of all people living with HIV who are receiving antiretroviral therapy."
   - Antiretroviral_therapy_coverage_for_PMTCT_(%_of_pregnant_women_living_with_HIV):
-    - description: "Percentage of pregnant women with HIV who receive antiretroviral medicine for prevention of mother-to-child transmission (PMTCT)."
+    - description:
+      - "Percentage of pregnant women with HIV who receive antiretroviral medicine for prevention of mother-to-child transmission (PMTCT)."
   - Aquaculture_production_(metric_tons):
-    - description: "Aquaculture is understood to mean the farming of aquatic organisms including fish"
+    - description:
+      - "Aquaculture is understood to mean the farming of aquatic organisms including fish"
   - Arable_land_(%_of_land_area):
-    - description: "Arable land includes land defined by the FAO as land under temporary crops (double-cropped areas are counted once)"
+    - description:
+      - "Arable land includes land defined by the FAO as land under temporary crops (double-cropped areas are counted once)"
   - Arable_land_(hectares_per_person):
-    - description: "Arable land (hectares per person) includes land defined by the FAO as land under temporary crops (double-cropped areas are counted once)"
+    - description:
+      - "Arable land (hectares per person) includes land defined by the FAO as land under temporary crops (double-cropped areas are counted once)"
   - Arable_land_(hectares):
-    - description: "Arable land (in hectares) includes land defined by the FAO as land under temporary crops (double-cropped areas are counted once)"
+    - description:
+      - "Arable land (in hectares) includes land defined by the FAO as land under temporary crops (double-cropped areas are counted once)"
   - ARI_treatment_(%_of_children_under_5_taken_to_a_health_provider):
-    - description: "Children with acute respiratory infection (ARI) who are taken to a health provider refers to the percentage of children under age five with ARI in the last two weeks who were taken to an appropriate health provider"
+    - description:
+      - "Children with acute respiratory infection (ARI) who are taken to a health provider refers to the percentage of children under age five with ARI in the last two weeks who were taken to an appropriate health provider"
   - Armed_forces_personnel_(%_of_total_labor_force):
-    - description: "Armed forces personnel are active duty military personnel"
+    - description:
+      - "Armed forces personnel are active duty military personnel"
   - Armed_forces_personnel:
-    - description: "total"
+    - description:
+      - "total"
   - Arms_exports_(SIPRI_trend_indicator_values):
-    - description: "Arms transfers cover the supply of military weapons through sales"
+    - description:
+      - "Arms transfers cover the supply of military weapons through sales"
   - Arms_imports_(SIPRI_trend_indicator_values):
-    - description: "Arms transfers cover the supply of military weapons through sales"
+    - description:
+      - "Arms transfers cover the supply of military weapons through sales"
   - Automated_teller_machines_(ATMs)_(per_100:
-    - description: "000 adults)"
+    - description:
+      - "000 adults)"
   - Average_grace_period_on_new_external_debt_commitments_(years):
-    - description: "Grace period is the period from the date of signature of the loan or the issue of the financial instrument to the first repayment of principal. To obtain the average"
+    - description:
+      - "Grace period is the period from the date of signature of the loan or the issue of the financial instrument to the first repayment of principal. To obtain the average"
   - Average_grace_period_on_new_external_debt_commitments:
-    - description: "official (years)"
+    - description:
+      - "official (years)"
   - Average_grace_period_on_new_external_debt_commitments:
-    - description: "private (years)"
+    - description:
+      - "private (years)"
   - Average_grant_element_on_new_external_debt_commitments_(%):
-    - description: "The grant element of a loan is the grant equivalent expressed as a percentage of the amount committed. It is used as a measure of the overall cost of borrowing. To obtain the average"
+    - description:
+      - "The grant element of a loan is the grant equivalent expressed as a percentage of the amount committed. It is used as a measure of the overall cost of borrowing. To obtain the average"
   - Average_grant_element_on_new_external_debt_commitments:
-    - description: "official (%)"
+    - description:
+      - "official (%)"
   - Average_grant_element_on_new_external_debt_commitments:
-    - description: "private (%)"
+    - description:
+      - "private (%)"
   - Average_interest_on_new_external_debt_commitments_(%):
-    - description: "Interest represents the average interest rate on all new public and publicly guaranteed loans contracted during the year. To obtain the average"
+    - description:
+      - "Interest represents the average interest rate on all new public and publicly guaranteed loans contracted during the year. To obtain the average"
   - Average_interest_on_new_external_debt_commitments:
-    - description: "official (%)"
+    - description:
+      - "official (%)"
   - Average_interest_on_new_external_debt_commitments:
-    - description: "private (%)"
+    - description:
+      - "private (%)"
   - Average_maturity_on_new_external_debt_commitments_(years):
-    - description: "Maturity is the number of years to original maturity date"
+    - description:
+      - "Maturity is the number of years to original maturity date"
   - Average_maturity_on_new_external_debt_commitments:
-    - description: "official (years)"
+    - description:
+      - "official (years)"
   - Average_maturity_on_new_external_debt_commitments:
-    - description: "private (years)"
+    - description:
+      - "private (years)"
   - Average_precipitation_in_depth_(mm_per_year):
-    - description: "Average precipitation is the long-term average in depth (over space and time) of annual precipitation in the country. Precipitation is defined as any kind of water that falls from clouds as a liquid or a solid."
+    - description:
+      - "Average precipitation is the long-term average in depth (over space and time) of annual precipitation in the country. Precipitation is defined as any kind of water that falls from clouds as a liquid or a solid."
   - Average_time_to_clear_exports_through_customs_(days):
-    - description: "Average time to clear exports through customs is the average number of days to clear direct exports through customs."
+    - description:
+      - "Average time to clear exports through customs is the average number of days to clear direct exports through customs."
   - Average_transaction_cost_of_sending_remittances_from_a_specific_country_(%):
-    - description: "Average transaction cost of sending remittance from a specific country is the average of the total transaction cost in percentage of the amount sent for sending USD 200 charged by each single remittance service provider (RSP) included in the Remittance Prices Worldwide (RPW) database from a specific country."
+    - description:
+      - "Average transaction cost of sending remittance from a specific country is the average of the total transaction cost in percentage of the amount sent for sending USD 200 charged by each single remittance service provider (RSP) included in the Remittance Prices Worldwide (RPW) database from a specific country."
   - Average_transaction_cost_of_sending_remittances_to_a_specific_country_(%):
-    - description: "Average transaction cost of sending remittance to a specific country is the average of the total transaction cost in percentage of the amount sent for sending USD 200 charged by each single remittance service provider (RSP) included in the Remittance Prices Worldwide (RPW) database to a specific country."
+    - description:
+      - "Average transaction cost of sending remittance to a specific country is the average of the total transaction cost in percentage of the amount sent for sending USD 200 charged by each single remittance service provider (RSP) included in the Remittance Prices Worldwide (RPW) database to a specific country."
   - Average_working_hours_of_children:
-    - description: "study and work"
+    - description:
+      - "study and work"
   - Average_working_hours_of_children:
-    - description: "study and work"
+    - description:
+      - "study and work"
   - Average_working_hours_of_children:
-    - description: "study and work"
+    - description:
+      - "study and work"
   - Average_working_hours_of_children:
-    - description: "working only"
+    - description:
+      - "working only"
   - Average_working_hours_of_children:
-    - description: "working only"
+    - description:
+      - "working only"
   - Average_working_hours_of_children:
-    - description: "working only"
+    - description:
+      - "working only"
   - Bank_capital_to_assets_ratio_(%):
-    - description: "Bank capital to assets is the ratio of bank capital and reserves to total assets. Capital and reserves include funds contributed by owners"
+    - description:
+      - "Bank capital to assets is the ratio of bank capital and reserves to total assets. Capital and reserves include funds contributed by owners"
   - Bank_liquid_reserves_to_bank_assets_ratio_(%):
-    - description: "Ratio of bank liquid reserves to bank assets is the ratio of domestic currency holdings and deposits with the monetary authorities to claims on other governments"
+    - description:
+      - "Ratio of bank liquid reserves to bank assets is the ratio of domestic currency holdings and deposits with the monetary authorities to claims on other governments"
   - Bank_nonperforming_loans_to_total_gross_loans_(%):
-    - description: "Bank nonperforming loans to total gross loans are the value of nonperforming loans divided by the total value of the loan portfolio (including nonperforming loans before the deduction of specific loan-loss provisions). The loan amount recorded as nonperforming should be the gross value of the loan as recorded on the balance sheet"
+    - description:
+      - "Bank nonperforming loans to total gross loans are the value of nonperforming loans divided by the total value of the loan portfolio (including nonperforming loans before the deduction of specific loan-loss provisions). The loan amount recorded as nonperforming should be the gross value of the loan as recorded on the balance sheet"
   - Battle-related_deaths_(number_of_people):
-    - description: "Battle-related deaths are deaths in battle-related conflicts between warring parties in the conflict dyad (two conflict units that are parties to a conflict). Typically"
+    - description:
+      - "Battle-related deaths are deaths in battle-related conflicts between warring parties in the conflict dyad (two conflict units that are parties to a conflict). Typically"
   - Benefit_incidence_of_social_insurance_programs_to_poorest_quintile_(%_of_total_social_insurance_benefits):
-    - description: "Benefit incidence of social insurance programs to poorest quintile shows the percentage of total social insurance benefits received by the poorest 20% of the population. Social insurance programs include old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
+    - description:
+      - "Benefit incidence of social insurance programs to poorest quintile shows the percentage of total social insurance benefits received by the poorest 20% of the population. Social insurance programs include old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
   - Benefit_incidence_of_social_protection_and_labor_programs_to_poorest_quintile_(%_of_total_SPL_benefits):
-    - description: "Benefit incidence of social protection and labor programs (SPL) to poorest quintile shows the percentage of total social protection and labor programs benefits received by the poorest 20% of the population. Social protection and labor programs include social insurance"
+    - description:
+      - "Benefit incidence of social protection and labor programs (SPL) to poorest quintile shows the percentage of total social protection and labor programs benefits received by the poorest 20% of the population. Social protection and labor programs include social insurance"
   - Benefit_incidence_of_social_safety_net_programs_to_poorest_quintile_(%_of_total_safety_net_benefits):
-    - description: "Benefit incidence of social safety net programs to poorest quintile shows the percentage of total social safety net benefits received by the poorest 20% of the population. Social safety net programs include cash transfers and last resort programs"
+    - description:
+      - "Benefit incidence of social safety net programs to poorest quintile shows the percentage of total social safety net benefits received by the poorest 20% of the population. Social safety net programs include cash transfers and last resort programs"
   - Benefit_incidence_of_unemployment_benefits_and_ALMP_to_poorest_quintile_(%_of_total_U/ALMP_benefits):
-    - description: "Benefit incidence of unemployment benefits and active labor market programs (ALMP) to poorest quintile shows the percentage of total unemployment and active labor market programs benefits received by the poorest 20% of the population. Unemployment benefits and active labor market programs include unemployment compensation"
+    - description:
+      - "Benefit incidence of unemployment benefits and active labor market programs (ALMP) to poorest quintile shows the percentage of total unemployment and active labor market programs benefits received by the poorest 20% of the population. Unemployment benefits and active labor market programs include unemployment compensation"
   - Binding_coverage:
-    - description: "all products (%)"
+    - description:
+      - "all products (%)"
   - Binding_coverage:
-    - description: "manufactured products (%)"
+    - description:
+      - "manufactured products (%)"
   - Binding_coverage:
-    - description: "primary products (%)"
+    - description:
+      - "primary products (%)"
   - Bird_species:
-    - description: "threatened"
+    - description:
+      - "threatened"
   - Birth_rate:
-    - description: "crude (per 1"
+    - description:
+      - "crude (per 1"
   - Births_attended_by_skilled_health_staff_(%_of_total):
-    - description: "Births attended by skilled health staff are the percentage of deliveries attended by personnel trained to give the necessary supervision"
+    - description:
+      - "Births attended by skilled health staff are the percentage of deliveries attended by personnel trained to give the necessary supervision"
   - Borrowers_from_commercial_banks_(per_1:
-    - description: "000 adults)"
+    - description:
+      - "000 adults)"
   - Bound_rate:
-    - description: "simple mean"
+    - description:
+      - "simple mean"
   - Bound_rate:
-    - description: "simple mean"
+    - description:
+      - "simple mean"
   - Bound_rate:
-    - description: "simple mean"
+    - description:
+      - "simple mean"
   - Bribery_incidence_(%_of_firms_experiencing_at_least_one_bribe_payment_request):
-    - description: "Bribery incidence is the percentage of firms experiencing at least one bribe payment request across 6 public transactions dealing with utilities access"
+    - description:
+      - "Bribery incidence is the percentage of firms experiencing at least one bribe payment request across 6 public transactions dealing with utilities access"
   - Broad_money_(%_of_GDP):
-    - description: "Broad money (IFS line 35L..ZK) is the sum of currency outside banks; demand deposits other than those of the central government; the time"
+    - description:
+      - "Broad money (IFS line 35L..ZK) is the sum of currency outside banks; demand deposits other than those of the central government; the time"
   - Broad_money_(current_LCU):
-    - description: "Broad money (IFS line 35L..ZK) is the sum of currency outside banks; demand deposits other than those of the central government; the time"
+    - description:
+      - "Broad money (IFS line 35L..ZK) is the sum of currency outside banks; demand deposits other than those of the central government; the time"
   - Broad_money_growth_(annual_%):
-    - description: "Broad money (IFS line 35L..ZK) is the sum of currency outside banks; demand deposits other than those of the central government; the time"
+    - description:
+      - "Broad money (IFS line 35L..ZK) is the sum of currency outside banks; demand deposits other than those of the central government; the time"
   - Broad_money_to_total_reserves_ratio:
-    - description: "Broad money (IFS line 35L..ZK) is the sum of currency outside banks; demand deposits other than those of the central government; the time"
+    - description:
+      - "Broad money (IFS line 35L..ZK) is the sum of currency outside banks; demand deposits other than those of the central government; the time"
   - Burden_of_customs_procedure:
-    - description: "WEF (1=extremely inefficient to 7=extremely efficient)"
+    - description:
+      - "WEF (1=extremely inefficient to 7=extremely efficient)"
   - Business_extent_of_disclosure_index_(0=less_disclosure_to_10=more_disclosure):
-    - description: "Disclosure index measures the extent to which investors are protected through disclosure of ownership and financial information. The index ranges from 0 to 10"
+    - description:
+      - "Disclosure index measures the extent to which investors are protected through disclosure of ownership and financial information. The index ranges from 0 to 10"
   - Capture_fisheries_production_(metric_tons):
-    - description: "Capture fisheries production measures the volume of fish catches landed by a country for all commercial"
+    - description:
+      - "Capture fisheries production measures the volume of fish catches landed by a country for all commercial"
   - Cause_of_death:
-    - description: "by communicable diseases and maternal"
+    - description:
+      - "by communicable diseases and maternal"
   - Cause_of_death:
-    - description: "by injury (% of total)"
+    - description:
+      - "by injury (% of total)"
   - Cause_of_death:
-    - description: "by non-communicable diseases (% of total)"
+    - description:
+      - "by non-communicable diseases (% of total)"
   - Central_government_debt:
-    - description: "total (% of GDP)"
+    - description:
+      - "total (% of GDP)"
   - Central_government_debt:
-    - description: "total (current LCU)"
+    - description:
+      - "total (current LCU)"
   - Cereal_production_(metric_tons):
-    - description: "Production data on cereals relate to crops harvested for dry grain only. Cereal crops harvested for hay or harvested green for food"
+    - description:
+      - "Production data on cereals relate to crops harvested for dry grain only. Cereal crops harvested for hay or harvested green for food"
   - Cereal_yield_(kg_per_hectare):
-    - description: "Cereal yield"
+    - description:
+      - "Cereal yield"
   - Changes_in_inventories_(constant_LCU):
-    - description: "Inventories are stocks of goods held by firms to meet temporary or unexpected fluctuations in production or sales"
+    - description:
+      - "Inventories are stocks of goods held by firms to meet temporary or unexpected fluctuations in production or sales"
   - Changes_in_inventories_(current_LCU):
-    - description: "Inventories are stocks of goods held by firms to meet temporary or unexpected fluctuations in production or sales"
+    - description:
+      - "Inventories are stocks of goods held by firms to meet temporary or unexpected fluctuations in production or sales"
   - Changes_in_inventories_(current_US$):
-    - description: "Inventories are stocks of goods held by firms to meet temporary or unexpected fluctuations in production or sales"
+    - description:
+      - "Inventories are stocks of goods held by firms to meet temporary or unexpected fluctuations in production or sales"
   - Charges_for_the_use_of_intellectual_property:
-    - description: "payments (BoP"
+    - description:
+      - "payments (BoP"
   - Charges_for_the_use_of_intellectual_property:
-    - description: "receipts (BoP"
+    - description:
+      - "receipts (BoP"
   - Chemicals_(%_of_value_added_in_manufacturing):
-    - description: "Value added in manufacturing is the sum of gross output less the value of intermediate inputs used in production for industries classified in ISIC major division D. Chemicals correspond to ISIC division 24."
+    - description:
+      - "Value added in manufacturing is the sum of gross output less the value of intermediate inputs used in production for industries classified in ISIC major division D. Chemicals correspond to ISIC division 24."
   - Child_employment_in_agriculture_(%_of_economically_active_children_ages_7-14):
-    - description: "Employment by economic activity refers to the distribution of economically active children by the major industrial categories of the International Standard Industrial Classification (ISIC). Agriculture corresponds to division 1 (ISIC revision 2)"
+    - description:
+      - "Employment by economic activity refers to the distribution of economically active children by the major industrial categories of the International Standard Industrial Classification (ISIC). Agriculture corresponds to division 1 (ISIC revision 2)"
   - Child_employment_in_agriculture:
-    - description: "female (% of female economically active children ages 7-14)"
+    - description:
+      - "female (% of female economically active children ages 7-14)"
   - Child_employment_in_agriculture:
-    - description: "male (% of male economically active children ages 7-14)"
+    - description:
+      - "male (% of male economically active children ages 7-14)"
   - Child_employment_in_manufacturing_(%_of_economically_active_children_ages_7-14):
-    - description: "Employment by economic activity refers to the distribution of economically active children by the major industrial categories of the International Standard Industrial Classification (ISIC). Manufacturing corresponds to division 3 (ISIC revision 2)"
+    - description:
+      - "Employment by economic activity refers to the distribution of economically active children by the major industrial categories of the International Standard Industrial Classification (ISIC). Manufacturing corresponds to division 3 (ISIC revision 2)"
   - Child_employment_in_manufacturing:
-    - description: "female (% of female economically active children ages 7-14)"
+    - description:
+      - "female (% of female economically active children ages 7-14)"
   - Child_employment_in_manufacturing:
-    - description: "male (% of male economically active children ages 7-14)"
+    - description:
+      - "male (% of male economically active children ages 7-14)"
   - Child_employment_in_services_(%_of_economically_active_children_ages_7-14):
-    - description: "Employment by economic activity refers to the distribution of economically active children by the major industrial categories of the International Standard Industrial Classification (ISIC). Services correspond to divisions 6-9 (ISIC revision 2)"
+    - description:
+      - "Employment by economic activity refers to the distribution of economically active children by the major industrial categories of the International Standard Industrial Classification (ISIC). Services correspond to divisions 6-9 (ISIC revision 2)"
   - Child_employment_in_services:
-    - description: "female (% of female economically active children ages 7-14)"
+    - description:
+      - "female (% of female economically active children ages 7-14)"
   - Child_employment_in_services:
-    - description: "male (% of male economically active children ages 7-14)"
+    - description:
+      - "male (% of male economically active children ages 7-14)"
   - Children_(0-14)_living_with_HIV:
-    - description: "Children living with HIV refers to the number of children ages 0-14 who are infected with HIV."
+    - description:
+      - "Children living with HIV refers to the number of children ages 0-14 who are infected with HIV."
   - Children_(ages_0-14)_newly_infected_with_HIV:
-    - description: "Number of children (ages 0-14) newly infected with HIV."
+    - description:
+      - "Number of children (ages 0-14) newly infected with HIV."
   - Children_in_employment:
-    - description: "female (% of female children ages 7-14)"
+    - description:
+      - "female (% of female children ages 7-14)"
   - Children_in_employment:
-    - description: "male (% of male children ages 7-14)"
+    - description:
+      - "male (% of male children ages 7-14)"
   - Children_in_employment:
-    - description: "self-employed (% of children in employment"
+    - description:
+      - "self-employed (% of children in employment"
   - Children_in_employment:
-    - description: "self-employed"
+    - description:
+      - "self-employed"
   - Children_in_employment:
-    - description: "self-employed"
+    - description:
+      - "self-employed"
   - Children_in_employment:
-    - description: "study and work (% of children in employment"
+    - description:
+      - "study and work (% of children in employment"
   - Children_in_employment:
-    - description: "study and work"
+    - description:
+      - "study and work"
   - Children_in_employment:
-    - description: "study and work"
+    - description:
+      - "study and work"
   - Children_in_employment:
-    - description: "total (% of children ages 7-14)"
+    - description:
+      - "total (% of children ages 7-14)"
   - Children_in_employment:
-    - description: "unpaid family workers (% of children in employment"
+    - description:
+      - "unpaid family workers (% of children in employment"
   - Children_in_employment:
-    - description: "unpaid family workers"
+    - description:
+      - "unpaid family workers"
   - Children_in_employment:
-    - description: "unpaid family workers"
+    - description:
+      - "unpaid family workers"
   - Children_in_employment:
-    - description: "wage workers (% of children in employment"
+    - description:
+      - "wage workers (% of children in employment"
   - Children_in_employment:
-    - description: "wage workers"
+    - description:
+      - "wage workers"
   - Children_in_employment:
-    - description: "wage workers"
+    - description:
+      - "wage workers"
   - Children_in_employment:
-    - description: "work only (% of children in employment"
+    - description:
+      - "work only (% of children in employment"
   - Children_in_employment:
-    - description: "work only"
+    - description:
+      - "work only"
   - Children_in_employment:
-    - description: "work only"
+    - description:
+      - "work only"
   - Children_out_of_school_(%_of_primary_school_age):
-    - description: "Children out of school are the percentage of primary-school-age children who are not enrolled in primary or secondary school. Children in the official primary age group that are in preprimary education should be considered out of school."
+    - description:
+      - "Children out of school are the percentage of primary-school-age children who are not enrolled in primary or secondary school. Children in the official primary age group that are in preprimary education should be considered out of school."
   - Children_out_of_school:
-    - description: "female (% of female primary school age)"
+    - description:
+      - "female (% of female primary school age)"
   - Children_out_of_school:
-    - description: "male (% of male primary school age)"
+    - description:
+      - "male (% of male primary school age)"
   - Children_out_of_school:
-    - description: "primary"
+    - description:
+      - "primary"
   - Children_out_of_school:
-    - description: "primary"
+    - description:
+      - "primary"
   - Children_out_of_school:
-    - description: "primary"
+    - description:
+      - "primary"
   - Children_with_fever_receiving_antimalarial_drugs_(%_of_children_under_age_5_with_fever):
-    - description: "Malaria treatment refers to the percentage of children under age five who were ill with fever in the last two weeks and received any appropriate (locally defined) anti-malarial drugs."
+    - description:
+      - "Malaria treatment refers to the percentage of children under age five who were ill with fever in the last two weeks and received any appropriate (locally defined) anti-malarial drugs."
   - Claims_on_central_government_(annual_growth_as_%_of_broad_money):
-    - description: "Claims on central government (IFS line 32AN..ZK) include loans to central government institutions net of deposits."
+    - description:
+      - "Claims on central government (IFS line 32AN..ZK) include loans to central government institutions net of deposits."
   - Claims_on_central_government:
-    - description: "etc. (% GDP)"
+    - description:
+      - "etc. (% GDP)"
   - Claims_on_other_sectors_of_the_domestic_economy_(%_of_GDP):
-    - description: "Claims on other sectors of the domestic economy (IFS line 52S or 32S) include gross credit from the financial system to households"
+    - description:
+      - "Claims on other sectors of the domestic economy (IFS line 52S or 32S) include gross credit from the financial system to households"
   - Claims_on_other_sectors_of_the_domestic_economy_(annual_growth_as_%_of_broad_money):
-    - description: "Claims on other sectors of the domestic economy (IFS line 32S..ZK) include gross credit from the financial system to households"
+    - description:
+      - "Claims on other sectors of the domestic economy (IFS line 32S..ZK) include gross credit from the financial system to households"
   - Claims_on_private_sector_(annual_growth_as_%_of_broad_money):
-    - description: "Claims on private sector (IFS line 32D..ZK or 32D..ZF) include gross credit from the financial system to individuals"
+    - description:
+      - "Claims on private sector (IFS line 32D..ZK or 32D..ZF) include gross credit from the financial system to individuals"
   - CO2_emissions_(kg_per_2010_US$_of_GDP):
-    - description: "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
+    - description:
+      - "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
   - CO2_emissions_(kg_per_2011_PPP_$_of_GDP):
-    - description: "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
+    - description:
+      - "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
   - CO2_emissions_(kg_per_PPP_$_of_GDP):
-    - description: "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
+    - description:
+      - "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
   - CO2_emissions_(kt):
-    - description: "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
+    - description:
+      - "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
   - CO2_emissions_(metric_tons_per_capita):
-    - description: "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
+    - description:
+      - "Carbon dioxide emissions are those stemming from the burning of fossil fuels and the manufacture of cement. They include carbon dioxide produced during consumption of solid"
   - CO2_emissions_from_electricity_and_heat_production:
-    - description: "total (% of total fuel combustion)"
+    - description:
+      - "total (% of total fuel combustion)"
   - CO2_emissions_from_gaseous_fuel_consumption_(%_of_total):
-    - description: "Carbon dioxide emissions from liquid fuel consumption refer mainly to emissions from use of natural gas as an energy source."
+    - description:
+      - "Carbon dioxide emissions from liquid fuel consumption refer mainly to emissions from use of natural gas as an energy source."
   - CO2_emissions_from_gaseous_fuel_consumption_(kt):
-    - description: "Carbon dioxide emissions from liquid fuel consumption refer mainly to emissions from use of natural gas as an energy source."
+    - description:
+      - "Carbon dioxide emissions from liquid fuel consumption refer mainly to emissions from use of natural gas as an energy source."
   - CO2_emissions_from_liquid_fuel_consumption_(%_of_total):
-    - description: "Carbon dioxide emissions from liquid fuel consumption refer mainly to emissions from use of petroleum-derived fuels as an energy source."
+    - description:
+      - "Carbon dioxide emissions from liquid fuel consumption refer mainly to emissions from use of petroleum-derived fuels as an energy source."
   - CO2_emissions_from_liquid_fuel_consumption_(kt):
-    - description: "Carbon dioxide emissions from liquid fuel consumption refer mainly to emissions from use of petroleum-derived fuels as an energy source."
+    - description:
+      - "Carbon dioxide emissions from liquid fuel consumption refer mainly to emissions from use of petroleum-derived fuels as an energy source."
   - CO2_emissions_from_manufacturing_industries_and_construction_(%_of_total_fuel_combustion):
-    - description: "CO2 emissions from manufacturing industries and construction contains the emissions from combustion of fuels in industry. The IPCC Source/Sink Category 1 A 2 includes these emissions. However"
+    - description:
+      - "CO2 emissions from manufacturing industries and construction contains the emissions from combustion of fuels in industry. The IPCC Source/Sink Category 1 A 2 includes these emissions. However"
   - CO2_emissions_from_other_sectors:
-    - description: "excluding residential buildings and commercial and public services (% of total fuel combustion)"
+    - description:
+      - "excluding residential buildings and commercial and public services (% of total fuel combustion)"
   - CO2_emissions_from_residential_buildings_and_commercial_and_public_services_(%_of_total_fuel_combustion):
-    - description: "CO2 emissions from residential buildings and commercial and public services contains all emissions from fuel combustion in households. This corresponds to IPCC Source/Sink Category 1 A 4 b. Commercial and public services includes emissions from all activities of ISIC Divisions 41"
+    - description:
+      - "CO2 emissions from residential buildings and commercial and public services contains all emissions from fuel combustion in households. This corresponds to IPCC Source/Sink Category 1 A 4 b. Commercial and public services includes emissions from all activities of ISIC Divisions 41"
   - CO2_emissions_from_solid_fuel_consumption_(%_of_total):
-    - description: "Carbon dioxide emissions from solid fuel consumption refer mainly to emissions from use of coal as an energy source."
+    - description:
+      - "Carbon dioxide emissions from solid fuel consumption refer mainly to emissions from use of coal as an energy source."
   - CO2_emissions_from_solid_fuel_consumption_(kt):
-    - description: "Carbon dioxide emissions from solid fuel consumption refer mainly to emissions from use of coal as an energy source."
+    - description:
+      - "Carbon dioxide emissions from solid fuel consumption refer mainly to emissions from use of coal as an energy source."
   - CO2_emissions_from_transport_(%_of_total_fuel_combustion):
-    - description: "CO2 emissions from transport contains emissions from the combustion of fuel for all transport activity"
+    - description:
+      - "CO2 emissions from transport contains emissions from the combustion of fuel for all transport activity"
   - CO2_intensity_(kg_per_kg_of_oil_equivalent_energy_use):
-    - description: "Carbon dioxide emissions from solid fuel consumption refer mainly to emissions from use of coal as an energy source."
+    - description:
+      - "Carbon dioxide emissions from solid fuel consumption refer mainly to emissions from use of coal as an energy source."
   - Coal_rents_(%_of_GDP):
-    - description: "Coal rents are the difference between the value of both hard and soft coal production at world prices and their total costs of production."
+    - description:
+      - "Coal rents are the difference between the value of both hard and soft coal production at world prices and their total costs of production."
   - Combustible_renewables_and_waste_(%_of_total_energy):
-    - description: "Combustible renewables and waste comprise solid biomass"
+    - description:
+      - "Combustible renewables and waste comprise solid biomass"
   - Commercial_bank_branches_(per_100:
-    - description: "000 adults)"
+    - description:
+      - "000 adults)"
   - Commercial_banks_and_other_lending_(PPG_+_PNG)_(NFL:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Commercial_service_exports_(current_US$):
-    - description: "Commercial service exports are total service exports minus exports of government services not included elsewhere. International transactions in services are defined by the IMF's Balance of Payments Manual (1993) as the economic output of intangible commodities that may be produced"
+    - description:
+      - "Commercial service exports are total service exports minus exports of government services not included elsewhere. International transactions in services are defined by the IMF's Balance of Payments Manual (1993) as the economic output of intangible commodities that may be produced"
   - Commercial_service_imports_(current_US$):
-    - description: "Commercial service imports are total service imports minus imports of government services not included elsewhere. International transactions in services are defined by the IMF's Balance of Payments Manual (1993) as the economic output of intangible commodities that may be produced"
+    - description:
+      - "Commercial service imports are total service imports minus imports of government services not included elsewhere. International transactions in services are defined by the IMF's Balance of Payments Manual (1993) as the economic output of intangible commodities that may be produced"
   - Commitments:
-    - description: "IBRD (COM"
+    - description:
+      - "IBRD (COM"
   - Commitments:
-    - description: "IDA (COM"
+    - description:
+      - "IDA (COM"
   - Commitments:
-    - description: "official creditors (COM"
+    - description:
+      - "official creditors (COM"
   - Commitments:
-    - description: "private creditors (COM"
+    - description:
+      - "private creditors (COM"
   - Commitments:
-    - description: "public and publicly guaranteed (COM"
+    - description:
+      - "public and publicly guaranteed (COM"
   - Communications:
-    - description: "computer"
+    - description:
+      - "computer"
   - Communications:
-    - description: "computer"
+    - description:
+      - "computer"
   - Community_health_workers_(per_1:
-    - description: "000 people)"
+    - description:
+      - "000 people)"
   - Compensation_of_employees_(%_of_expense):
-    - description: "Compensation of employees consists of all payments in cash"
+    - description:
+      - "Compensation of employees consists of all payments in cash"
   - Compensation_of_employees_(current_LCU):
-    - description: "Compensation of employees consists of all payments in cash"
+    - description:
+      - "Compensation of employees consists of all payments in cash"
   - Completeness_of_birth_registration_(%):
-    - description: "Completeness of birth registration is the percentage of children under age 5 whose births were registered at the time of the survey. The numerator of completeness of birth registration includes children whose birth certificate was seen by the interviewer or whose mother or caretaker says the birth has been registered."
+    - description:
+      - "Completeness of birth registration is the percentage of children under age 5 whose births were registered at the time of the survey. The numerator of completeness of birth registration includes children whose birth certificate was seen by the interviewer or whose mother or caretaker says the birth has been registered."
   - Completeness_of_birth_registration:
-    - description: "female (%)"
+    - description:
+      - "female (%)"
   - Completeness_of_birth_registration:
-    - description: "male (%)"
+    - description:
+      - "male (%)"
   - Completeness_of_birth_registration:
-    - description: "rural (%)"
+    - description:
+      - "rural (%)"
   - Completeness_of_birth_registration:
-    - description: "urban (%)"
+    - description:
+      - "urban (%)"
   - Completeness_of_death_registration_with_cause-of-death_information_(%):
-    - description: "Completeness of death registration is the estimated percentage of deaths that are registered with their cause of death information in the vital registration system of a country."
+    - description:
+      - "Completeness of death registration is the estimated percentage of deaths that are registered with their cause of death information in the vital registration system of a country."
   - Completeness_of_infant_death_reporting_(%_of_reported_infant_deaths_to_estimated_infant_deaths):
-    - description: "Completeness of infant death reporting is the number of infant deaths reported by national statistics authorities to the United Nations Statistics Division's Demography Yearbook divided by the number of infant deaths estimated by the United Nations Population Division."
+    - description:
+      - "Completeness of infant death reporting is the number of infant deaths reported by national statistics authorities to the United Nations Statistics Division's Demography Yearbook divided by the number of infant deaths estimated by the United Nations Population Division."
   - Completeness_of_total_death_reporting_(%_of_reported_total_deaths_to_estimated_total_deaths):
-    - description: "Completeness of total death reporting is the number of total deaths reported by national statistics authorities to the United Nations Statistics Division's Demography Yearbook divided by the number of total deaths estimated by the United Nations Population Division."
+    - description:
+      - "Completeness of total death reporting is the number of total deaths reported by national statistics authorities to the United Nations Statistics Division's Demography Yearbook divided by the number of total deaths estimated by the United Nations Population Division."
   - Compulsory_education:
-    - description: "duration (years)"
+    - description:
+      - "duration (years)"
   - Computer:
-    - description: "communications and other services (% of commercial service exports)"
+    - description:
+      - "communications and other services (% of commercial service exports)"
   - Computer:
-    - description: "communications and other services (% of commercial service imports)"
+    - description:
+      - "communications and other services (% of commercial service imports)"
   - Concessional_debt_(%_of_total_external_debt):
-    - description: "Concessional debt to total external debt stocks. Concessional debt is defined as loans with an original grant element of 25 percent or more."
+    - description:
+      - "Concessional debt to total external debt stocks. Concessional debt is defined as loans with an original grant element of 25 percent or more."
   - Condom_use:
-    - description: "population ages 15-24"
+    - description:
+      - "population ages 15-24"
   - Condom_use:
-    - description: "population ages 15-24"
+    - description:
+      - "population ages 15-24"
   - Consumer_price_index_(2010_=_100):
-    - description: "Consumer price index reflects changes in the cost to the average consumer of acquiring a basket of goods and services that may be fixed or changed at specified intervals"
+    - description:
+      - "Consumer price index reflects changes in the cost to the average consumer of acquiring a basket of goods and services that may be fixed or changed at specified intervals"
   - Consumption_of_iodized_salt_(%_of_households):
-    - description: "Consumption of iodized salt refers to the percentage of households that use edible salt fortified with iodine."
+    - description:
+      - "Consumption of iodized salt refers to the percentage of households that use edible salt fortified with iodine."
   - Container_port_traffic_(TEU:_20_foot_equivalent_units):
-    - description: "Port container traffic measures the flow of containers from land to sea transport modes."
+    - description:
+      - "Port container traffic measures the flow of containers from land to sea transport modes."
   - Contraceptive_prevalence:
-    - description: "any methods (% of women ages 15-49)"
+    - description:
+      - "any methods (% of women ages 15-49)"
   - Contraceptive_prevalence:
-    - description: "modern methods (% of women ages 15-49)"
+    - description:
+      - "modern methods (% of women ages 15-49)"
   - Contributing_family_workers:
-    - description: "female (% of female employment) (modeled ILO estimate)"
+    - description:
+      - "female (% of female employment) (modeled ILO estimate)"
   - Contributing_family_workers:
-    - description: "male (% of male employment) (modeled ILO estimate)"
+    - description:
+      - "male (% of male employment) (modeled ILO estimate)"
   - Contributing_family_workers:
-    - description: "total (% of total employment) (modeled ILO estimate)"
+    - description:
+      - "total (% of total employment) (modeled ILO estimate)"
   - Cost_of_business_start-up_procedures_(%_of_GNI_per_capita):
-    - description: "Cost to register a business is normalized by presenting it as a percentage of gross national income (GNI) per capita."
+    - description:
+      - "Cost to register a business is normalized by presenting it as a percentage of gross national income (GNI) per capita."
   - Cost_of_business_start-up_procedures:
-    - description: "female (% of GNI per capita)"
+    - description:
+      - "female (% of GNI per capita)"
   - Cost_of_business_start-up_procedures:
-    - description: "male (% of GNI per capita)"
+    - description:
+      - "male (% of GNI per capita)"
   - Cost_to_export_(US$_per_container):
-    - description: "Cost measures the fees levied on a 20-foot container in U.S. dollars. All the fees associated with completing the procedures to export or import the goods are included. These include costs for documents"
+    - description:
+      - "Cost measures the fees levied on a 20-foot container in U.S. dollars. All the fees associated with completing the procedures to export or import the goods are included. These include costs for documents"
   - Cost_to_export:
-    - description: "border compliance (US$)"
+    - description:
+      - "border compliance (US$)"
   - Cost_to_export:
-    - description: "documentary compliance (US$)"
+    - description:
+      - "documentary compliance (US$)"
   - Cost_to_import_(US$_per_container):
-    - description: "Cost measures the fees levied on a 20-foot container in U.S. dollars. All the fees associated with completing the procedures to export or import the goods are included. These include costs for documents"
+    - description:
+      - "Cost measures the fees levied on a 20-foot container in U.S. dollars. All the fees associated with completing the procedures to export or import the goods are included. These include costs for documents"
   - Cost_to_import:
-    - description: "border compliance (US$)"
+    - description:
+      - "border compliance (US$)"
   - Cost_to_import:
-    - description: "documentary compliance (US$)"
+    - description:
+      - "documentary compliance (US$)"
   - Coverage_of_social_insurance_programs_(%_of_population):
-    - description: "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
+    - description:
+      - "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
   - Coverage_of_social_insurance_programs_in_2nd_quintile_(%_of_population):
-    - description: "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
+    - description:
+      - "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
   - Coverage_of_social_insurance_programs_in_3rd_quintile_(%_of_population):
-    - description: "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
+    - description:
+      - "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
   - Coverage_of_social_insurance_programs_in_4th_quintile_(%_of_population):
-    - description: "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
+    - description:
+      - "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
   - Coverage_of_social_insurance_programs_in_poorest_quintile_(%_of_population):
-    - description: "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
+    - description:
+      - "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
   - Coverage_of_social_insurance_programs_in_richest_quintile_(%_of_population):
-    - description: "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
+    - description:
+      - "Coverage of social insurance programs shows the percentage of population participating in programs that provide old age contributory pensions (including survivors and disability) and social security and health insurance benefits (including occupational injury benefits"
   - Coverage_of_social_protection_and_labor_programs_(%_of_population):
-    - description: "Coverage of social protection and labor programs (SPL) shows the percentage of population participating in social insurance"
+    - description:
+      - "Coverage of social protection and labor programs (SPL) shows the percentage of population participating in social insurance"
   - Coverage_of_social_safety_net_programs_(%_of_population):
-    - description: "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
+    - description:
+      - "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
   - Coverage_of_social_safety_net_programs_in_2nd_quintile_(%_of_population):
-    - description: "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
+    - description:
+      - "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
   - Coverage_of_social_safety_net_programs_in_3rd_quintile_(%_of_population):
-    - description: "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
+    - description:
+      - "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
   - Coverage_of_social_safety_net_programs_in_4th_quintile_(%_of_population):
-    - description: "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
+    - description:
+      - "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
   - Coverage_of_social_safety_net_programs_in_poorest_quintile_(%_of_population):
-    - description: "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
+    - description:
+      - "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
   - Coverage_of_social_safety_net_programs_in_richest_quintile_(%_of_population):
-    - description: "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
+    - description:
+      - "Coverage of social safety net programs shows the percentage of population participating in cash transfers and last resort programs"
   - Coverage_of_unemployment_benefits_and_ALMP_(%_of_population):
-    - description: "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
+    - description:
+      - "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
   - Coverage_of_unemployment_benefits_and_ALMP_in_2nd_quintile_(%_of_population):
-    - description: "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
+    - description:
+      - "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
   - Coverage_of_unemployment_benefits_and_ALMP_in_3rd_quintile_(%_of_population):
-    - description: "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
+    - description:
+      - "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
   - Coverage_of_unemployment_benefits_and_ALMP_in_4th_quintile_(%_of_population):
-    - description: "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
+    - description:
+      - "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
   - Coverage_of_unemployment_benefits_and_ALMP_in_poorest_quintile_(%_of_population):
-    - description: "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
+    - description:
+      - "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
   - Coverage_of_unemployment_benefits_and_ALMP_in_richest_quintile_(%_of_population):
-    - description: "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
+    - description:
+      - "Coverage of unemployment benefits and active labor market programs (ALMP) shows the percentage of population participating in unemployment compensation"
   - CPIA_building_human_resources_rating_(1=low_to_6=high):
-    - description: "Building human resources assesses the national policies and public and private sector service delivery that affect the access to and quality of health and education services"
+    - description:
+      - "Building human resources assesses the national policies and public and private sector service delivery that affect the access to and quality of health and education services"
   - CPIA_business_regulatory_environment_rating_(1=low_to_6=high):
-    - description: "Business regulatory environment assesses the extent to which the legal"
+    - description:
+      - "Business regulatory environment assesses the extent to which the legal"
   - CPIA_debt_policy_rating_(1=low_to_6=high):
-    - description: "Debt policy assesses whether the debt management strategy is conducive to minimizing budgetary risks and ensuring long-term debt sustainability."
+    - description:
+      - "Debt policy assesses whether the debt management strategy is conducive to minimizing budgetary risks and ensuring long-term debt sustainability."
   - CPIA_economic_management_cluster_average_(1=low_to_6=high):
-    - description: "The economic management cluster includes macroeconomic management"
+    - description:
+      - "The economic management cluster includes macroeconomic management"
   - CPIA_efficiency_of_revenue_mobilization_rating_(1=low_to_6=high):
-    - description: "Efficiency of revenue mobilization assesses the overall pattern of revenue mobilization--not only the de facto tax structure"
+    - description:
+      - "Efficiency of revenue mobilization assesses the overall pattern of revenue mobilization--not only the de facto tax structure"
   - CPIA_equity_of_public_resource_use_rating_(1=low_to_6=high):
-    - description: "Equity of public resource use assesses the extent to which the pattern of public expenditures and revenue collection affects the poor and is consistent with national poverty reduction priorities."
+    - description:
+      - "Equity of public resource use assesses the extent to which the pattern of public expenditures and revenue collection affects the poor and is consistent with national poverty reduction priorities."
   - CPIA_financial_sector_rating_(1=low_to_6=high):
-    - description: "Financial sector assesses the structure of the financial sector and the policies and regulations that affect it."
+    - description:
+      - "Financial sector assesses the structure of the financial sector and the policies and regulations that affect it."
   - CPIA_fiscal_policy_rating_(1=low_to_6=high):
-    - description: "Fiscal policy assesses the short- and medium-term sustainability of fiscal policy (taking into account monetary and exchange rate policy and the sustainability of the public debt) and its impact on growth."
+    - description:
+      - "Fiscal policy assesses the short- and medium-term sustainability of fiscal policy (taking into account monetary and exchange rate policy and the sustainability of the public debt) and its impact on growth."
   - CPIA_gender_equality_rating_(1=low_to_6=high):
-    - description: "Gender equality assesses the extent to which the country has installed institutions and programs to enforce laws and policies that promote equal access for men and women in education"
+    - description:
+      - "Gender equality assesses the extent to which the country has installed institutions and programs to enforce laws and policies that promote equal access for men and women in education"
   - CPIA_macroeconomic_management_rating_(1=low_to_6=high):
-    - description: "Macroeconomic management assesses the monetary"
+    - description:
+      - "Macroeconomic management assesses the monetary"
   - CPIA_policies_for_social_inclusion/equity_cluster_average_(1=low_to_6=high):
-    - description: "The policies for social inclusion and equity cluster includes gender equality"
+    - description:
+      - "The policies for social inclusion and equity cluster includes gender equality"
   - CPIA_policy_and_institutions_for_environmental_sustainability_rating_(1=low_to_6=high):
-    - description: "Policy and institutions for environmental sustainability assess the extent to which environmental policies foster the protection and sustainable use of natural resources and the management of pollution."
+    - description:
+      - "Policy and institutions for environmental sustainability assess the extent to which environmental policies foster the protection and sustainable use of natural resources and the management of pollution."
   - CPIA_property_rights_and_rule-based_governance_rating_(1=low_to_6=high):
-    - description: "Property rights and rule-based governance assess the extent to which private economic activity is facilitated by an effective legal system and rule-based governance structure in which property and contract rights are reliably respected and enforced."
+    - description:
+      - "Property rights and rule-based governance assess the extent to which private economic activity is facilitated by an effective legal system and rule-based governance structure in which property and contract rights are reliably respected and enforced."
   - CPIA_public_sector_management_and_institutions_cluster_average_(1=low_to_6=high):
-    - description: "The public sector management and institutions cluster includes property rights and rule-based governance"
+    - description:
+      - "The public sector management and institutions cluster includes property rights and rule-based governance"
   - CPIA_quality_of_budgetary_and_financial_management_rating_(1=low_to_6=high):
-    - description: "Quality of budgetary and financial management assesses the extent to which there is a comprehensive and credible budget linked to policy priorities"
+    - description:
+      - "Quality of budgetary and financial management assesses the extent to which there is a comprehensive and credible budget linked to policy priorities"
   - CPIA_quality_of_public_administration_rating_(1=low_to_6=high):
-    - description: "Quality of public administration assesses the extent to which civilian central government staff is structured to design and implement government policy and deliver services effectively."
+    - description:
+      - "Quality of public administration assesses the extent to which civilian central government staff is structured to design and implement government policy and deliver services effectively."
   - CPIA_social_protection_rating_(1=low_to_6=high):
-    - description: "Social protection and labor assess government policies in social protection and labor market regulations that reduce the risk of becoming poor"
+    - description:
+      - "Social protection and labor assess government policies in social protection and labor market regulations that reduce the risk of becoming poor"
   - CPIA_structural_policies_cluster_average_(1=low_to_6=high):
-    - description: "The structural policies cluster includes trade"
+    - description:
+      - "The structural policies cluster includes trade"
   - CPIA_trade_rating_(1=low_to_6=high):
-    - description: "Trade assesses how the policy framework fosters trade in goods."
+    - description:
+      - "Trade assesses how the policy framework fosters trade in goods."
   - CPIA_transparency:
-    - description: "accountability"
+    - description:
+      - "accountability"
   - Crop_production_index_(2004-2006_=_100):
-    - description: "Crop production index shows agricultural production for each year relative to the base period 2004-2006. It includes all crops except fodder crops. Regional and income group aggregates for the FAO's production indexes are calculated from the underlying values in international dollars"
+    - description:
+      - "Crop production index shows agricultural production for each year relative to the base period 2004-2006. It includes all crops except fodder crops. Regional and income group aggregates for the FAO's production indexes are calculated from the underlying values in international dollars"
   - Currency_composition_of_PPG_debt:
-    - description: "all other currencies (%)"
+    - description:
+      - "all other currencies (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "Deutsche mark (%)"
+    - description:
+      - "Deutsche mark (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "Euro (%)"
+    - description:
+      - "Euro (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "French franc (%)"
+    - description:
+      - "French franc (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "Japanese yen (%)"
+    - description:
+      - "Japanese yen (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "Multiple currencies (%)"
+    - description:
+      - "Multiple currencies (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "Pound sterling (%)"
+    - description:
+      - "Pound sterling (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "SDR (%)"
+    - description:
+      - "SDR (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "Swiss franc (%)"
+    - description:
+      - "Swiss franc (%)"
   - Currency_composition_of_PPG_debt:
-    - description: "U.S. dollars (%)"
+    - description:
+      - "U.S. dollars (%)"
   - Current_account_balance_(%_of_GDP):
-    - description: "Current account balance is the sum of net exports of goods and services"
+    - description:
+      - "Current account balance is the sum of net exports of goods and services"
   - Current_account_balance_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Current_education_expenditure:
-    - description: "primary (% of total expenditure in primary public institutions)"
+    - description:
+      - "primary (% of total expenditure in primary public institutions)"
   - Current_education_expenditure:
-    - description: "secondary (% of total expenditure in secondary public institutions)"
+    - description:
+      - "secondary (% of total expenditure in secondary public institutions)"
   - Current_education_expenditure:
-    - description: "tertiary (% of total expenditure in tertiary public institutions)"
+    - description:
+      - "tertiary (% of total expenditure in tertiary public institutions)"
   - Current_education_expenditure:
-    - description: "total (% of total expenditure in public institutions)"
+    - description:
+      - "total (% of total expenditure in public institutions)"
   - Current_health_expenditure_(%_of_GDP):
-    - description: "Level of current health expenditure expressed as a percentage of GDP.  Estimates of current health expenditures include healthcare goods and services consumed during each year. This indicator does not include capital health expenditures such as buildings"
+    - description:
+      - "Level of current health expenditure expressed as a percentage of GDP.  Estimates of current health expenditures include healthcare goods and services consumed during each year. This indicator does not include capital health expenditures such as buildings"
   - Current_health_expenditure_per_capita_(current_US$):
-    - description: "Current expenditures on health per capita in current US dollars. Estimates of current health expenditures include healthcare goods and services consumed during each year."
+    - description:
+      - "Current expenditures on health per capita in current US dollars. Estimates of current health expenditures include healthcare goods and services consumed during each year."
   - Current_health_expenditure_per_capita:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - Customs_and_other_import_duties_(%_of_tax_revenue):
-    - description: "Customs and other import duties are all levies collected on goods that are entering the country or services delivered by nonresidents to residents. They include levies imposed for revenue or protection purposes and determined on a specific or ad valorem basis as long as they are restricted to imported goods or services."
+    - description:
+      - "Customs and other import duties are all levies collected on goods that are entering the country or services delivered by nonresidents to residents. They include levies imposed for revenue or protection purposes and determined on a specific or ad valorem basis as long as they are restricted to imported goods or services."
   - Customs_and_other_import_duties_(current_LCU):
-    - description: "Customs and other import duties are all levies collected on goods that are entering the country or services delivered by nonresidents to residents. They include levies imposed for revenue or protection purposes and determined on a specific or ad valorem basis as long as they are restricted to imported goods or services."
+    - description:
+      - "Customs and other import duties are all levies collected on goods that are entering the country or services delivered by nonresidents to residents. They include levies imposed for revenue or protection purposes and determined on a specific or ad valorem basis as long as they are restricted to imported goods or services."
   - Death_rate:
-    - description: "crude (per 1"
+    - description:
+      - "crude (per 1"
   - Debt_buyback_(current_US$):
-    - description: "Debt buyback is the repurchase by a debtor of its own debt"
+    - description:
+      - "Debt buyback is the repurchase by a debtor of its own debt"
   - Debt_forgiveness_grants_(current_US$):
-    - description: "Debt forgiveness grants data cover both debt cancelled by agreement between debtor and creditor and a reduction in the net present value of non-ODA debt achieved by concessional rescheduling or refinancing. The  data are on a disbursement basis and cover flows from all bilateral and multilateral donors. Data are in current U.S. dollars."
+    - description:
+      - "Debt forgiveness grants data cover both debt cancelled by agreement between debtor and creditor and a reduction in the net present value of non-ODA debt achieved by concessional rescheduling or refinancing. The  data are on a disbursement basis and cover flows from all bilateral and multilateral donors. Data are in current U.S. dollars."
   - Debt_forgiveness_or_reduction_(current_US$):
-    - description: "Debt forgiveness or reduction shows the change in debt stock due to debt forgiveness or reduction. It is derived by subtracting debt forgiven and debt stock reduction from debt buyback. Data are in current U.S. dollars."
+    - description:
+      - "Debt forgiveness or reduction shows the change in debt stock due to debt forgiveness or reduction. It is derived by subtracting debt forgiven and debt stock reduction from debt buyback. Data are in current U.S. dollars."
   - Debt_service_on_external_debt:
-    - description: "long-term (TDS"
+    - description:
+      - "long-term (TDS"
   - Debt_service_on_external_debt:
-    - description: "private nonguaranteed (PNG) (TDS"
+    - description:
+      - "private nonguaranteed (PNG) (TDS"
   - Debt_service_on_external_debt:
-    - description: "public and publicly guaranteed (PPG) (TDS"
+    - description:
+      - "public and publicly guaranteed (PPG) (TDS"
   - Debt_service_on_external_debt:
-    - description: "total (TDS"
+    - description:
+      - "total (TDS"
   - Debt_service_to_exports_(%):
-    - description: "Debt service (PPG and IMF only"
+    - description:
+      - "Debt service (PPG and IMF only"
   - Debt_stock_reduction_(current_US$):
-    - description: "Debt stock reductions show the amount that has been netted out of the stock of debt using debt conversion schemes such as buybacks and equity swaps or the discounted value of long-term bonds that were issued in exchange for outstanding debt. It includes the effect of any financial operation that will reduce the debt stock other than debt stock restructuring"
+    - description:
+      - "Debt stock reductions show the amount that has been netted out of the stock of debt using debt conversion schemes such as buybacks and equity swaps or the discounted value of long-term bonds that were issued in exchange for outstanding debt. It includes the effect of any financial operation that will reduce the debt stock other than debt stock restructuring"
   - Debt_stock_rescheduled_(current_US$):
-    - description: "Debt stocks rescheduled is the amount of debt outstanding rescheduled in any given year. Data are in current U.S. dollars."
+    - description:
+      - "Debt stocks rescheduled is the amount of debt outstanding rescheduled in any given year. Data are in current U.S. dollars."
   - DEC_alternative_conversion_factor_(LCU_per_US$):
-    - description: "The DEC alternative conversion factor is the underlying annual exchange rate used for the World Bank Atlas method. As a rule"
+    - description:
+      - "The DEC alternative conversion factor is the underlying annual exchange rate used for the World Bank Atlas method. As a rule"
   - Delay_in_obtaining_an_electrical_connection_(days):
-    - description: "Delay in obtaining an electrical connection is the average wait"
+    - description:
+      - "Delay in obtaining an electrical connection is the average wait"
   - Demand_for_family_planning_satisfied_by_modern_methods_(%_of_married_women_with_demand_for_family_planning):
-    - description: "Demand for family planning satisfied by modern methods refers to the percentage of married women ages 15-49 years whose need for family planning is satisfied with modern methods."
+    - description:
+      - "Demand for family planning satisfied by modern methods refers to the percentage of married women ages 15-49 years whose need for family planning is satisfied with modern methods."
   - Deposit_interest_rate_(%):
-    - description: "Deposit interest rate is the rate paid by commercial or similar banks for demand"
+    - description:
+      - "Deposit interest rate is the rate paid by commercial or similar banks for demand"
   - Depositors_with_commercial_banks_(per_1:
-    - description: "000 adults)"
+    - description:
+      - "000 adults)"
   - Depth_of_credit_information_index_(0=low_to_8=high):
-    - description: "Depth of credit information index measures rules affecting the scope"
+    - description:
+      - "Depth of credit information index measures rules affecting the scope"
   - Depth_of_the_food_deficit_(kilocalories_per_person_per_day):
-    - description: "The depth of the food deficit indicates how many calories would be needed to lift the undernourished from their status"
+    - description:
+      - "The depth of the food deficit indicates how many calories would be needed to lift the undernourished from their status"
   - Diabetes_prevalence_(%_of_population_ages_20_to_79):
-    - description: "Diabetes prevalence refers to the percentage of people ages 20-79 who have type 1 or type 2 diabetes."
+    - description:
+      - "Diabetes prevalence refers to the percentage of people ages 20-79 who have type 1 or type 2 diabetes."
   - Diarrhea_treatment_(%_of_children_under_5_receiving_oral_rehydration_and_continued_feeding):
-    - description: "Children with diarrhea who received oral rehydration and continued feeding refer to the percentage of children under age five with diarrhea in the two weeks prior to the survey who received either oral rehydration therapy or increased fluids"
+    - description:
+      - "Children with diarrhea who received oral rehydration and continued feeding refer to the percentage of children under age five with diarrhea in the two weeks prior to the survey who received either oral rehydration therapy or increased fluids"
   - Diarrhea_treatment_(%_of_children_under_5_who_received_ORS_packet):
-    - description: "Percentage of children under age 5 with diarrhea in the two weeks preceding the survey who received oral rehydration salts (ORS packets or pre-packaged ORS fluids)."
+    - description:
+      - "Percentage of children under age 5 with diarrhea in the two weeks preceding the survey who received oral rehydration salts (ORS packets or pre-packaged ORS fluids)."
   - Disaster_risk_reduction_progress_score_(1-5_scale;_5=best):
-    - description: "Disaster risk reduction progress score is an average of self-assessment scores"
+    - description:
+      - "Disaster risk reduction progress score is an average of self-assessment scores"
   - Disbursements_on_external_debt:
-    - description: "long-term (DIS"
+    - description:
+      - "long-term (DIS"
   - Disbursements_on_external_debt:
-    - description: "long-term + IMF (DIS"
+    - description:
+      - "long-term + IMF (DIS"
   - Disbursements_on_external_debt:
-    - description: "private nonguaranteed (PNG) (DIS"
+    - description:
+      - "private nonguaranteed (PNG) (DIS"
   - Disbursements_on_external_debt:
-    - description: "public and publicly guaranteed (PPG) (DIS"
+    - description:
+      - "public and publicly guaranteed (PPG) (DIS"
   - Discrepancy_in_expenditure_estimate_of_GDP_(constant_LCU):
-    - description: "A statistical discrepancy usually arises when the GDP components are estimated independently by industrial origin and by expenditure categories. This item represents the discrepancy in the use of resources (i.e."
+    - description:
+      - "A statistical discrepancy usually arises when the GDP components are estimated independently by industrial origin and by expenditure categories. This item represents the discrepancy in the use of resources (i.e."
   - Discrepancy_in_expenditure_estimate_of_GDP_(current_LCU):
-    - description: "Discrepancy in expenditure estimate of GDP is the discrepancy included in final consumption expenditure"
+    - description:
+      - "Discrepancy in expenditure estimate of GDP is the discrepancy included in final consumption expenditure"
   - Distance_to_frontier_score_(0=lowest_performance_to_100=frontier):
-    - description: "Distance to frontier score illustrates the distance of an economy to the frontier"
+    - description:
+      - "Distance to frontier score illustrates the distance of an economy to the frontier"
   - Documents_to_export_(number):
-    - description: "All documents required per shipment to export goods are recorded. It is assumed that the contract has already been agreed upon and signed by both parties. Documents required for clearance by government ministries"
+    - description:
+      - "All documents required per shipment to export goods are recorded. It is assumed that the contract has already been agreed upon and signed by both parties. Documents required for clearance by government ministries"
   - Documents_to_import_(number):
-    - description: "All documents required per shipment to import goods are recorded. It is assumed that the contract has already been agreed upon and signed by both parties. Documents required for clearance by government ministries"
+    - description:
+      - "All documents required per shipment to import goods are recorded. It is assumed that the contract has already been agreed upon and signed by both parties. Documents required for clearance by government ministries"
   - Domestic_credit_provided_by_financial_sector_(%_of_GDP):
-    - description: "Domestic credit provided by the financial sector includes all credit to various sectors on a gross basis"
+    - description:
+      - "Domestic credit provided by the financial sector includes all credit to various sectors on a gross basis"
   - Domestic_credit_to_private_sector_(%_of_GDP):
-    - description: "Domestic credit to private sector refers to financial resources provided to the private sector by financial corporations"
+    - description:
+      - "Domestic credit to private sector refers to financial resources provided to the private sector by financial corporations"
   - Domestic_credit_to_private_sector_by_banks_(%_of_GDP):
-    - description: "Domestic credit to private sector by banks refers to financial resources provided to the private sector by other depository corporations (deposit taking corporations except central banks)"
+    - description:
+      - "Domestic credit to private sector by banks refers to financial resources provided to the private sector by other depository corporations (deposit taking corporations except central banks)"
   - Domestic_general_government_health_expenditure_(%_of_current_health_expenditure):
-    - description: "Share of current health expenditures funded from domestic public sources for health.  Domestic public sources include domestic revenue as internal transfers and grants"
+    - description:
+      - "Share of current health expenditures funded from domestic public sources for health.  Domestic public sources include domestic revenue as internal transfers and grants"
   - Domestic_general_government_health_expenditure_(%_of_GDP):
-    - description: "Public expenditure on health from domestic sources as a share of the economy as measured by GDP."
+    - description:
+      - "Public expenditure on health from domestic sources as a share of the economy as measured by GDP."
   - Domestic_general_government_health_expenditure_(%_of_general_government_expenditure):
-    - description: "Public expenditure on health from domestic sources as a share of total public expenditure.  It indicates the priority of the government to spend on health from own domestic public resources."
+    - description:
+      - "Public expenditure on health from domestic sources as a share of total public expenditure.  It indicates the priority of the government to spend on health from own domestic public resources."
   - Domestic_general_government_health_expenditure_per_capita_(current_US$):
-    - description: "Public expenditure on health from domestic sources per capita expressed in current US dollars."
+    - description:
+      - "Public expenditure on health from domestic sources per capita expressed in current US dollars."
   - Domestic_general_government_health_expenditure_per_capita:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - Domestic_private_health_expenditure_(%_of_current_health_expenditure):
-    - description: "Share of current health expenditures funded from domestic private sources.  Domestic private sources include funds from households"
+    - description:
+      - "Share of current health expenditures funded from domestic private sources.  Domestic private sources include funds from households"
   - Domestic_private_health_expenditure_per_capita_(current_US$):
-    - description: "Current private expenditures on health per capita expressed in current US dollars. Domestic private sources include funds from households"
+    - description:
+      - "Current private expenditures on health per capita expressed in current US dollars. Domestic private sources include funds from households"
   - Domestic_private_health_expenditure_per_capita:
-    - description: "PPP  (current international $)"
+    - description:
+      - "PPP  (current international $)"
   - Droughts:
-    - description: "floods"
+    - description:
+      - "floods"
   - Ease_of_doing_business_index_(1=most_business-friendly_regulations):
-    - description: "Ease of doing business ranks economies from 1 to 190"
+    - description:
+      - "Ease of doing business ranks economies from 1 to 190"
   - EBRD:
-    - description: "private nonguaranteed (NFL"
+    - description:
+      - "private nonguaranteed (NFL"
   - Educational_attainment:
-    - description: "at least Bachelor's or equivalent"
+    - description:
+      - "at least Bachelor's or equivalent"
   - Educational_attainment:
-    - description: "at least Bachelor's or equivalent"
+    - description:
+      - "at least Bachelor's or equivalent"
   - Educational_attainment:
-    - description: "at least Bachelor's or equivalent"
+    - description:
+      - "at least Bachelor's or equivalent"
   - Educational_attainment:
-    - description: "at least completed lower secondary"
+    - description:
+      - "at least completed lower secondary"
   - Educational_attainment:
-    - description: "at least completed lower secondary"
+    - description:
+      - "at least completed lower secondary"
   - Educational_attainment:
-    - description: "at least completed lower secondary"
+    - description:
+      - "at least completed lower secondary"
   - Educational_attainment:
-    - description: "at least completed post-secondary"
+    - description:
+      - "at least completed post-secondary"
   - Educational_attainment:
-    - description: "at least completed post-secondary"
+    - description:
+      - "at least completed post-secondary"
   - Educational_attainment:
-    - description: "at least completed post-secondary"
+    - description:
+      - "at least completed post-secondary"
   - Educational_attainment:
-    - description: "at least completed primary"
+    - description:
+      - "at least completed primary"
   - Educational_attainment:
-    - description: "at least completed primary"
+    - description:
+      - "at least completed primary"
   - Educational_attainment:
-    - description: "at least completed primary"
+    - description:
+      - "at least completed primary"
   - Educational_attainment:
-    - description: "at least completed short-cycle tertiary"
+    - description:
+      - "at least completed short-cycle tertiary"
   - Educational_attainment:
-    - description: "at least completed short-cycle tertiary"
+    - description:
+      - "at least completed short-cycle tertiary"
   - Educational_attainment:
-    - description: "at least completed short-cycle tertiary"
+    - description:
+      - "at least completed short-cycle tertiary"
   - Educational_attainment:
-    - description: "at least completed upper secondary"
+    - description:
+      - "at least completed upper secondary"
   - Educational_attainment:
-    - description: "at least completed upper secondary"
+    - description:
+      - "at least completed upper secondary"
   - Educational_attainment:
-    - description: "at least completed upper secondary"
+    - description:
+      - "at least completed upper secondary"
   - Educational_attainment:
-    - description: "at least Master's or equivalent"
+    - description:
+      - "at least Master's or equivalent"
   - Educational_attainment:
-    - description: "at least Master's or equivalent"
+    - description:
+      - "at least Master's or equivalent"
   - Educational_attainment:
-    - description: "at least Master's or equivalent"
+    - description:
+      - "at least Master's or equivalent"
   - Educational_attainment:
-    - description: "Doctoral or equivalent"
+    - description:
+      - "Doctoral or equivalent"
   - Educational_attainment:
-    - description: "Doctoral or equivalent"
+    - description:
+      - "Doctoral or equivalent"
   - Educational_attainment:
-    - description: "Doctoral or equivalent"
+    - description:
+      - "Doctoral or equivalent"
   - Electric_power_consumption_(kWh_per_capita):
-    - description: "Electric power consumption measures the production of power plants and combined heat and power plants less transmission"
+    - description:
+      - "Electric power consumption measures the production of power plants and combined heat and power plants less transmission"
   - Electric_power_transmission_and_distribution_losses_(%_of_output):
-    - description: "Electric power transmission and distribution losses include losses in transmission between sources of supply and points of distribution and in the distribution to consumers"
+    - description:
+      - "Electric power transmission and distribution losses include losses in transmission between sources of supply and points of distribution and in the distribution to consumers"
   - Electricity_production_from_coal_sources_(%_of_total):
-    - description: "Sources of electricity refer to the inputs used to generate electricity. Coal refers to all coal and brown coal"
+    - description:
+      - "Sources of electricity refer to the inputs used to generate electricity. Coal refers to all coal and brown coal"
   - Electricity_production_from_hydroelectric_sources_(%_of_total):
-    - description: "Sources of electricity refer to the inputs used to generate electricity. Hydropower refers to electricity produced by hydroelectric power plants."
+    - description:
+      - "Sources of electricity refer to the inputs used to generate electricity. Hydropower refers to electricity produced by hydroelectric power plants."
   - Electricity_production_from_natural_gas_sources_(%_of_total):
-    - description: "Sources of electricity refer to the inputs used to generate electricity. Gas refers to natural gas but excludes natural gas liquids."
+    - description:
+      - "Sources of electricity refer to the inputs used to generate electricity. Gas refers to natural gas but excludes natural gas liquids."
   - Electricity_production_from_nuclear_sources_(%_of_total):
-    - description: "Sources of electricity refer to the inputs used to generate electricity. Nuclear power refers to electricity produced by nuclear power plants."
+    - description:
+      - "Sources of electricity refer to the inputs used to generate electricity. Nuclear power refers to electricity produced by nuclear power plants."
   - Electricity_production_from_oil_sources_(%_of_total):
-    - description: "Sources of electricity refer to the inputs used to generate electricity. Oil refers to crude oil and petroleum products."
+    - description:
+      - "Sources of electricity refer to the inputs used to generate electricity. Oil refers to crude oil and petroleum products."
   - Electricity_production_from_oil:
-    - description: "gas and coal sources (% of total)"
+    - description:
+      - "gas and coal sources (% of total)"
   - Electricity_production_from_renewable_sources:
-    - description: "excluding hydroelectric (% of total)"
+    - description:
+      - "excluding hydroelectric (% of total)"
   - Electricity_production_from_renewable_sources:
-    - description: "excluding hydroelectric (kWh)"
+    - description:
+      - "excluding hydroelectric (kWh)"
   - Employers:
-    - description: "female (% of female employment) (modeled ILO estimate)"
+    - description:
+      - "female (% of female employment) (modeled ILO estimate)"
   - Employers:
-    - description: "male (% of male employment) (modeled ILO estimate)"
+    - description:
+      - "male (% of male employment) (modeled ILO estimate)"
   - Employers:
-    - description: "total (% of total employment) (modeled ILO estimate)"
+    - description:
+      - "total (% of total employment) (modeled ILO estimate)"
   - Employment_in_agriculture_(%_of_total_employment)_(modeled_ILO_estimate):
-    - description: "Employment is defined as persons of working age who were engaged in any activity to produce goods or provide services for pay or profit"
+    - description:
+      - "Employment is defined as persons of working age who were engaged in any activity to produce goods or provide services for pay or profit"
   - Employment_in_agriculture:
-    - description: "female (% of female employment) (modeled ILO estimate)"
+    - description:
+      - "female (% of female employment) (modeled ILO estimate)"
   - Employment_in_agriculture:
-    - description: "male (% of male employment) (modeled ILO estimate)"
+    - description:
+      - "male (% of male employment) (modeled ILO estimate)"
   - Employment_in_industry_(%_of_total_employment)_(modeled_ILO_estimate):
-    - description: "Employment is defined as persons of working age who were engaged in any activity to produce goods or provide services for pay or profit"
+    - description:
+      - "Employment is defined as persons of working age who were engaged in any activity to produce goods or provide services for pay or profit"
   - Employment_in_industry:
-    - description: "female (% of female employment) (modeled ILO estimate)"
+    - description:
+      - "female (% of female employment) (modeled ILO estimate)"
   - Employment_in_industry:
-    - description: "male (% of male employment) (modeled ILO estimate)"
+    - description:
+      - "male (% of male employment) (modeled ILO estimate)"
   - Employment_in_services_(%_of_total_employment)_(modeled_ILO_estimate):
-    - description: "Employment is defined as persons of working age who were engaged in any activity to produce goods or provide services for pay or profit"
+    - description:
+      - "Employment is defined as persons of working age who were engaged in any activity to produce goods or provide services for pay or profit"
   - Employment_in_services:
-    - description: "female (% of female employment) (modeled ILO estimate)"
+    - description:
+      - "female (% of female employment) (modeled ILO estimate)"
   - Employment_in_services:
-    - description: "male (% of male employment) (modeled ILO estimate)"
+    - description:
+      - "male (% of male employment) (modeled ILO estimate)"
   - Employment_to_population_ratio:
-    - description: "15+"
+    - description:
+      - "15+"
   - Employment_to_population_ratio:
-    - description: "15+"
+    - description:
+      - "15+"
   - Employment_to_population_ratio:
-    - description: "15+"
+    - description:
+      - "15+"
   - Employment_to_population_ratio:
-    - description: "15+"
+    - description:
+      - "15+"
   - Employment_to_population_ratio:
-    - description: "15+"
+    - description:
+      - "15+"
   - Employment_to_population_ratio:
-    - description: "15+"
+    - description:
+      - "15+"
   - Employment_to_population_ratio:
-    - description: "ages 15-24"
+    - description:
+      - "ages 15-24"
   - Employment_to_population_ratio:
-    - description: "ages 15-24"
+    - description:
+      - "ages 15-24"
   - Employment_to_population_ratio:
-    - description: "ages 15-24"
+    - description:
+      - "ages 15-24"
   - Employment_to_population_ratio:
-    - description: "ages 15-24"
+    - description:
+      - "ages 15-24"
   - Employment_to_population_ratio:
-    - description: "ages 15-24"
+    - description:
+      - "ages 15-24"
   - Employment_to_population_ratio:
-    - description: "ages 15-24"
+    - description:
+      - "ages 15-24"
   - Energy_imports:
-    - description: "net (% of energy use)"
+    - description:
+      - "net (% of energy use)"
   - Energy_intensity_level_of_primary_energy_(MJ/$2011_PPP_GDP):
-    - description: "Energy intensity level of primary energy is the ratio between energy supply and gross domestic product measured at purchasing power parity. Energy intensity is an indication of how much energy is used to produce one unit of economic output. Lower ratio indicates that less energy is used to produce one unit of output."
+    - description:
+      - "Energy intensity level of primary energy is the ratio between energy supply and gross domestic product measured at purchasing power parity. Energy intensity is an indication of how much energy is used to produce one unit of economic output. Lower ratio indicates that less energy is used to produce one unit of output."
   - Energy_related_methane_emissions_(%_of_total):
-    - description: "Methane emissions from energy processes are emissions from the production"
+    - description:
+      - "Methane emissions from energy processes are emissions from the production"
   - Energy_use_(kg_of_oil_equivalent_per_capita):
-    - description: "Energy use refers to use of primary energy before transformation to other end-use fuels"
+    - description:
+      - "Energy use refers to use of primary energy before transformation to other end-use fuels"
   - Energy_use_(kg_of_oil_equivalent)_per_$1:
-    - description: "000 GDP (constant 2011 PPP)"
+    - description:
+      - "000 GDP (constant 2011 PPP)"
   - Exclusive_breastfeeding_(%_of_children_under_6_months):
-    - description: "Exclusive breastfeeding refers to the percentage of children less than six months old who are fed breast milk alone (no other liquids) in the past 24 hours."
+    - description:
+      - "Exclusive breastfeeding refers to the percentage of children less than six months old who are fed breast milk alone (no other liquids) in the past 24 hours."
   - Expenditure_on_primary_education_(%_of_government_expenditure_on_education):
-    - description: "Expenditure on primary education is expressed as a percentage of total general government expenditure on education. General government usually refers to local"
+    - description:
+      - "Expenditure on primary education is expressed as a percentage of total general government expenditure on education. General government usually refers to local"
   - Expenditure_on_secondary_education_(%_of_government_expenditure_on_education):
-    - description: "Expenditure on secondary education is expressed as a percentage of total general government expenditure on education. General government usually refers to local"
+    - description:
+      - "Expenditure on secondary education is expressed as a percentage of total general government expenditure on education. General government usually refers to local"
   - Expenditure_on_tertiary_education_(%_of_government_expenditure_on_education):
-    - description: "Expenditure on tertiary education is expressed as a percentage of total general government expenditure on education. General government usually refers to local"
+    - description:
+      - "Expenditure on tertiary education is expressed as a percentage of total general government expenditure on education. General government usually refers to local"
   - Expense_(%_of_GDP):
-    - description: "Expense is cash payments for operating activities of the government in providing goods and services. It includes compensation of employees (such as wages and salaries)"
+    - description:
+      - "Expense is cash payments for operating activities of the government in providing goods and services. It includes compensation of employees (such as wages and salaries)"
   - Expense_(current_LCU):
-    - description: "Expense is cash payments for operating activities of the government in providing goods and services. It includes compensation of employees (such as wages and salaries)"
+    - description:
+      - "Expense is cash payments for operating activities of the government in providing goods and services. It includes compensation of employees (such as wages and salaries)"
   - Export_unit_value_index_(2000_=_100):
-    - description: "Export unit value indices come from UNCTAD's trade database. Unit value indices are based on data reported by countries that demonstrate consistency under UNCTAD quality controls"
+    - description:
+      - "Export unit value indices come from UNCTAD's trade database. Unit value indices are based on data reported by countries that demonstrate consistency under UNCTAD quality controls"
   - Export_value_index_(2000_=_100):
-    - description: "Export values are the current value of exports (f.o.b.) converted to U.S. dollars and expressed as a percentage of the average for the base period (2000). UNCTAD's export value indexes are reported for most economies. For selected economies for which UNCTAD does not publish data"
+    - description:
+      - "Export values are the current value of exports (f.o.b.) converted to U.S. dollars and expressed as a percentage of the average for the base period (2000). UNCTAD's export value indexes are reported for most economies. For selected economies for which UNCTAD does not publish data"
   - Export_volume_index_(2000_=_100):
-    - description: "Export volume indexes are derived from UNCTAD's volume index series and are the ratio of the export value indexes to the corresponding unit value indexes. Unit value indexes are based on data reported by countries that demonstrate consistency under UNCTAD quality controls"
+    - description:
+      - "Export volume indexes are derived from UNCTAD's volume index series and are the ratio of the export value indexes to the corresponding unit value indexes. Unit value indexes are based on data reported by countries that demonstrate consistency under UNCTAD quality controls"
   - Exports_as_a_capacity_to_import_(constant_LCU):
-    - description: "Exports as a capacity to import equals the current price value of exports of goods and services deflated by the import price index. Data are in constant local currency."
+    - description:
+      - "Exports as a capacity to import equals the current price value of exports of goods and services deflated by the import price index. Data are in constant local currency."
   - Exports_of_goods_and_services_(%_of_GDP):
-    - description: "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
+    - description:
+      - "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
   - Exports_of_goods_and_services_(annual_%_growth):
-    - description: "Annual growth rate of exports of goods and services based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
+    - description:
+      - "Annual growth rate of exports of goods and services based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
   - Exports_of_goods_and_services_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Exports_of_goods_and_services_(constant_2010_US$):
-    - description: "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
+    - description:
+      - "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
   - Exports_of_goods_and_services_(constant_LCU):
-    - description: "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
+    - description:
+      - "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
   - Exports_of_goods_and_services_(current_LCU):
-    - description: "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
+    - description:
+      - "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
   - Exports_of_goods_and_services_(current_US$):
-    - description: "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
+    - description:
+      - "Exports of goods and services represent the value of all goods and other market services provided to the rest of the world. They include the value of merchandise"
   - Exports_of_goods:
-    - description: "services and primary income (BoP"
+    - description:
+      - "services and primary income (BoP"
   - External_balance_on_goods_and_services_(%_of_GDP):
-    - description: "External balance on goods and services (formerly resource balance) equals exports of goods and services minus imports of goods and services (previously nonfactor services)."
+    - description:
+      - "External balance on goods and services (formerly resource balance) equals exports of goods and services minus imports of goods and services (previously nonfactor services)."
   - External_balance_on_goods_and_services_(constant_LCU):
-    - description: "External balance on goods and services (formerly resource balance) equals exports of goods and services minus imports of goods and services (previously nonfactor services). Data are in constant local currency."
+    - description:
+      - "External balance on goods and services (formerly resource balance) equals exports of goods and services minus imports of goods and services (previously nonfactor services). Data are in constant local currency."
   - External_balance_on_goods_and_services_(current_LCU):
-    - description: "External balance on goods and services (formerly resource balance) equals exports of goods and services minus imports of goods and services (previously nonfactor services). Data are in current local currency."
+    - description:
+      - "External balance on goods and services (formerly resource balance) equals exports of goods and services minus imports of goods and services (previously nonfactor services). Data are in current local currency."
   - External_balance_on_goods_and_services_(current_US$):
-    - description: "External balance on goods and services (formerly resource balance) equals exports of goods and services minus imports of goods and services (previously nonfactor services). Data are in current U.S. dollars."
+    - description:
+      - "External balance on goods and services (formerly resource balance) equals exports of goods and services minus imports of goods and services (previously nonfactor services). Data are in current U.S. dollars."
   - External_debt_stocks_(%_of_exports_of_goods:
-    - description: "services and primary income)"
+    - description:
+      - "services and primary income)"
   - External_debt_stocks_(%_of_GNI):
-    - description: "Total external debt stocks to gross national income. Total external debt is debt owed to nonresidents repayable in currency"
+    - description:
+      - "Total external debt stocks to gross national income. Total external debt is debt owed to nonresidents repayable in currency"
   - External_debt_stocks:
-    - description: "concessional (DOD"
+    - description:
+      - "concessional (DOD"
   - External_debt_stocks:
-    - description: "long-term (DOD"
+    - description:
+      - "long-term (DOD"
   - External_debt_stocks:
-    - description: "long-term private sector (DOD"
+    - description:
+      - "long-term private sector (DOD"
   - External_debt_stocks:
-    - description: "long-term public sector (DOD"
+    - description:
+      - "long-term public sector (DOD"
   - External_debt_stocks:
-    - description: "private nonguaranteed (PNG) (DOD"
+    - description:
+      - "private nonguaranteed (PNG) (DOD"
   - External_debt_stocks:
-    - description: "public and publicly guaranteed (PPG) (DOD"
+    - description:
+      - "public and publicly guaranteed (PPG) (DOD"
   - External_debt_stocks:
-    - description: "short-term (DOD"
+    - description:
+      - "short-term (DOD"
   - External_debt_stocks:
-    - description: "total (DOD"
+    - description:
+      - "total (DOD"
   - External_debt_stocks:
-    - description: "variable rate (DOD"
+    - description:
+      - "variable rate (DOD"
   - External_health_expenditure_(%_of_current_health_expenditure):
-    - description: "Share of current health expenditures funded from external sources. External sources compose of direct foreign transfers and foreign transfers distributed by government encompassing all financial inflows into the national health system from outside the country. External sources either flow through the government scheme or are channeled through non-governmental organizations or other schemes."
+    - description:
+      - "Share of current health expenditures funded from external sources. External sources compose of direct foreign transfers and foreign transfers distributed by government encompassing all financial inflows into the national health system from outside the country. External sources either flow through the government scheme or are channeled through non-governmental organizations or other schemes."
   - External_health_expenditure_per_capita_(current_US$):
-    - description: "Current external expenditures on health per capita expressed in current US dollars. External sources are composed of direct foreign transfers and foreign transfers distributed by government encompassing all financial inflows into the national health system from outside the country."
+    - description:
+      - "Current external expenditures on health per capita expressed in current US dollars. External sources are composed of direct foreign transfers and foreign transfers distributed by government encompassing all financial inflows into the national health system from outside the country."
   - External_health_expenditure_per_capita:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - Female_genital_mutilation_prevalence_(%):
-    - description: "Percentage of women aged 15-49 who have gone through partial or total removal of the female external genitalia or other injury to the female genital organs for cultural or other non-therapeutic reasons."
+    - description:
+      - "Percentage of women aged 15-49 who have gone through partial or total removal of the female external genitalia or other injury to the female genital organs for cultural or other non-therapeutic reasons."
   - Female_headed_households_(%_of_households_with_a_female_head):
-    - description: "Female headed households shows the percentage of households with a female head."
+    - description:
+      - "Female headed households shows the percentage of households with a female head."
   - Female_share_of_employment_in_senior_and_middle_management_(%):
-    - description: "The proportion of females in total employment in senior and middle management. It corresponds to major group 1 in both ISCO-08 and ISCO-88 minus category 14 in ISCO-08 (hospitality"
+    - description:
+      - "The proportion of females in total employment in senior and middle management. It corresponds to major group 1 in both ISCO-08 and ISCO-88 minus category 14 in ISCO-08 (hospitality"
   - Fertility_rate:
-    - description: "total (births per woman)"
+    - description:
+      - "total (births per woman)"
   - Fertilizer_consumption_(%_of_fertilizer_production):
-    - description: "Fertilizer consumption measures the quantity of plant nutrients used per unit of arable land. Fertilizer products cover nitrogenous"
+    - description:
+      - "Fertilizer consumption measures the quantity of plant nutrients used per unit of arable land. Fertilizer products cover nitrogenous"
   - Fertilizer_consumption_(kilograms_per_hectare_of_arable_land):
-    - description: "Fertilizer consumption measures the quantity of plant nutrients used per unit of arable land. Fertilizer products cover nitrogenous"
+    - description:
+      - "Fertilizer consumption measures the quantity of plant nutrients used per unit of arable land. Fertilizer products cover nitrogenous"
   - Final_consumption_expenditure_(constant_2010_US$):
-    - description: "Final consumption expenditure (formerly total consumption) is the sum of household final consumption expenditure (formerly private consumption) and general government final consumption expenditure (formerly general government consumption). Data are in constant 2010 U.S. dollars."
+    - description:
+      - "Final consumption expenditure (formerly total consumption) is the sum of household final consumption expenditure (formerly private consumption) and general government final consumption expenditure (formerly general government consumption). Data are in constant 2010 U.S. dollars."
   - Final_consumption_expenditure_(constant_LCU):
-    - description: "Final consumption expenditure (formerly total consumption) is the sum of household final consumption expenditure (formerly private consumption) and general government final consumption expenditure (formerly general government consumption). Data are in constant local currency."
+    - description:
+      - "Final consumption expenditure (formerly total consumption) is the sum of household final consumption expenditure (formerly private consumption) and general government final consumption expenditure (formerly general government consumption). Data are in constant local currency."
   - Final_consumption_expenditure_(current_LCU):
-    - description: "Final consumption expenditure (formerly total consumption) is the sum of household final consumption expenditure (private consumption) and general government final consumption expenditure (general government consumption). Data are in current local currency."
+    - description:
+      - "Final consumption expenditure (formerly total consumption) is the sum of household final consumption expenditure (private consumption) and general government final consumption expenditure (general government consumption). Data are in current local currency."
   - Final_consumption_expenditure_(current_US$):
-    - description: "Final consumption expenditure (formerly total consumption) is the sum of household final consumption expenditure (private consumption) and general government final consumption expenditure (general government consumption). Data are in current U.S. dollars."
+    - description:
+      - "Final consumption expenditure (formerly total consumption) is the sum of household final consumption expenditure (private consumption) and general government final consumption expenditure (general government consumption). Data are in current U.S. dollars."
   - Final_consumption_expenditure:
-    - description: "etc. (% of GDP)"
+    - description:
+      - "etc. (% of GDP)"
   - Final_consumption_expenditure:
-    - description: "etc. (annual % growth)"
+    - description:
+      - "etc. (annual % growth)"
   - Final_consumption_expenditure:
-    - description: "etc. (constant 2010 US$)"
+    - description:
+      - "etc. (constant 2010 US$)"
   - Final_consumption_expenditure:
-    - description: "etc. (constant LCU)"
+    - description:
+      - "etc. (constant LCU)"
   - Final_consumption_expenditure:
-    - description: "etc. (current LCU)"
+    - description:
+      - "etc. (current LCU)"
   - Final_consumption_expenditure:
-    - description: "etc. (current US$)"
+    - description:
+      - "etc. (current US$)"
   - Firms_competing_against_unregistered_firms_(%_of_firms):
-    - description: "Firms competing against unregistered firms are the percentage of firms competing against unregistered or informal firms."
+    - description:
+      - "Firms competing against unregistered firms are the percentage of firms competing against unregistered or informal firms."
   - Firms_expected_to_give_gifts_in_meetings_with_tax_officials_(%_of_firms):
-    - description: "Firms expected to give gifts in meetings with tax officials is the percentage of firms that answered positively to the question was a gift or informal payment expected or requested during a meeting with tax officials?"
+    - description:
+      - "Firms expected to give gifts in meetings with tax officials is the percentage of firms that answered positively to the question was a gift or informal payment expected or requested during a meeting with tax officials?"
   - Firms_experiencing_electrical_outages_(%_of_firms):
-    - description: "Percent of firms experiencing electrical outages during the previous fiscal year."
+    - description:
+      - "Percent of firms experiencing electrical outages during the previous fiscal year."
   - Firms_experiencing_losses_due_to_theft_and_vandalism_(%_of_firms):
-    - description: "Percent of firms experiencing losses due to theft"
+    - description:
+      - "Percent of firms experiencing losses due to theft"
   - Firms_formally_registered_when_operations_started_(%_of_firms):
-    - description: "Firms formally registered when operations started are the percentage of firms formally registered when they started operations in the country."
+    - description:
+      - "Firms formally registered when operations started are the percentage of firms formally registered when they started operations in the country."
   - Firms_offering_formal_training_(%_of_firms):
-    - description: "Firms offering formal training are the percentage of firms offering formal training programs for their permanent"
+    - description:
+      - "Firms offering formal training are the percentage of firms offering formal training programs for their permanent"
   - Firms_that_do_not_report_all_sales_for_tax_purposes_(%_of_firms):
-    - description: "Firms that do not report all sales for tax purposes are the percentage of firms that expressed that a typical firm reports less than 100 percent of sales for tax purposes; such firms are termed informal firms."
+    - description:
+      - "Firms that do not report all sales for tax purposes are the percentage of firms that expressed that a typical firm reports less than 100 percent of sales for tax purposes; such firms are termed informal firms."
   - Firms_that_spend_on_R&D_(%_of_firms):
-    - description: "Percent of firms that spend on research and development."
+    - description:
+      - "Percent of firms that spend on research and development."
   - Firms_using_banks_to_finance_investment_(%_of_firms):
-    - description: "Firms using banks to finance investment are the percentage of firms using banks to finance investments."
+    - description:
+      - "Firms using banks to finance investment are the percentage of firms using banks to finance investments."
   - Firms_using_banks_to_finance_working_capital_(%_of_firms):
-    - description: "Firms using banks to finance working capital are the percentage of firms using bank loans to finance working capital."
+    - description:
+      - "Firms using banks to finance working capital are the percentage of firms using bank loans to finance working capital."
   - Firms_visited_or_required_meetings_with_tax_officials_(%_of_firms):
-    - description: "Percent of firms that were visited or required to meet with tax officials."
+    - description:
+      - "Percent of firms that were visited or required to meet with tax officials."
   - Firms_with_female_participation_in_ownership_(%_of_firms):
-    - description: "Firms with female participation in ownership are the percentage of firms with a woman among the principal owners."
+    - description:
+      - "Firms with female participation in ownership are the percentage of firms with a woman among the principal owners."
   - Firms_with_female_top_manager_(%_of_firms):
-    - description: "Firms with female top manager refers to the percentage of firms in the private sector who have females as top managers. Top manager refers to the highest ranking manager or CEO of the establishment. This person may be the owner if he/she works as the manager of the firm. The results are based on surveys of more than 100"
+    - description:
+      - "Firms with female top manager refers to the percentage of firms in the private sector who have females as top managers. Top manager refers to the highest ranking manager or CEO of the establishment. This person may be the owner if he/she works as the manager of the firm. The results are based on surveys of more than 100"
   - Fish_species:
-    - description: "threatened"
+    - description:
+      - "threatened"
   - Fixed_broadband_subscriptions:
-    - description: "Fixed broadband subscriptions refers to fixed subscriptions to high-speed access to the public Internet (a TCP/IP connection)"
+    - description:
+      - "Fixed broadband subscriptions refers to fixed subscriptions to high-speed access to the public Internet (a TCP/IP connection)"
   - Fixed_broadband_subscriptions_(per_100_people):
-    - description: "Fixed broadband subscriptions refers to fixed subscriptions to high-speed access to the public Internet (a TCP/IP connection)"
+    - description:
+      - "Fixed broadband subscriptions refers to fixed subscriptions to high-speed access to the public Internet (a TCP/IP connection)"
   - Fixed_telephone_subscriptions:
-    - description: "Fixed telephone subscriptions refers to the sum of active number of analogue fixed telephone lines"
+    - description:
+      - "Fixed telephone subscriptions refers to the sum of active number of analogue fixed telephone lines"
   - Fixed_telephone_subscriptions_(per_100_people):
-    - description: "Fixed telephone subscriptions refers to the sum of active number of analogue fixed telephone lines"
+    - description:
+      - "Fixed telephone subscriptions refers to the sum of active number of analogue fixed telephone lines"
   - Food_exports_(%_of_merchandise_exports):
-    - description: "Food comprises the commodities in SITC sections 0 (food and live animals)"
+    - description:
+      - "Food comprises the commodities in SITC sections 0 (food and live animals)"
   - Food_imports_(%_of_merchandise_imports):
-    - description: "Food comprises the commodities in SITC sections 0 (food and live animals)"
+    - description:
+      - "Food comprises the commodities in SITC sections 0 (food and live animals)"
   - Food_production_index_(2004-2006_=_100):
-    - description: "Food production index covers food crops that are considered edible and that contain nutrients. Coffee and tea are excluded because"
+    - description:
+      - "Food production index covers food crops that are considered edible and that contain nutrients. Coffee and tea are excluded because"
   - Food:
-    - description: "beverages and tobacco (% of value added in manufacturing)"
+    - description:
+      - "beverages and tobacco (% of value added in manufacturing)"
   - Foreign_direct_investment:
-    - description: "net (BoP"
+    - description:
+      - "net (BoP"
   - Foreign_direct_investment:
-    - description: "net inflows (% of GDP)"
+    - description:
+      - "net inflows (% of GDP)"
   - Foreign_direct_investment:
-    - description: "net inflows (BoP"
+    - description:
+      - "net inflows (BoP"
   - Foreign_direct_investment:
-    - description: "net outflows (% of GDP)"
+    - description:
+      - "net outflows (% of GDP)"
   - Foreign_direct_investment:
-    - description: "net outflows (BoP"
+    - description:
+      - "net outflows (BoP"
   - Forest_area_(%_of_land_area):
-    - description: "Forest area is land under natural or planted stands of trees of at least 5 meters in situ"
+    - description:
+      - "Forest area is land under natural or planted stands of trees of at least 5 meters in situ"
   - Forest_area_(sq._km):
-    - description: "Forest area is land under natural or planted stands of trees of at least 5 meters in situ"
+    - description:
+      - "Forest area is land under natural or planted stands of trees of at least 5 meters in situ"
   - Forest_rents_(%_of_GDP):
-    - description: "Forest rents are roundwood harvest times the product of average prices and a region-specific rental rate."
+    - description:
+      - "Forest rents are roundwood harvest times the product of average prices and a region-specific rental rate."
   - Fossil_fuel_energy_consumption_(%_of_total):
-    - description: "Fossil fuel comprises coal"
+    - description:
+      - "Fossil fuel comprises coal"
   - Fuel_exports_(%_of_merchandise_exports):
-    - description: "Fuels comprise the commodities in SITC section 3 (mineral fuels"
+    - description:
+      - "Fuels comprise the commodities in SITC section 3 (mineral fuels"
   - Fuel_imports_(%_of_merchandise_imports):
-    - description: "Fuels comprise the commodities in SITC section 3 (mineral fuels"
+    - description:
+      - "Fuels comprise the commodities in SITC section 3 (mineral fuels"
   - GDP_(constant_2010_US$):
-    - description: "GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant 2010 U.S. dollars. Dollar figures for GDP are converted from domestic currencies using 2010 official exchange rates. For a few countries where the official exchange rate does not reflect the rate effectively applied to actual foreign exchange transactions"
+    - description:
+      - "GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant 2010 U.S. dollars. Dollar figures for GDP are converted from domestic currencies using 2010 official exchange rates. For a few countries where the official exchange rate does not reflect the rate effectively applied to actual foreign exchange transactions"
   - GDP_(constant_LCU):
-    - description: "GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant local currency."
+    - description:
+      - "GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant local currency."
   - GDP_(current_LCU):
-    - description: "GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in current local currency."
+    - description:
+      - "GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in current local currency."
   - GDP_(current_US$):
-    - description: "GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in current U.S. dollars. Dollar figures for GDP are converted from domestic currencies using single year official exchange rates. For a few countries where the official exchange rate does not reflect the rate effectively applied to actual foreign exchange transactions"
+    - description:
+      - "GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in current U.S. dollars. Dollar figures for GDP are converted from domestic currencies using single year official exchange rates. For a few countries where the official exchange rate does not reflect the rate effectively applied to actual foreign exchange transactions"
   - GDP_at_market_prices:_linked_series_(current_LCU):
-    - description: "GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. This series has been linked to produce a consistent time series to counteract breaks in series over time due to changes in base years"
+    - description:
+      - "GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. This series has been linked to produce a consistent time series to counteract breaks in series over time due to changes in base years"
   - GDP_deflator_(base_year_varies_by_country):
-    - description: "The GDP implicit deflator is the ratio of GDP in current local currency to GDP in constant local currency. The base year varies by country."
+    - description:
+      - "The GDP implicit deflator is the ratio of GDP in current local currency to GDP in constant local currency. The base year varies by country."
   - GDP_deflator:_linked_series_(base_year_varies_by_country):
-    - description: "The GDP implicit deflator is calculated as the ratio of GDP in current local currency to GDP in constant local currency. This series has been linked to produce a consistent time series to counteract breaks in series over time due to changes in base years"
+    - description:
+      - "The GDP implicit deflator is calculated as the ratio of GDP in current local currency to GDP in constant local currency. This series has been linked to produce a consistent time series to counteract breaks in series over time due to changes in base years"
   - GDP_growth_(annual_%):
-    - description: "Annual percentage growth rate of GDP at market prices based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources."
+    - description:
+      - "Annual percentage growth rate of GDP at market prices based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources."
   - GDP_per_capita_(constant_2010_US$):
-    - description: "GDP per capita is gross domestic product divided by midyear population. GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant 2010 U.S. dollars."
+    - description:
+      - "GDP per capita is gross domestic product divided by midyear population. GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant 2010 U.S. dollars."
   - GDP_per_capita_(constant_LCU):
-    - description: "GDP per capita is gross domestic product divided by midyear population. GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant local currency."
+    - description:
+      - "GDP per capita is gross domestic product divided by midyear population. GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant local currency."
   - GDP_per_capita_(current_LCU):
-    - description: "GDP per capita is gross domestic product divided by midyear population. GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in current local currency."
+    - description:
+      - "GDP per capita is gross domestic product divided by midyear population. GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in current local currency."
   - GDP_per_capita_(current_US$):
-    - description: "GDP per capita is gross domestic product divided by midyear population. GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in current U.S. dollars."
+    - description:
+      - "GDP per capita is gross domestic product divided by midyear population. GDP is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in current U.S. dollars."
   - GDP_per_capita_growth_(annual_%):
-    - description: "Annual percentage growth rate of GDP per capita based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. GDP per capita is gross domestic product divided by midyear population. GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources."
+    - description:
+      - "Annual percentage growth rate of GDP per capita based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. GDP per capita is gross domestic product divided by midyear population. GDP at purchaser's prices is the sum of gross value added by all resident producers in the economy plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources."
   - GDP_per_capita:
-    - description: "PPP (constant 2011 international $)"
+    - description:
+      - "PPP (constant 2011 international $)"
   - GDP_per_capita:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - GDP_per_person_employed_(constant_2011_PPP_$):
-    - description: "GDP per person employed is gross domestic product (GDP) divided by total employment in the economy. Purchasing power parity (PPP) GDP is GDP converted to 2011 constant international dollars using PPP rates. An international dollar has the same purchasing power over GDP that a U.S. dollar has in the United States."
+    - description:
+      - "GDP per person employed is gross domestic product (GDP) divided by total employment in the economy. Purchasing power parity (PPP) GDP is GDP converted to 2011 constant international dollars using PPP rates. An international dollar has the same purchasing power over GDP that a U.S. dollar has in the United States."
   - GDP_per_unit_of_energy_use_(constant_2011_PPP_$_per_kg_of_oil_equivalent):
-    - description: "GDP per unit of energy use is the PPP GDP per kilogram of oil equivalent of energy use. PPP GDP is gross domestic product converted to 2011 constant international dollars using purchasing power parity rates. An international dollar has the same purchasing power over GDP as a U.S. dollar has in the United States."
+    - description:
+      - "GDP per unit of energy use is the PPP GDP per kilogram of oil equivalent of energy use. PPP GDP is gross domestic product converted to 2011 constant international dollars using purchasing power parity rates. An international dollar has the same purchasing power over GDP as a U.S. dollar has in the United States."
   - GDP_per_unit_of_energy_use_(PPP_$_per_kg_of_oil_equivalent):
-    - description: "GDP per unit of energy use is the PPP GDP per kilogram of oil equivalent of energy use. PPP GDP is gross domestic product converted to current international dollars using purchasing power parity rates based on the 2011 ICP round. An international dollar has the same purchasing power over GDP as a U.S. dollar has in the United States."
+    - description:
+      - "GDP per unit of energy use is the PPP GDP per kilogram of oil equivalent of energy use. PPP GDP is gross domestic product converted to current international dollars using purchasing power parity rates based on the 2011 ICP round. An international dollar has the same purchasing power over GDP as a U.S. dollar has in the United States."
   - GDP:
-    - description: "PPP (constant 2011 international $)"
+    - description:
+      - "PPP (constant 2011 international $)"
   - GDP:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - General_government_final_consumption_expenditure_(%_of_GDP):
-    - description: "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
+    - description:
+      - "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
   - General_government_final_consumption_expenditure_(annual_%_growth):
-    - description: "Annual percentage growth of general government final consumption expenditure based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. General government final consumption expenditure (general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
+    - description:
+      - "Annual percentage growth of general government final consumption expenditure based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. General government final consumption expenditure (general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
   - General_government_final_consumption_expenditure_(constant_2010_US$):
-    - description: "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
+    - description:
+      - "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
   - General_government_final_consumption_expenditure_(constant_LCU):
-    - description: "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
+    - description:
+      - "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
   - General_government_final_consumption_expenditure_(current_LCU):
-    - description: "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
+    - description:
+      - "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
   - General_government_final_consumption_expenditure_(current_US$):
-    - description: "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
+    - description:
+      - "General government final consumption expenditure (formerly general government consumption) includes all government current expenditures for purchases of goods and services (including compensation of employees). It also includes most expenditures on national defense and security"
   - GHG_net_emissions/removals_by_LUCF_(Mt_of_CO2_equivalent):
-    - description: "GHG net emissions/removals by LUCF refers to changes in atmospheric levels of all greenhouse gases attributable to forest and land-use change activities"
+    - description:
+      - "GHG net emissions/removals by LUCF refers to changes in atmospheric levels of all greenhouse gases attributable to forest and land-use change activities"
   - GINI_index_(World_Bank_estimate):
-    - description: "Gini index measures the extent to which the distribution of income (or"
+    - description:
+      - "Gini index measures the extent to which the distribution of income (or"
   - GNI_(constant_2010_US$):
-    - description: "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in constant 2010 U.S. dollars."
+    - description:
+      - "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in constant 2010 U.S. dollars."
   - GNI_(constant_LCU):
-    - description: "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in constant local currency."
+    - description:
+      - "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in constant local currency."
   - GNI_(current_LCU):
-    - description: "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in current local currency."
+    - description:
+      - "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in current local currency."
   - GNI_(current_US$):
-    - description: "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in current U.S. dollars."
+    - description:
+      - "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in current U.S. dollars."
   - GNI_growth_(annual_%):
-    - description: "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad."
+    - description:
+      - "GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad."
   - GNI_per_capita_(constant_2010_US$):
-    - description: "GNI per capita is gross national income divided by midyear population. GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in constant 2010 U.S. dollars."
+    - description:
+      - "GNI per capita is gross national income divided by midyear population. GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in constant 2010 U.S. dollars."
   - GNI_per_capita_(constant_LCU):
-    - description: "GNI per capita is gross national income divided by midyear population. GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in constant local currency."
+    - description:
+      - "GNI per capita is gross national income divided by midyear population. GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in constant local currency."
   - GNI_per_capita_(current_LCU):
-    - description: "GNI per capita is gross national income divided by midyear population. GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in current local currency."
+    - description:
+      - "GNI per capita is gross national income divided by midyear population. GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad. Data are in current local currency."
   - GNI_per_capita_growth_(annual_%):
-    - description: "Annual percentage growth rate of GNI per capita based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. GNI per capita is gross national income divided by midyear population. GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad."
+    - description:
+      - "Annual percentage growth rate of GNI per capita based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. GNI per capita is gross national income divided by midyear population. GNI (formerly GNP) is the sum of value added by all resident producers plus any product taxes (less subsidies) not included in the valuation of output plus net receipts of primary income (compensation of employees and property income) from abroad."
   - GNI_per_capita:
-    - description: "Atlas method (current US$)"
+    - description:
+      - "Atlas method (current US$)"
   - GNI_per_capita:
-    - description: "PPP (constant 2011 international $)"
+    - description:
+      - "PPP (constant 2011 international $)"
   - GNI_per_capita:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - GNI:
-    - description: "Atlas method (current US$)"
+    - description:
+      - "Atlas method (current US$)"
   - GNI:
-    - description: "PPP (constant 2011 international $)"
+    - description:
+      - "PPP (constant 2011 international $)"
   - GNI:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - Goods_and_services_expense_(%_of_expense):
-    - description: "Goods and services include all government payments in exchange for goods and services used for the production of market and nonmarket goods and services. Own-account capital formation is excluded."
+    - description:
+      - "Goods and services include all government payments in exchange for goods and services used for the production of market and nonmarket goods and services. Own-account capital formation is excluded."
   - Goods_and_services_expense_(current_LCU):
-    - description: "Goods and services include all government payments in exchange for goods and services used for the production of market and nonmarket goods and services. Own-account capital formation is excluded."
+    - description:
+      - "Goods and services include all government payments in exchange for goods and services used for the production of market and nonmarket goods and services. Own-account capital formation is excluded."
   - Goods_exports_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Goods_imports_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Government_expenditure_on_education:
-    - description: "total (% of GDP)"
+    - description:
+      - "total (% of GDP)"
   - Government_expenditure_on_education:
-    - description: "total (% of government expenditure)"
+    - description:
+      - "total (% of government expenditure)"
   - Government_expenditure_per_student:
-    - description: "primary (% of GDP per capita)"
+    - description:
+      - "primary (% of GDP per capita)"
   - Government_expenditure_per_student:
-    - description: "secondary (% of GDP per capita)"
+    - description:
+      - "secondary (% of GDP per capita)"
   - Government_expenditure_per_student:
-    - description: "tertiary (% of GDP per capita)"
+    - description:
+      - "tertiary (% of GDP per capita)"
   - Grants_and_other_revenue_(%_of_revenue):
-    - description: "Grants and other revenue include grants from other foreign governments"
+    - description:
+      - "Grants and other revenue include grants from other foreign governments"
   - Grants_and_other_revenue_(current_LCU):
-    - description: "Grants and other revenue include grants from other foreign governments"
+    - description:
+      - "Grants and other revenue include grants from other foreign governments"
   - Grants:
-    - description: "excluding technical cooperation (BoP"
+    - description:
+      - "excluding technical cooperation (BoP"
   - Gross_capital_formation_(%_of_GDP):
-    - description: "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
+    - description:
+      - "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
   - Gross_capital_formation_(annual_%_growth):
-    - description: "Annual growth rate of gross capital formation based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
+    - description:
+      - "Annual growth rate of gross capital formation based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
   - Gross_capital_formation_(constant_2010_US$):
-    - description: "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
+    - description:
+      - "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
   - Gross_capital_formation_(constant_LCU):
-    - description: "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
+    - description:
+      - "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
   - Gross_capital_formation_(current_LCU):
-    - description: "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
+    - description:
+      - "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
   - Gross_capital_formation_(current_US$):
-    - description: "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
+    - description:
+      - "Gross capital formation (formerly gross domestic investment) consists of outlays on additions to the fixed assets of the economy plus net changes in the level of inventories. Fixed assets include land improvements (fences"
   - Gross_domestic_income_(constant_LCU):
-    - description: "Gross domestic income is derived as the sum of GDP and the terms of trade adjustment. Data are in constant local currency."
+    - description:
+      - "Gross domestic income is derived as the sum of GDP and the terms of trade adjustment. Data are in constant local currency."
   - Gross_domestic_savings_(%_of_GDP):
-    - description: "Gross domestic savings are calculated as GDP less final consumption expenditure (total consumption)."
+    - description:
+      - "Gross domestic savings are calculated as GDP less final consumption expenditure (total consumption)."
   - Gross_domestic_savings_(current_LCU):
-    - description: "Gross domestic savings are calculated as GDP less final consumption expenditure (total consumption). Data are in current local currency."
+    - description:
+      - "Gross domestic savings are calculated as GDP less final consumption expenditure (total consumption). Data are in current local currency."
   - Gross_domestic_savings_(current_US$):
-    - description: "Gross domestic savings are calculated as GDP less final consumption expenditure (total consumption). Data are in current U.S. dollars."
+    - description:
+      - "Gross domestic savings are calculated as GDP less final consumption expenditure (total consumption). Data are in current U.S. dollars."
   - Gross_fixed_capital_formation_(%_of_GDP):
-    - description: "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
+    - description:
+      - "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
   - Gross_fixed_capital_formation_(annual_%_growth):
-    - description: "Average annual growth of gross fixed capital formation based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
+    - description:
+      - "Average annual growth of gross fixed capital formation based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
   - Gross_fixed_capital_formation_(constant_2010_US$):
-    - description: "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
+    - description:
+      - "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
   - Gross_fixed_capital_formation_(constant_LCU):
-    - description: "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
+    - description:
+      - "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
   - Gross_fixed_capital_formation_(current_LCU):
-    - description: "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
+    - description:
+      - "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
   - Gross_fixed_capital_formation_(current_US$):
-    - description: "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
+    - description:
+      - "Gross fixed capital formation (formerly gross domestic fixed investment) includes land improvements (fences"
   - Gross_fixed_capital_formation:
-    - description: "private sector (% of GDP)"
+    - description:
+      - "private sector (% of GDP)"
   - Gross_fixed_capital_formation:
-    - description: "private sector (current LCU)"
+    - description:
+      - "private sector (current LCU)"
   - Gross_intake_ratio_in_first_grade_of_primary_education:
-    - description: "female (% of relevant age group)"
+    - description:
+      - "female (% of relevant age group)"
   - Gross_intake_ratio_in_first_grade_of_primary_education:
-    - description: "male (% of relevant age group)"
+    - description:
+      - "male (% of relevant age group)"
   - Gross_intake_ratio_in_first_grade_of_primary_education:
-    - description: "total (% of relevant age group)"
+    - description:
+      - "total (% of relevant age group)"
   - Gross_national_expenditure_(%_of_GDP):
-    - description: "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
+    - description:
+      - "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
   - Gross_national_expenditure_(constant_2010_US$):
-    - description: "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
+    - description:
+      - "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
   - Gross_national_expenditure_(constant_LCU):
-    - description: "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
+    - description:
+      - "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
   - Gross_national_expenditure_(current_LCU):
-    - description: "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
+    - description:
+      - "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
   - Gross_national_expenditure_(current_US$):
-    - description: "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
+    - description:
+      - "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
   - Gross_national_expenditure_deflator_(base_year_varies_by_country):
-    - description: "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
+    - description:
+      - "Gross national expenditure (formerly domestic absorption) is the sum of household final consumption expenditure (formerly private consumption)"
   - Gross_savings_(%_of_GDP):
-    - description: "Gross savings are calculated as gross national income less total consumption"
+    - description:
+      - "Gross savings are calculated as gross national income less total consumption"
   - Gross_savings_(%_of_GNI):
-    - description: "Gross savings are calculated as gross national income less total consumption"
+    - description:
+      - "Gross savings are calculated as gross national income less total consumption"
   - Gross_savings_(current_LCU):
-    - description: "Gross savings are calculated as gross national income less total consumption"
+    - description:
+      - "Gross savings are calculated as gross national income less total consumption"
   - Gross_savings_(current_US$):
-    - description: "Gross savings are calculated as gross national income less total consumption"
+    - description:
+      - "Gross savings are calculated as gross national income less total consumption"
   - Gross_value_added_at_factor_cost_(constant_2010_US$):
-    - description: "Gross value added at factor cost (formerly GDP at factor cost) is derived as the sum of the value added in the agriculture"
+    - description:
+      - "Gross value added at factor cost (formerly GDP at factor cost) is derived as the sum of the value added in the agriculture"
   - Gross_value_added_at_factor_cost_(constant_LCU):
-    - description: "Gross value added at factor cost (formerly GDP at factor cost) is derived as the sum of the value added in the agriculture"
+    - description:
+      - "Gross value added at factor cost (formerly GDP at factor cost) is derived as the sum of the value added in the agriculture"
   - Gross_value_added_at_factor_cost_(current_LCU):
-    - description: "Gross value added at factor cost (formerly GDP at factor cost) is derived as the sum of the value added in the agriculture"
+    - description:
+      - "Gross value added at factor cost (formerly GDP at factor cost) is derived as the sum of the value added in the agriculture"
   - Gross_value_added_at_factor_cost_(current_US$):
-    - description: "Gross value added at factor cost (formerly GDP at factor cost) is derived as the sum of the value added in the agriculture"
+    - description:
+      - "Gross value added at factor cost (formerly GDP at factor cost) is derived as the sum of the value added in the agriculture"
   - HFC_gas_emissions_(thousand_metric_tons_of_CO2_equivalent):
-    - description: "Hydrofluorocarbons"
+    - description:
+      - "Hydrofluorocarbons"
   - High-technology_exports_(%_of_manufactured_exports):
-    - description: "High-technology exports are products with high R&D intensity"
+    - description:
+      - "High-technology exports are products with high R&D intensity"
   - High-technology_exports_(current_US$):
-    - description: "High-technology exports are products with high R&D intensity"
+    - description:
+      - "High-technology exports are products with high R&D intensity"
   - Hospital_beds_(per_1:
-    - description: "000 people)"
+    - description:
+      - "000 people)"
   - Household_final_consumption_expenditure_(annual_%_growth):
-    - description: "Annual percentage growth of household final consumption expenditure based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
+    - description:
+      - "Annual percentage growth of household final consumption expenditure based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
   - Household_final_consumption_expenditure_(constant_2010_US$):
-    - description: "Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
+    - description:
+      - "Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
   - Household_final_consumption_expenditure_(constant_LCU):
-    - description: "Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
+    - description:
+      - "Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
   - Household_final_consumption_expenditure_(current_LCU):
-    - description: "Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
+    - description:
+      - "Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
   - Household_final_consumption_expenditure_(current_US$):
-    - description: "Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
+    - description:
+      - "Household final consumption expenditure (formerly private consumption) is the market value of all goods and services"
   - Household_final_consumption_expenditure_per_capita_(constant_2010_US$):
-    - description: "Household final consumption expenditure per capita (private consumption per capita) is calculated using private consumption in constant 2010 prices and World Bank population estimates. Household final consumption expenditure is the market value of all goods and services"
+    - description:
+      - "Household final consumption expenditure per capita (private consumption per capita) is calculated using private consumption in constant 2010 prices and World Bank population estimates. Household final consumption expenditure is the market value of all goods and services"
   - Household_final_consumption_expenditure_per_capita_growth_(annual_%):
-    - description: "Annual percentage growth of household final consumption expenditure per capita"
+    - description:
+      - "Annual percentage growth of household final consumption expenditure per capita"
   - Household_final_consumption_expenditure:
-    - description: "etc. (% of GDP)"
+    - description:
+      - "etc. (% of GDP)"
   - Household_final_consumption_expenditure:
-    - description: "etc. (annual % growth)"
+    - description:
+      - "etc. (annual % growth)"
   - Household_final_consumption_expenditure:
-    - description: "etc. (constant 2010 US$)"
+    - description:
+      - "etc. (constant 2010 US$)"
   - Household_final_consumption_expenditure:
-    - description: "etc. (constant LCU)"
+    - description:
+      - "etc. (constant LCU)"
   - Household_final_consumption_expenditure:
-    - description: "etc. (current LCU)"
+    - description:
+      - "etc. (current LCU)"
   - Household_final_consumption_expenditure:
-    - description: "etc. (current US$)"
+    - description:
+      - "etc. (current US$)"
   - Household_final_consumption_expenditure:
-    - description: "PPP (constant 2011 international $)"
+    - description:
+      - "PPP (constant 2011 international $)"
   - Household_final_consumption_expenditure:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - IBRD_loans_and_IDA_credits_(DOD:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - ICT_goods_exports_(%_of_total_goods_exports):
-    - description: "Information and communication technology goods exports include computers and peripheral equipment"
+    - description:
+      - "Information and communication technology goods exports include computers and peripheral equipment"
   - ICT_goods_imports_(%_total_goods_imports):
-    - description: "Information and communication technology goods imports include computers and peripheral equipment"
+    - description:
+      - "Information and communication technology goods imports include computers and peripheral equipment"
   - ICT_service_exports_(%_of_service_exports:
-    - description: "BoP)"
+    - description:
+      - "BoP)"
   - ICT_service_exports_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - IDA_grants_(current_US$):
-    - description: "IDA grants are net disbursements of grants from the International Development Association (IDA). Data are in current U.S. dollars. Regional allocations are included in aggregate data."
+    - description:
+      - "IDA grants are net disbursements of grants from the International Development Association (IDA). Data are in current U.S. dollars. Regional allocations are included in aggregate data."
   - IDA_resource_allocation_index_(1=low_to_6=high):
-    - description: "IDA Resource Allocation Index is obtained by calculating the average score for each cluster and then by averaging those scores. For each of 16 criteria countries are rated on a scale of 1 (low) to 6 (high)."
+    - description:
+      - "IDA Resource Allocation Index is obtained by calculating the average score for each cluster and then by averaging those scores. For each of 16 criteria countries are rated on a scale of 1 (low) to 6 (high)."
   - IFC:
-    - description: "private nonguaranteed (NFL"
+    - description:
+      - "private nonguaranteed (NFL"
   - IMF_charges_(INT:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - IMF_purchases_(DIS:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - IMF_repurchases_(AMT:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - IMF_repurchases_and_charges_(TDS:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Immunization:
-    - description: "DPT (% of children ages 12-23 months)"
+    - description:
+      - "DPT (% of children ages 12-23 months)"
   - Immunization:
-    - description: "HepB3 (% of one-year-old children)"
+    - description:
+      - "HepB3 (% of one-year-old children)"
   - Immunization:
-    - description: "measles (% of children ages 12-23 months)"
+    - description:
+      - "measles (% of children ages 12-23 months)"
   - Import_unit_value_index_(2000_=_100):
-    - description: "Import unit value indices come from UNCTAD's trade database. Unit value indices are based on data reported by countries that demonstrate consistency under UNCTAD quality controls"
+    - description:
+      - "Import unit value indices come from UNCTAD's trade database. Unit value indices are based on data reported by countries that demonstrate consistency under UNCTAD quality controls"
   - Import_value_index_(2000_=_100):
-    - description: "Import value indexes are the current value of imports (c.i.f.) converted to U.S. dollars and expressed as a percentage of the average for the base period (2000). UNCTAD's import value indexes are reported for most economies. For selected economies for which UNCTAD does not publish data"
+    - description:
+      - "Import value indexes are the current value of imports (c.i.f.) converted to U.S. dollars and expressed as a percentage of the average for the base period (2000). UNCTAD's import value indexes are reported for most economies. For selected economies for which UNCTAD does not publish data"
   - Import_volume_index_(2000_=_100):
-    - description: "Import volume indexes are derived from UNCTAD's volume index series and are the ratio of the import value indexes to the corresponding unit value indexes. Unit value indexes are based on data reported by countries that demonstrate consistency under UNCTAD quality controls"
+    - description:
+      - "Import volume indexes are derived from UNCTAD's volume index series and are the ratio of the import value indexes to the corresponding unit value indexes. Unit value indexes are based on data reported by countries that demonstrate consistency under UNCTAD quality controls"
   - Imports_of_goods_and_services_(%_of_GDP):
-    - description: "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
+    - description:
+      - "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
   - Imports_of_goods_and_services_(annual_%_growth):
-    - description: "Annual growth rate of imports of goods and services based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
+    - description:
+      - "Annual growth rate of imports of goods and services based on constant local currency. Aggregates are based on constant 2010 U.S. dollars. Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
   - Imports_of_goods_and_services_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Imports_of_goods_and_services_(constant_2010_US$):
-    - description: "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
+    - description:
+      - "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
   - Imports_of_goods_and_services_(constant_LCU):
-    - description: "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
+    - description:
+      - "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
   - Imports_of_goods_and_services_(current_LCU):
-    - description: "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
+    - description:
+      - "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
   - Imports_of_goods_and_services_(current_US$):
-    - description: "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
+    - description:
+      - "Imports of goods and services represent the value of all goods and other market services received from the rest of the world. They include the value of merchandise"
   - Imports_of_goods:
-    - description: "services and primary income (BoP"
+    - description:
+      - "services and primary income (BoP"
   - Incidence_of_HIV_(%_of_uninfected_population_ages_15-49):
-    - description: "Number of new HIV infections among uninfected populations ages 15-49 expressed per 100 uninfected population in the year before the period."
+    - description:
+      - "Number of new HIV infections among uninfected populations ages 15-49 expressed per 100 uninfected population in the year before the period."
   - Incidence_of_malaria_(per_1:
-    - description: "000 population at risk)"
+    - description:
+      - "000 population at risk)"
   - Incidence_of_tuberculosis_(per_100:
-    - description: "000 people)"
+    - description:
+      - "000 people)"
   - Income_share_held_by_fourth_20%:
-    - description: "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
+    - description:
+      - "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
   - Income_share_held_by_highest_10%:
-    - description: "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles."
+    - description:
+      - "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles."
   - Income_share_held_by_highest_20%:
-    - description: "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
+    - description:
+      - "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
   - Income_share_held_by_lowest_10%:
-    - description: "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles."
+    - description:
+      - "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles."
   - Income_share_held_by_lowest_20%:
-    - description: "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
+    - description:
+      - "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
   - Income_share_held_by_second_20%:
-    - description: "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
+    - description:
+      - "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
   - Income_share_held_by_third_20%:
-    - description: "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
+    - description:
+      - "Percentage share of income or consumption is the share that accrues to subgroups of population indicated by deciles or quintiles. Percentage shares by quintile may not sum to 100 because of rounding."
   - Individuals_using_the_Internet_(%_of_population):
-    - description: "Internet users are individuals who have used the Internet (from any location) in the last 3 months. The Internet can be used via a computer"
+    - description:
+      - "Internet users are individuals who have used the Internet (from any location) in the last 3 months. The Internet can be used via a computer"
   - Industrial_design_applications:
-    - description: "nonresident"
+    - description:
+      - "nonresident"
   - Industrial_design_applications:
-    - description: "resident"
+    - description:
+      - "resident"
   - Industry:
-    - description: "value added (% of GDP)"
+    - description:
+      - "value added (% of GDP)"
   - Industry:
-    - description: "value added (annual % growth)"
+    - description:
+      - "value added (annual % growth)"
   - Industry:
-    - description: "value added (constant 2010 US$)"
+    - description:
+      - "value added (constant 2010 US$)"
   - Industry:
-    - description: "value added (constant LCU)"
+    - description:
+      - "value added (constant LCU)"
   - Industry:
-    - description: "value added (current LCU)"
+    - description:
+      - "value added (current LCU)"
   - Industry:
-    - description: "value added (current US$)"
+    - description:
+      - "value added (current US$)"
   - Industry:
-    - description: "value added per worker (constant 2010 US$)"
+    - description:
+      - "value added per worker (constant 2010 US$)"
   - Inflation:
-    - description: "consumer prices (annual %)"
+    - description:
+      - "consumer prices (annual %)"
   - Inflation:
-    - description: "GDP deflator (annual %)"
+    - description:
+      - "GDP deflator (annual %)"
   - Inflation:
-    - description: "GDP deflator: linked series (annual %)"
+    - description:
+      - "GDP deflator: linked series (annual %)"
   - Informal_employment_(%_of_total_non-agricultural_employment):
-    - description: "Employment in the informal economy as a percentage of total non-agricultural employment. It basically includes all jobs in unregistered and/or small-scale private unincorporated enterprises that produce goods or services meant for sale or barter. Self-employed street vendors"
+    - description:
+      - "Employment in the informal economy as a percentage of total non-agricultural employment. It basically includes all jobs in unregistered and/or small-scale private unincorporated enterprises that produce goods or services meant for sale or barter. Self-employed street vendors"
   - Informal_employment:
-    - description: "female (% of total non-agricultural employment)"
+    - description:
+      - "female (% of total non-agricultural employment)"
   - Informal_employment:
-    - description: "male (% of total non-agricultural employment)"
+    - description:
+      - "male (% of total non-agricultural employment)"
   - Informal_payments_to_public_officials_(%_of_firms):
-    - description: "Informal payments to public officials are the percentage of firms expected to make informal payments to public officials to get things done with regard to customs"
+    - description:
+      - "Informal payments to public officials are the percentage of firms expected to make informal payments to public officials to get things done with regard to customs"
   - Insurance_and_financial_services_(%_of_commercial_service_exports):
-    - description: "Insurance and financial services cover freight insurance on goods exported and other direct insurance such as life insurance; financial intermediation services such as commissions"
+    - description:
+      - "Insurance and financial services cover freight insurance on goods exported and other direct insurance such as life insurance; financial intermediation services such as commissions"
   - Insurance_and_financial_services_(%_of_commercial_service_imports):
-    - description: "Insurance and financial services cover freight insurance on goods imported and other direct insurance such as life insurance; financial intermediation services such as commissions"
+    - description:
+      - "Insurance and financial services cover freight insurance on goods imported and other direct insurance such as life insurance; financial intermediation services such as commissions"
   - Insurance_and_financial_services_(%_of_service_exports:
-    - description: "BoP)"
+    - description:
+      - "BoP)"
   - Insurance_and_financial_services_(%_of_service_imports:
-    - description: "BoP)"
+    - description:
+      - "BoP)"
   - Intentional_homicides_(per_100:
-    - description: "000 people)"
+    - description:
+      - "000 people)"
   - Interest_arrears:
-    - description: "official creditors (current US$)"
+    - description:
+      - "official creditors (current US$)"
   - Interest_arrears:
-    - description: "private creditors (current US$)"
+    - description:
+      - "private creditors (current US$)"
   - Interest_arrears:
-    - description: "public and publicly guaranteed (current US$)"
+    - description:
+      - "public and publicly guaranteed (current US$)"
   - Interest_forgiven_(current_US$):
-    - description: "Interest forgiven is the amount of interest due or in arrears that was written off or forgiven in any given year. Data are in current U.S. dollars."
+    - description:
+      - "Interest forgiven is the amount of interest due or in arrears that was written off or forgiven in any given year. Data are in current U.S. dollars."
   - Interest_payments_(%_of_expense):
-    - description: "Interest payments include interest payments on government debt--including long-term bonds"
+    - description:
+      - "Interest payments include interest payments on government debt--including long-term bonds"
   - Interest_payments_(%_of_revenue):
-    - description: "Interest payments include interest payments on government debt--including long-term bonds"
+    - description:
+      - "Interest payments include interest payments on government debt--including long-term bonds"
   - Interest_payments_(current_LCU):
-    - description: "Interest payments include interest payments on government debt--including long-term bonds"
+    - description:
+      - "Interest payments include interest payments on government debt--including long-term bonds"
   - Interest_payments_on_external_debt_(%_of_exports_of_goods:
-    - description: "services and primary income)"
+    - description:
+      - "services and primary income)"
   - Interest_payments_on_external_debt_(%_of_GNI):
-    - description: "Total interest payments to gross national income."
+    - description:
+      - "Total interest payments to gross national income."
   - Interest_payments_on_external_debt:
-    - description: "long-term (INT"
+    - description:
+      - "long-term (INT"
   - Interest_payments_on_external_debt:
-    - description: "private nonguaranteed (PNG) (INT"
+    - description:
+      - "private nonguaranteed (PNG) (INT"
   - Interest_payments_on_external_debt:
-    - description: "public and publicly guaranteed (PPG) (INT"
+    - description:
+      - "public and publicly guaranteed (PPG) (INT"
   - Interest_payments_on_external_debt:
-    - description: "short-term (INT"
+    - description:
+      - "short-term (INT"
   - Interest_payments_on_external_debt:
-    - description: "total (INT"
+    - description:
+      - "total (INT"
   - Interest_rate_spread_(lending_rate_minus_deposit_rate:
-    - description: "%)"
+    - description:
+      - "%)"
   - Interest_rescheduled_(capitalized)_(current_US$):
-    - description: "Interest rescheduled is the amount of interest due or in arrears that was rescheduled in any given year. (Interest capitalized is the interest that became part of the stock of debt due to a rescheduling operation.) Data are in current U.S. dollars."
+    - description:
+      - "Interest rescheduled is the amount of interest due or in arrears that was rescheduled in any given year. (Interest capitalized is the interest that became part of the stock of debt due to a rescheduling operation.) Data are in current U.S. dollars."
   - Interest_rescheduled:
-    - description: "official (current US$)"
+    - description:
+      - "official (current US$)"
   - Interest_rescheduled:
-    - description: "private (current US$)"
+    - description:
+      - "private (current US$)"
   - Internally_displaced_persons:
-    - description: "new displacement associated with conflict and violence (number of cases)"
+    - description:
+      - "new displacement associated with conflict and violence (number of cases)"
   - Internally_displaced_persons:
-    - description: "new displacement associated with disasters (number of cases)"
+    - description:
+      - "new displacement associated with disasters (number of cases)"
   - Internally_displaced_persons:
-    - description: "total displaced by conflict and violence (number of people)"
+    - description:
+      - "total displaced by conflict and violence (number of people)"
   - International_migrant_stock_(%_of_population):
-    - description: "International migrant stock is the number of people born in a country other than that in which they live. It also includes refugees. The data used to estimate the international migrant stock at a particular time are obtained mainly from population censuses. The estimates are derived from the data on foreign-born population--people who have residence in one country but were born in another country. When data on the foreign-born population are not available"
+    - description:
+      - "International migrant stock is the number of people born in a country other than that in which they live. It also includes refugees. The data used to estimate the international migrant stock at a particular time are obtained mainly from population censuses. The estimates are derived from the data on foreign-born population--people who have residence in one country but were born in another country. When data on the foreign-born population are not available"
   - International_migrant_stock:
-    - description: "total"
+    - description:
+      - "total"
   - International_tourism:
-    - description: "expenditures (% of total imports)"
+    - description:
+      - "expenditures (% of total imports)"
   - International_tourism:
-    - description: "expenditures (current US$)"
+    - description:
+      - "expenditures (current US$)"
   - International_tourism:
-    - description: "expenditures for passenger transport items (current US$)"
+    - description:
+      - "expenditures for passenger transport items (current US$)"
   - International_tourism:
-    - description: "expenditures for travel items (current US$)"
+    - description:
+      - "expenditures for travel items (current US$)"
   - International_tourism:
-    - description: "number of arrivals"
+    - description:
+      - "number of arrivals"
   - International_tourism:
-    - description: "number of departures"
+    - description:
+      - "number of departures"
   - International_tourism:
-    - description: "receipts (% of total exports)"
+    - description:
+      - "receipts (% of total exports)"
   - International_tourism:
-    - description: "receipts (current US$)"
+    - description:
+      - "receipts (current US$)"
   - International_tourism:
-    - description: "receipts for passenger transport items (current US$)"
+    - description:
+      - "receipts for passenger transport items (current US$)"
   - International_tourism:
-    - description: "receipts for travel items (current US$)"
+    - description:
+      - "receipts for travel items (current US$)"
   - Investment_in_energy_with_private_participation_(current_US$):
-    - description: "Investment in energy projects with private participation  refers to commitments to  infrastructure projects in energy (electricity and natural gas: generation"
+    - description:
+      - "Investment in energy projects with private participation  refers to commitments to  infrastructure projects in energy (electricity and natural gas: generation"
   - Investment_in_ICT_with_private_participation_(current_US$):
-    - description: "Investment in ICT projects with private participation refers to commitments to projects in ICT backbone infrastructure (including land based and submarine cables) that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are operations and management contracts"
+    - description:
+      - "Investment in ICT projects with private participation refers to commitments to projects in ICT backbone infrastructure (including land based and submarine cables) that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are operations and management contracts"
   - Investment_in_telecoms_with_private_participation_(current_US$):
-    - description: "Investment  in telecom projects with private participation refers to commitments to infrastructure projects in telecommunications that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are management and lease contracts"
+    - description:
+      - "Investment  in telecom projects with private participation refers to commitments to infrastructure projects in telecommunications that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are management and lease contracts"
   - Investment_in_transport_with_private_participation_(current_US$):
-    - description: "Investment  in transport projects with private participation refers to commitments to  infrastructure projects in transport that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are  management and lease contracts"
+    - description:
+      - "Investment  in transport projects with private participation refers to commitments to  infrastructure projects in transport that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are  management and lease contracts"
   - Investment_in_water_and_sanitation_with_private_participation_(current_US$):
-    - description: "Investment in water and sanitation projects with private participation refers to commitments to  infrastructure projects in water and sanitation that have reached financial closure and directly or indirectly serve the public. Movable assets"
+    - description:
+      - "Investment in water and sanitation projects with private participation refers to commitments to  infrastructure projects in water and sanitation that have reached financial closure and directly or indirectly serve the public. Movable assets"
   - Labor_force_participation_rate_for_ages_15-24:
-    - description: "female (%) (modeled ILO estimate)"
+    - description:
+      - "female (%) (modeled ILO estimate)"
   - Labor_force_participation_rate_for_ages_15-24:
-    - description: "female (%) (national estimate)"
+    - description:
+      - "female (%) (national estimate)"
   - Labor_force_participation_rate_for_ages_15-24:
-    - description: "male (%) (modeled ILO estimate)"
+    - description:
+      - "male (%) (modeled ILO estimate)"
   - Labor_force_participation_rate_for_ages_15-24:
-    - description: "male (%) (national estimate)"
+    - description:
+      - "male (%) (national estimate)"
   - Labor_force_participation_rate_for_ages_15-24:
-    - description: "total (%) (modeled ILO estimate)"
+    - description:
+      - "total (%) (modeled ILO estimate)"
   - Labor_force_participation_rate_for_ages_15-24:
-    - description: "total (%) (national estimate)"
+    - description:
+      - "total (%) (national estimate)"
   - Labor_force_participation_rate:
-    - description: "female (% of female population ages 15+) (modeled ILO estimate)"
+    - description:
+      - "female (% of female population ages 15+) (modeled ILO estimate)"
   - Labor_force_participation_rate:
-    - description: "female (% of female population ages 15+) (national estimate)"
+    - description:
+      - "female (% of female population ages 15+) (national estimate)"
   - Labor_force_participation_rate:
-    - description: "female (% of female population ages 15-64) (modeled ILO estimate)"
+    - description:
+      - "female (% of female population ages 15-64) (modeled ILO estimate)"
   - Labor_force_participation_rate:
-    - description: "male (% of male population ages 15+) (modeled ILO estimate)"
+    - description:
+      - "male (% of male population ages 15+) (modeled ILO estimate)"
   - Labor_force_participation_rate:
-    - description: "male (% of male population ages 15+) (national estimate)"
+    - description:
+      - "male (% of male population ages 15+) (national estimate)"
   - Labor_force_participation_rate:
-    - description: "male (% of male population ages 15-64) (modeled ILO estimate)"
+    - description:
+      - "male (% of male population ages 15-64) (modeled ILO estimate)"
   - Labor_force_participation_rate:
-    - description: "total (% of total population ages 15+) (modeled ILO estimate)"
+    - description:
+      - "total (% of total population ages 15+) (modeled ILO estimate)"
   - Labor_force_participation_rate:
-    - description: "total (% of total population ages 15+) (national estimate)"
+    - description:
+      - "total (% of total population ages 15+) (national estimate)"
   - Labor_force_participation_rate:
-    - description: "total (% of total population ages 15-64) (modeled ILO estimate)"
+    - description:
+      - "total (% of total population ages 15-64) (modeled ILO estimate)"
   - Labor_force_with_advanced_education_(%_of_total_working-age_population_with_advanced_education):
-    - description: "The percentage of the working age population with an advanced level of education who are in the labor force. Advanced education comprises short-cycle tertiary education"
+    - description:
+      - "The percentage of the working age population with an advanced level of education who are in the labor force. Advanced education comprises short-cycle tertiary education"
   - Labor_force_with_advanced_education:
-    - description: "female (% of female working-age population with advanced education)"
+    - description:
+      - "female (% of female working-age population with advanced education)"
   - Labor_force_with_advanced_education:
-    - description: "male (% of male working-age population with advanced education)"
+    - description:
+      - "male (% of male working-age population with advanced education)"
   - Labor_force_with_basic_education_(%_of_total_working-age_population_with_basic_education):
-    - description: "The percentage of the working age population with a basic level of education who are in the labor force. Basic education comprises primary education or lower secondary education according to the International Standard Classification of Education 2011 (ISCED 2011)."
+    - description:
+      - "The percentage of the working age population with a basic level of education who are in the labor force. Basic education comprises primary education or lower secondary education according to the International Standard Classification of Education 2011 (ISCED 2011)."
   - Labor_force_with_basic_education:
-    - description: "female (% of female working-age population with basic education)"
+    - description:
+      - "female (% of female working-age population with basic education)"
   - Labor_force_with_basic_education:
-    - description: "male (% of male working-age population with basic education)"
+    - description:
+      - "male (% of male working-age population with basic education)"
   - Labor_force_with_intermediate_education_(%_of_total_working-age_population_with_intermediate_education):
-    - description: "The percentage of the working age population with an intermediate level of education who are in the labor force. Intermediate education comprises upper secondary or post-secondary non tertiary education according to the International Standard Classification of Education 2011 (ISCED 2011)."
+    - description:
+      - "The percentage of the working age population with an intermediate level of education who are in the labor force. Intermediate education comprises upper secondary or post-secondary non tertiary education according to the International Standard Classification of Education 2011 (ISCED 2011)."
   - Labor_force_with_intermediate_education:
-    - description: "female (% of female working-age population with intermediate education)"
+    - description:
+      - "female (% of female working-age population with intermediate education)"
   - Labor_force_with_intermediate_education:
-    - description: "male (% of male working-age population with intermediate education)"
+    - description:
+      - "male (% of male working-age population with intermediate education)"
   - Labor_force:
-    - description: "female (% of total labor force)"
+    - description:
+      - "female (% of total labor force)"
   - Labor_force:
-    - description: "total"
+    - description:
+      - "total"
   - Labor_tax_and_contributions_(%_of_commercial_profits):
-    - description: "Labor tax and contributions is the amount of taxes and mandatory contributions on labor paid by the business."
+    - description:
+      - "Labor tax and contributions is the amount of taxes and mandatory contributions on labor paid by the business."
   - Land_area_(sq._km):
-    - description: "Land area is a country's total area"
+    - description:
+      - "Land area is a country's total area"
   - Land_area_where_elevation_is_below_5_meters_(%_of_total_land_area):
-    - description: "Land area below 5m is the percentage of total land where the elevation is 5 meters or less."
+    - description:
+      - "Land area below 5m is the percentage of total land where the elevation is 5 meters or less."
   - Land_under_cereal_production_(hectares):
-    - description: "Land under cereal production refers to harvested area"
+    - description:
+      - "Land under cereal production refers to harvested area"
   - Law_mandates_equal_remuneration_for_females_and_males_for_work_of_equal_value_(1=yes;_0=no):
-    - description: "Law mandates equal remuneration for females and males for work of equal value is whether there is a law that obligates employers to pay equal remuneration to male and female employees who do work of equal value.\"Remuneration\" refers to the ordinary"
+    - description:
+      - "Law mandates equal remuneration for females and males for work of equal value is whether there is a law that obligates employers to pay equal remuneration to male and female employees who do work of equal value.\"Remuneration\" refers to the ordinary"
   - Law_mandates_nondiscrimination_based_on_gender_in_hiring_(1=yes;_0=no):
-    - description: "Law mandates nondiscrimination based on gender in hiring is whether the law specifically prevents or penalizes gender-based discrimination in the hiring process; the law may prohibit discrimination in employment on the basis of gender but be silent about whether job applicants are protected from discrimination. Hiring refers to the process of employing a person for wages and making a selection by presenting a candidate with a job offer. Job advertisements"
+    - description:
+      - "Law mandates nondiscrimination based on gender in hiring is whether the law specifically prevents or penalizes gender-based discrimination in the hiring process; the law may prohibit discrimination in employment on the basis of gender but be silent about whether job applicants are protected from discrimination. Hiring refers to the process of employing a person for wages and making a selection by presenting a candidate with a job offer. Job advertisements"
   - Law_mandates_paid_or_unpaid_maternity_leave_(1=yes;_0=no):
-    - description: "Law mandates paid or unpaid maternity leave is whether there is a law mandating paid or unpaid maternity leave available only to the mother. Provisions for circumstantial leave by which an employee is entitled to a certain number of days of paid leave (usually fewer than five days) upon the birth of a child are considered paternity leave; even if the law is gender-neutral"
+    - description:
+      - "Law mandates paid or unpaid maternity leave is whether there is a law mandating paid or unpaid maternity leave available only to the mother. Provisions for circumstantial leave by which an employee is entitled to a certain number of days of paid leave (usually fewer than five days) upon the birth of a child are considered paternity leave; even if the law is gender-neutral"
   - Law_prohibits_or_invalidates_child_or_early_marriage_(1=yes;_0=no):
-    - description: "Law prohibits or invalidates child or early marriage is whether there are provisions that prevent the marriage of girls"
+    - description:
+      - "Law prohibits or invalidates child or early marriage is whether there are provisions that prevent the marriage of girls"
   - Lead_time_to_export:
-    - description: "median case (days)"
+    - description:
+      - "median case (days)"
   - Lead_time_to_import:
-    - description: "median case (days)"
+    - description:
+      - "median case (days)"
   - Legislation_exists_on_domestic_violence_(1=yes;_0=no):
-    - description: "Legislation exists on domestic violence is whether there is legislation addressing domestic violence: violence between spouses"
+    - description:
+      - "Legislation exists on domestic violence is whether there is legislation addressing domestic violence: violence between spouses"
   - Lending_interest_rate_(%):
-    - description: "Lending rate is the bank rate that usually meets the short- and medium-term financing needs of the private sector. This rate is normally differentiated according to creditworthiness of borrowers and objectives of financing. The terms and conditions attached to these rates differ by country"
+    - description:
+      - "Lending rate is the bank rate that usually meets the short- and medium-term financing needs of the private sector. This rate is normally differentiated according to creditworthiness of borrowers and objectives of financing. The terms and conditions attached to these rates differ by country"
   - Life_expectancy_at_birth:
-    - description: "female (years)"
+    - description:
+      - "female (years)"
   - Life_expectancy_at_birth:
-    - description: "male (years)"
+    - description:
+      - "male (years)"
   - Life_expectancy_at_birth:
-    - description: "total (years)"
+    - description:
+      - "total (years)"
   - Lifetime_risk_of_maternal_death_(%):
-    - description: "Life time risk of maternal death is the probability that a 15-year-old female will die eventually from a maternal cause assuming that current levels of fertility and mortality (including maternal mortality) do not change in the future"
+    - description:
+      - "Life time risk of maternal death is the probability that a 15-year-old female will die eventually from a maternal cause assuming that current levels of fertility and mortality (including maternal mortality) do not change in the future"
   - Lifetime_risk_of_maternal_death_(1_in:_rate_varies_by_country):
-    - description: "Life time risk of maternal death is the probability that a 15-year-old female will die eventually from a maternal cause assuming that current levels of fertility and mortality (including maternal mortality) do not change in the future"
+    - description:
+      - "Life time risk of maternal death is the probability that a 15-year-old female will die eventually from a maternal cause assuming that current levels of fertility and mortality (including maternal mortality) do not change in the future"
   - Liner_shipping_connectivity_index_(maximum_value_in_2004_=_100):
-    - description: "The Liner Shipping Connectivity Index captures how well countries are connected to global shipping networks. It is computed by the United Nations Conference on Trade and Development (UNCTAD) based on five components of the maritime transport sector: number of ships"
+    - description:
+      - "The Liner Shipping Connectivity Index captures how well countries are connected to global shipping networks. It is computed by the United Nations Conference on Trade and Development (UNCTAD) based on five components of the maritime transport sector: number of ships"
   - Listed_domestic_companies:
-    - description: "total"
+    - description:
+      - "total"
   - Literacy_rate:
-    - description: "adult female (% of females ages 15 and above)"
+    - description:
+      - "adult female (% of females ages 15 and above)"
   - Literacy_rate:
-    - description: "adult male (% of males ages 15 and above)"
+    - description:
+      - "adult male (% of males ages 15 and above)"
   - Literacy_rate:
-    - description: "adult total (% of people ages 15 and above)"
+    - description:
+      - "adult total (% of people ages 15 and above)"
   - Literacy_rate:
-    - description: "youth (ages 15-24)"
+    - description:
+      - "youth (ages 15-24)"
   - Literacy_rate:
-    - description: "youth female (% of females ages 15-24)"
+    - description:
+      - "youth female (% of females ages 15-24)"
   - Literacy_rate:
-    - description: "youth male (% of males ages 15-24)"
+    - description:
+      - "youth male (% of males ages 15-24)"
   - Literacy_rate:
-    - description: "youth total (% of people ages 15-24)"
+    - description:
+      - "youth total (% of people ages 15-24)"
   - Livestock_production_index_(2004-2006_=_100):
-    - description: "Livestock production index includes meat and milk from all sources"
+    - description:
+      - "Livestock production index includes meat and milk from all sources"
   - Logistics_performance_index:_Ability_to_track_and_trace_consignments_(1=low_to_5=high):
-    - description: "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
+    - description:
+      - "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
   - Logistics_performance_index:_Competence_and_quality_of_logistics_services_(1=low_to_5=high):
-    - description: "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
+    - description:
+      - "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
   - Logistics_performance_index:_Ease_of_arranging_competitively_priced_shipments_(1=low_to_5=high):
-    - description: "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
+    - description:
+      - "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
   - Logistics_performance_index:_Efficiency_of_customs_clearance_process_(1=low_to_5=high):
-    - description: "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
+    - description:
+      - "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
   - Logistics_performance_index:_Frequency_with_which_shipments_reach_consignee_within_scheduled_or_expected_time_(1=low_to_5=high):
-    - description: "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
+    - description:
+      - "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
   - Logistics_performance_index:_Overall_(1=low_to_5=high):
-    - description: "Logistics Performance Index overall score reflects perceptions of a country's logistics based on efficiency of customs clearance process"
+    - description:
+      - "Logistics Performance Index overall score reflects perceptions of a country's logistics based on efficiency of customs clearance process"
   - Logistics_performance_index:_Quality_of_trade_and_transport-related_infrastructure_(1=low_to_5=high):
-    - description: "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
+    - description:
+      - "Data are from Logistics Performance Index surveys conducted by the World Bank in partnership with academic and international institutions and private companies and individuals engaged in international logistics. 2009 round of surveys covered more than 5"
   - Losses_due_to_theft_and_vandalism_(%_of_annual_sales_for_affected_firms):
-    - description: "Average losses as a result of theft"
+    - description:
+      - "Average losses as a result of theft"
   - Low-birthweight_babies_(%_of_births):
-    - description: "Low-birthweight babies are newborns weighing less than 2"
+    - description:
+      - "Low-birthweight babies are newborns weighing less than 2"
   - Lower_secondary_completion_rate:
-    - description: "female (% of relevant age group)"
+    - description:
+      - "female (% of relevant age group)"
   - Lower_secondary_completion_rate:
-    - description: "male (% of relevant age group)"
+    - description:
+      - "male (% of relevant age group)"
   - Lower_secondary_completion_rate:
-    - description: "total (% of relevant age group)"
+    - description:
+      - "total (% of relevant age group)"
   - Lower_secondary_school_starting_age_(years):
-    - description: "Lower secondary school starting age is the age at which students would enter lower secondary education"
+    - description:
+      - "Lower secondary school starting age is the age at which students would enter lower secondary education"
   - Machinery_and_transport_equipment_(%_of_value_added_in_manufacturing):
-    - description: "Value added in manufacturing is the sum of gross output less the value of intermediate inputs used in production for industries classified in ISIC major division D. Machinery and transport equipment correspond to ISIC divisions 29"
+    - description:
+      - "Value added in manufacturing is the sum of gross output less the value of intermediate inputs used in production for industries classified in ISIC major division D. Machinery and transport equipment correspond to ISIC divisions 29"
   - Mammal_species:
-    - description: "threatened"
+    - description:
+      - "threatened"
   - Manufactures_exports_(%_of_merchandise_exports):
-    - description: "Manufactures comprise commodities in SITC sections 5 (chemicals)"
+    - description:
+      - "Manufactures comprise commodities in SITC sections 5 (chemicals)"
   - Manufactures_imports_(%_of_merchandise_imports):
-    - description: "Manufactures comprise the commodities in SITC sections 5 (chemicals)"
+    - description:
+      - "Manufactures comprise the commodities in SITC sections 5 (chemicals)"
   - Manufacturing:
-    - description: "value added (% of GDP)"
+    - description:
+      - "value added (% of GDP)"
   - Manufacturing:
-    - description: "value added (annual % growth)"
+    - description:
+      - "value added (annual % growth)"
   - Manufacturing:
-    - description: "value added (constant 2010 US$)"
+    - description:
+      - "value added (constant 2010 US$)"
   - Manufacturing:
-    - description: "value added (constant LCU)"
+    - description:
+      - "value added (constant LCU)"
   - Manufacturing:
-    - description: "value added (current LCU)"
+    - description:
+      - "value added (current LCU)"
   - Manufacturing:
-    - description: "value added (current US$)"
+    - description:
+      - "value added (current US$)"
   - Marine_protected_areas_(%_of_territorial_waters):
-    - description: "Marine protected areas are areas of intertidal or subtidal terrain--and overlying water and associated flora and fauna and historical and cultural features--that have been reserved by law or other effective means to protect part or all of the enclosed environment."
+    - description:
+      - "Marine protected areas are areas of intertidal or subtidal terrain--and overlying water and associated flora and fauna and historical and cultural features--that have been reserved by law or other effective means to protect part or all of the enclosed environment."
   - Market_capitalization_of_listed_domestic_companies_(%_of_GDP):
-    - description: "Market capitalization (also known as market value) is the share price times the number of shares outstanding (including their several classes) for listed domestic companies. Investment funds"
+    - description:
+      - "Market capitalization (also known as market value) is the share price times the number of shares outstanding (including their several classes) for listed domestic companies. Investment funds"
   - Market_capitalization_of_listed_domestic_companies_(current_US$):
-    - description: "Market capitalization (also known as market value) is the share price times the number of shares outstanding (including their several classes) for listed domestic companies. Investment funds"
+    - description:
+      - "Market capitalization (also known as market value) is the share price times the number of shares outstanding (including their several classes) for listed domestic companies. Investment funds"
   - Maternal_mortality_ratio_(modeled_estimate:
-    - description: "per 100"
+    - description:
+      - "per 100"
   - Maternal_mortality_ratio_(national_estimate:
-    - description: "per 100"
+    - description:
+      - "per 100"
   - Medium_and_high-tech_exports_(%_manufactured_exports):
-    - description: "Share of medium and high-tech manufactured exports in total manufactured exports."
+    - description:
+      - "Share of medium and high-tech manufactured exports in total manufactured exports."
   - Medium_and_high-tech_industry_(%_manufacturing_value_added):
-    - description: "The proportion of medium and high-tech industry value added in total value added of manufacturing"
+    - description:
+      - "The proportion of medium and high-tech industry value added in total value added of manufacturing"
   - Merchandise_exports_(current_US$):
-    - description: "Merchandise exports show the f.o.b. value of goods provided to the rest of the world valued in current U.S. dollars."
+    - description:
+      - "Merchandise exports show the f.o.b. value of goods provided to the rest of the world valued in current U.S. dollars."
   - Merchandise_exports_by_the_reporting_economy_(current_US$):
-    - description: "Merchandise exports by the reporting economy are the total merchandise exports by the reporting economy to the rest of the world"
+    - description:
+      - "Merchandise exports by the reporting economy are the total merchandise exports by the reporting economy to the rest of the world"
   - Merchandise_exports_by_the_reporting_economy:
-    - description: "residual (% of total merchandise exports)"
+    - description:
+      - "residual (% of total merchandise exports)"
   - Merchandise_exports_to_economies_in_the_Arab_World_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to economies in the Arab World are the sum of merchandise exports by the reporting economy to economies in the Arab World. Data are expressed as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to economies in the Arab World are the sum of merchandise exports by the reporting economy to economies in the Arab World. Data are expressed as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_high-income_economies_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to high-income economies are the sum of merchandise exports from the reporting economy to high-income economies according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to high-income economies are the sum of merchandise exports from the reporting economy to high-income economies according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_low-_and_middle-income_economies_in_East_Asia_&_Pacific_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to low- and middle-income economies in East Asia and Pacific are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the East Asia and Pacific region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to low- and middle-income economies in East Asia and Pacific are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the East Asia and Pacific region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_low-_and_middle-income_economies_in_Europe_&_Central_Asia_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to low- and middle-income economies in Europe and Central Asia are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the Europe and Central Asia region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to low- and middle-income economies in Europe and Central Asia are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the Europe and Central Asia region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_low-_and_middle-income_economies_in_Latin_America_&_the_Caribbean_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to low- and middle-income economies in Latin America and the Caribbean are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the Latin America and the Caribbean region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to low- and middle-income economies in Latin America and the Caribbean are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the Latin America and the Caribbean region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_low-_and_middle-income_economies_in_Middle_East_&_North_Africa_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to low- and middle-income economies in Middle East and North Africa are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the Middle East and North Africa region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to low- and middle-income economies in Middle East and North Africa are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the Middle East and North Africa region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_low-_and_middle-income_economies_in_South_Asia_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to low- and middle-income economies in South Asia are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the South Asia region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to low- and middle-income economies in South Asia are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the South Asia region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_low-_and_middle-income_economies_in_Sub-Saharan_Africa_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to low- and middle-income economies in Sub-Saharan Africa are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the Sub-Saharan Africa region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to low- and middle-income economies in Sub-Saharan Africa are the sum of merchandise exports from the reporting economy to low- and middle-income economies in the Sub-Saharan Africa region according to World Bank classification of economies. Data are as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_low-_and_middle-income_economies_outside_region_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to low- and middle-income economies outside region are the sum of merchandise exports from the reporting economy to other low- and middle-income economies in other World Bank regions according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise exports to low- and middle-income economies outside region are the sum of merchandise exports from the reporting economy to other low- and middle-income economies in other World Bank regions according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_exports_to_low-_and_middle-income_economies_within_region_(%_of_total_merchandise_exports):
-    - description: "Merchandise exports to low- and middle-income economies within region are the sum of merchandise exports from the reporting economy to other low- and middle-income economies in the same World Bank region as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data. No figures are shown for high-income economies"
+    - description:
+      - "Merchandise exports to low- and middle-income economies within region are the sum of merchandise exports from the reporting economy to other low- and middle-income economies in the same World Bank region as a percentage of total merchandise exports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data. No figures are shown for high-income economies"
   - Merchandise_imports_(current_US$):
-    - description: "Merchandise imports show the c.i.f. value of goods received from the rest of the world valued in current U.S. dollars."
+    - description:
+      - "Merchandise imports show the c.i.f. value of goods received from the rest of the world valued in current U.S. dollars."
   - Merchandise_imports_by_the_reporting_economy_(current_US$):
-    - description: "Merchandise imports by the reporting economy are the total merchandise imports by the reporting economy from the rest of the world"
+    - description:
+      - "Merchandise imports by the reporting economy are the total merchandise imports by the reporting economy from the rest of the world"
   - Merchandise_imports_by_the_reporting_economy:
-    - description: "residual (% of total merchandise imports)"
+    - description:
+      - "residual (% of total merchandise imports)"
   - Merchandise_imports_from_economies_in_the_Arab_World_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from economies in the Arab World are the sum of merchandise imports by the reporting economy from economies in the Arab World. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from economies in the Arab World are the sum of merchandise imports by the reporting economy from economies in the Arab World. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_high-income_economies_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from high-income economies are the sum of merchandise imports by the reporting economy from high-income economies according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from high-income economies are the sum of merchandise imports by the reporting economy from high-income economies according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_low-_and_middle-income_economies_in_East_Asia_&_Pacific_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from low- and middle-income economies in East Asia and Pacific are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the East Asia and Pacific region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from low- and middle-income economies in East Asia and Pacific are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the East Asia and Pacific region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_low-_and_middle-income_economies_in_Europe_&_Central_Asia_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from low- and middle-income economies in Europe and Central Asia are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the Europe and Central Asia region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from low- and middle-income economies in Europe and Central Asia are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the Europe and Central Asia region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_low-_and_middle-income_economies_in_Latin_America_&_the_Caribbean_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from low- and middle-income economies in Latin America and the Caribbean are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the Latin America and the Caribbean region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from low- and middle-income economies in Latin America and the Caribbean are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the Latin America and the Caribbean region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_low-_and_middle-income_economies_in_Middle_East_&_North_Africa_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from low- and middle-income economies in Middle East and North Africa are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the Middle East and North Africa region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from low- and middle-income economies in Middle East and North Africa are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the Middle East and North Africa region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_low-_and_middle-income_economies_in_South_Asia_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from low- and middle-income economies in South Asia are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the South Asia region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from low- and middle-income economies in South Asia are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the South Asia region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_low-_and_middle-income_economies_in_Sub-Saharan_Africa_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from low- and middle-income economies in Sub-Saharan Africa are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the Sub-Saharan Africa region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from low- and middle-income economies in Sub-Saharan Africa are the sum of merchandise imports by the reporting economy from low- and middle-income economies in the Sub-Saharan Africa region according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_low-_and_middle-income_economies_outside_region_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from low- and middle-income economies outside region are the sum of merchandise imports by the reporting economy from other low- and middle-income economies in other World Bank regions according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
+    - description:
+      - "Merchandise imports from low- and middle-income economies outside region are the sum of merchandise imports by the reporting economy from other low- and middle-income economies in other World Bank regions according to the World Bank classification of economies. Data are expressed as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data."
   - Merchandise_imports_from_low-_and_middle-income_economies_within_region_(%_of_total_merchandise_imports):
-    - description: "Merchandise imports from low- and middle-income economies within region are the sum of merchandise imports by the reporting economy from other low- and middle-income economies in the same World Bank region according to the World Bank classification of economies. Data are as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data. No figures are shown for high-income economies"
+    - description:
+      - "Merchandise imports from low- and middle-income economies within region are the sum of merchandise imports by the reporting economy from other low- and middle-income economies in the same World Bank region according to the World Bank classification of economies. Data are as a percentage of total merchandise imports by the economy. Data are computed only if at least half of the economies in the partner country group had non-missing data. No figures are shown for high-income economies"
   - Merchandise_trade_(%_of_GDP):
-    - description: "Merchandise trade as a share of GDP is the sum of merchandise exports and imports divided by the value of GDP"
+    - description:
+      - "Merchandise trade as a share of GDP is the sum of merchandise exports and imports divided by the value of GDP"
   - Methane_emissions_(%_change_from_1990):
-    - description: "Methane emissions are those stemming from human activities such as agriculture and from industrial methane production. Each year of data shows the percentage change to that year from 1990."
+    - description:
+      - "Methane emissions are those stemming from human activities such as agriculture and from industrial methane production. Each year of data shows the percentage change to that year from 1990."
   - Methane_emissions_(kt_of_CO2_equivalent):
-    - description: "Methane emissions are those stemming from human activities such as agriculture and from industrial methane production."
+    - description:
+      - "Methane emissions are those stemming from human activities such as agriculture and from industrial methane production."
   - Methane_emissions_in_energy_sector_(thousand_metric_tons_of_CO2_equivalent):
-    - description: "Methane emissions from energy processes are emissions from the production"
+    - description:
+      - "Methane emissions from energy processes are emissions from the production"
   - Methodology_assessment_of_statistical_capacity_(scale_0_-_100):
-    - description: "The methodology indicator measures a country's ability to adhere to internationally recommended standards and methods. The methodology score is calculated as the weighted average of 10 underlying indicator scores. The final methodology score contributes 1/3 of the overall Statistical Capacity Indicator score."
+    - description:
+      - "The methodology indicator measures a country's ability to adhere to internationally recommended standards and methods. The methodology score is calculated as the weighted average of 10 underlying indicator scores. The final methodology score contributes 1/3 of the overall Statistical Capacity Indicator score."
   - Military_expenditure_(%_of_central_government_expenditure):
-    - description: "Military expenditures data from SIPRI are derived from the NATO definition"
+    - description:
+      - "Military expenditures data from SIPRI are derived from the NATO definition"
   - Military_expenditure_(%_of_GDP):
-    - description: "Military expenditures data from SIPRI are derived from the NATO definition"
+    - description:
+      - "Military expenditures data from SIPRI are derived from the NATO definition"
   - Military_expenditure_(current_LCU):
-    - description: "Military expenditures data from SIPRI are derived from the NATO definition"
+    - description:
+      - "Military expenditures data from SIPRI are derived from the NATO definition"
   - Mineral_rents_(%_of_GDP):
-    - description: "Mineral rents are the difference between the value of production for a stock of minerals at world prices and their total costs of production. Minerals included in the calculation are tin"
+    - description:
+      - "Mineral rents are the difference between the value of production for a stock of minerals at world prices and their total costs of production. Minerals included in the calculation are tin"
   - Mobile_cellular_subscriptions:
-    - description: "Mobile cellular telephone subscriptions are subscriptions to a public mobile telephone service that provide access to the PSTN using cellular technology. The indicator includes (and is split into) the number of postpaid subscriptions"
+    - description:
+      - "Mobile cellular telephone subscriptions are subscriptions to a public mobile telephone service that provide access to the PSTN using cellular technology. The indicator includes (and is split into) the number of postpaid subscriptions"
   - Mobile_cellular_subscriptions_(per_100_people):
-    - description: "Mobile cellular telephone subscriptions are subscriptions to a public mobile telephone service that provide access to the PSTN using cellular technology. The indicator includes (and is split into) the number of postpaid subscriptions"
+    - description:
+      - "Mobile cellular telephone subscriptions are subscriptions to a public mobile telephone service that provide access to the PSTN using cellular technology. The indicator includes (and is split into) the number of postpaid subscriptions"
   - Mortality_caused_by_road_traffic_injury_(per_100:
-    - description: "000 people)"
+    - description:
+      - "000 people)"
   - Mortality_from_CVD:
-    - description: "cancer"
+    - description:
+      - "cancer"
   - Mortality_rate:
-    - description: "adult"
+    - description:
+      - "adult"
   - Mortality_rate:
-    - description: "adult"
+    - description:
+      - "adult"
   - Mortality_rate:
-    - description: "infant (per 1"
+    - description:
+      - "infant (per 1"
   - Mortality_rate:
-    - description: "infant"
+    - description:
+      - "infant"
   - Mortality_rate:
-    - description: "infant"
+    - description:
+      - "infant"
   - Mortality_rate:
-    - description: "neonatal (per 1"
+    - description:
+      - "neonatal (per 1"
   - Mortality_rate:
-    - description: "under-5 (per 1"
+    - description:
+      - "under-5 (per 1"
   - Mortality_rate:
-    - description: "under-5"
+    - description:
+      - "under-5"
   - Mortality_rate:
-    - description: "under-5"
+    - description:
+      - "under-5"
   - Mothers_are_guaranteed_an_equivalent_position_after_maternity_leave_(1=yes;_0=no):
-    - description: "Mothers are guaranteed an equivalent position after maternity leave is whether employers of women returning from maternity leave are legally obligated to provide them with an equivalent position after maternity leave. It takes into account paid and unpaid maternity leave and captures whether the employer has a legal obligation to reinstate the returning employee in an equivalent or better position and salary than the employee had pre-leave. Where the maternity leave regime explicitly states that the employee may not be indefinitely replaced"
+    - description:
+      - "Mothers are guaranteed an equivalent position after maternity leave is whether employers of women returning from maternity leave are legally obligated to provide them with an equivalent position after maternity leave. It takes into account paid and unpaid maternity leave and captures whether the employer has a legal obligation to reinstate the returning employee in an equivalent or better position and salary than the employee had pre-leave. Where the maternity leave regime explicitly states that the employee may not be indefinitely replaced"
   - Multilateral_debt_(%_of_total_external_debt):
-    - description: "Multilateral debt to total external debt stocks."
+    - description:
+      - "Multilateral debt to total external debt stocks."
   - Multilateral_debt_service_(%_of_public_and_publicly_guaranteed_debt_service):
-    - description: "Multilateral debt service is the repayment of principal and interest to the World Bank"
+    - description:
+      - "Multilateral debt service is the repayment of principal and interest to the World Bank"
   - Multilateral_debt_service_(TDS:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Natural_gas_rents_(%_of_GDP):
-    - description: "Natural gas rents are the difference between the value of natural gas production at world prices and total costs of production."
+    - description:
+      - "Natural gas rents are the difference between the value of natural gas production at world prices and total costs of production."
   - Net_acquisition_of_financial_assets_(%_of_GDP):
-    - description: "Net acquisition of government financial assets includes domestic and foreign financial claims"
+    - description:
+      - "Net acquisition of government financial assets includes domestic and foreign financial claims"
   - Net_acquisition_of_financial_assets_(current_LCU):
-    - description: "Net acquisition of government financial assets includes domestic and foreign financial claims"
+    - description:
+      - "Net acquisition of government financial assets includes domestic and foreign financial claims"
   - Net_barter_terms_of_trade_index_(2000_=_100):
-    - description: "Net barter terms of trade index is calculated as the percentage ratio of the export unit value indexes to the import unit value indexes"
+    - description:
+      - "Net barter terms of trade index is calculated as the percentage ratio of the export unit value indexes to the import unit value indexes"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Australia (current US$)"
+    - description:
+      - "Australia (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Austria (current US$)"
+    - description:
+      - "Austria (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Belgium (current US$)"
+    - description:
+      - "Belgium (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Canada (current US$)"
+    - description:
+      - "Canada (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Czech Republic (current US$)"
+    - description:
+      - "Czech Republic (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Denmark (current US$)"
+    - description:
+      - "Denmark (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "European Union institutions (current US$)"
+    - description:
+      - "European Union institutions (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Finland (current US$)"
+    - description:
+      - "Finland (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "France (current US$)"
+    - description:
+      - "France (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Germany (current US$)"
+    - description:
+      - "Germany (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Greece (current US$)"
+    - description:
+      - "Greece (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Iceland (current US$)"
+    - description:
+      - "Iceland (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Ireland (current US$)"
+    - description:
+      - "Ireland (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Italy (current US$)"
+    - description:
+      - "Italy (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Japan (current US$)"
+    - description:
+      - "Japan (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Korea"
+    - description:
+      - "Korea"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Luxembourg (current US$)"
+    - description:
+      - "Luxembourg (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Netherlands (current US$)"
+    - description:
+      - "Netherlands (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "New Zealand (current US$)"
+    - description:
+      - "New Zealand (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Norway (current US$)"
+    - description:
+      - "Norway (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Poland (current US$)"
+    - description:
+      - "Poland (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Portugal (current US$)"
+    - description:
+      - "Portugal (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Slovak Republic (current US$)"
+    - description:
+      - "Slovak Republic (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Slovenia (current US$)"
+    - description:
+      - "Slovenia (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Spain (current US$)"
+    - description:
+      - "Spain (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Sweden (current US$)"
+    - description:
+      - "Sweden (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Switzerland (current US$)"
+    - description:
+      - "Switzerland (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "Total (current US$)"
+    - description:
+      - "Total (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "United Kingdom (current US$)"
+    - description:
+      - "United Kingdom (current US$)"
   - Net_bilateral_aid_flows_from_DAC_donors:
-    - description: "United States (current US$)"
+    - description:
+      - "United States (current US$)"
   - Net_capital_account_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Net_change_in_interest_arrears_(current_US$):
-    - description: "Net change in interest arrears is the variation in the total amount of interest in arrears between two consecutive years. Data are in current U.S. dollars."
+    - description:
+      - "Net change in interest arrears is the variation in the total amount of interest in arrears between two consecutive years. Data are in current U.S. dollars."
   - Net_current_transfers_from_abroad_(constant_LCU):
-    - description: "Current transfers comprise transfers of income between residents of the reporting country and the rest of the world that carry no provisions for repayment. Net current transfers from abroad is equal to the unrequited transfers of income from nonresidents to residents minus the unrequited transfers from residents to nonresidents. Data are in constant local currency."
+    - description:
+      - "Current transfers comprise transfers of income between residents of the reporting country and the rest of the world that carry no provisions for repayment. Net current transfers from abroad is equal to the unrequited transfers of income from nonresidents to residents minus the unrequited transfers from residents to nonresidents. Data are in constant local currency."
   - Net_current_transfers_from_abroad_(current_LCU):
-    - description: "Current transfers comprise transfers of income between residents of the reporting country and the rest of the world that carry no provisions for repayment. Net current transfers from abroad is equal to the unrequited transfers of income from nonresidents to residents minus the unrequited transfers from residents to nonresidents. Data are in current local currency."
+    - description:
+      - "Current transfers comprise transfers of income between residents of the reporting country and the rest of the world that carry no provisions for repayment. Net current transfers from abroad is equal to the unrequited transfers of income from nonresidents to residents minus the unrequited transfers from residents to nonresidents. Data are in current local currency."
   - Net_current_transfers_from_abroad_(current_US$):
-    - description: "Current transfers comprise transfers of income between residents of the reporting country and the rest of the world that carry no provisions for repayment. Net current transfers from abroad is equal to the unrequited transfers of income from nonresidents to residents minus the unrequited transfers from residents to nonresidents. Data are in current U.S. dollars."
+    - description:
+      - "Current transfers comprise transfers of income between residents of the reporting country and the rest of the world that carry no provisions for repayment. Net current transfers from abroad is equal to the unrequited transfers of income from nonresidents to residents minus the unrequited transfers from residents to nonresidents. Data are in current U.S. dollars."
   - Net_domestic_credit_(current_LCU):
-    - description: "Net domestic credit is the sum of net claims on the central government and claims on other sectors of the domestic economy (IFS line 32). Data are in current local currency."
+    - description:
+      - "Net domestic credit is the sum of net claims on the central government and claims on other sectors of the domestic economy (IFS line 32). Data are in current local currency."
   - Net_errors_and_omissions_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Net_financial_account_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Net_financial_flows:
-    - description: "bilateral (NFL"
+    - description:
+      - "bilateral (NFL"
   - Net_financial_flows:
-    - description: "IBRD (NFL"
+    - description:
+      - "IBRD (NFL"
   - Net_financial_flows:
-    - description: "IDA (NFL"
+    - description:
+      - "IDA (NFL"
   - Net_financial_flows:
-    - description: "IMF concessional (NFL"
+    - description:
+      - "IMF concessional (NFL"
   - Net_financial_flows:
-    - description: "IMF nonconcessional (NFL"
+    - description:
+      - "IMF nonconcessional (NFL"
   - Net_financial_flows:
-    - description: "multilateral (NFL"
+    - description:
+      - "multilateral (NFL"
   - Net_financial_flows:
-    - description: "others (NFL"
+    - description:
+      - "others (NFL"
   - Net_financial_flows:
-    - description: "RDB concessional (NFL"
+    - description:
+      - "RDB concessional (NFL"
   - Net_financial_flows:
-    - description: "RDB nonconcessional (NFL"
+    - description:
+      - "RDB nonconcessional (NFL"
   - Net_flows_on_external_debt:
-    - description: "long-term (NFL"
+    - description:
+      - "long-term (NFL"
   - Net_flows_on_external_debt:
-    - description: "private nonguaranteed (PNG) (NFL"
+    - description:
+      - "private nonguaranteed (PNG) (NFL"
   - Net_flows_on_external_debt:
-    - description: "public and publicly guaranteed (PPG) (NFL"
+    - description:
+      - "public and publicly guaranteed (PPG) (NFL"
   - Net_flows_on_external_debt:
-    - description: "short-term (NFL"
+    - description:
+      - "short-term (NFL"
   - Net_flows_on_external_debt:
-    - description: "total (NFL"
+    - description:
+      - "total (NFL"
   - Net_foreign_assets_(current_LCU):
-    - description: "Net foreign assets are the sum of foreign assets held by monetary authorities and deposit money banks"
+    - description:
+      - "Net foreign assets are the sum of foreign assets held by monetary authorities and deposit money banks"
   - Net_income_from_abroad_(constant_LCU):
-    - description: "Net income includes the net labor income and net property and entrepreneurial income components of the SNA. Labor income covers compensation of employees paid to nonresident workers. Property and entrepreneurial income covers investment income from the ownership of foreign financial claims (interest"
+    - description:
+      - "Net income includes the net labor income and net property and entrepreneurial income components of the SNA. Labor income covers compensation of employees paid to nonresident workers. Property and entrepreneurial income covers investment income from the ownership of foreign financial claims (interest"
   - Net_income_from_abroad_(current_LCU):
-    - description: "Net income includes the net labor income and net property and entrepreneurial income components of the SNA. Labor income covers compensation of employees paid to nonresident workers. Property and entrepreneurial income covers investment income from the ownership of foreign financial claims (interest"
+    - description:
+      - "Net income includes the net labor income and net property and entrepreneurial income components of the SNA. Labor income covers compensation of employees paid to nonresident workers. Property and entrepreneurial income covers investment income from the ownership of foreign financial claims (interest"
   - Net_income_from_abroad_(current_US$):
-    - description: "Net income includes the net labor income and net property and entrepreneurial income components of the SNA. Labor income covers compensation of employees paid to nonresident workers. Property and entrepreneurial income covers investment income from the ownership of foreign financial claims (interest"
+    - description:
+      - "Net income includes the net labor income and net property and entrepreneurial income components of the SNA. Labor income covers compensation of employees paid to nonresident workers. Property and entrepreneurial income covers investment income from the ownership of foreign financial claims (interest"
   - Net_incurrence_of_liabilities:
-    - description: "total (% of GDP)"
+    - description:
+      - "total (% of GDP)"
   - Net_incurrence_of_liabilities:
-    - description: "total (current LCU)"
+    - description:
+      - "total (current LCU)"
   - Net_intake_rate_in_grade_1_(%_of_official_school-age_population):
-    - description: "Net intake rate in grade 1 is the number of new entrants in the first grade of primary education who are of official primary school entrance age"
+    - description:
+      - "Net intake rate in grade 1 is the number of new entrants in the first grade of primary education who are of official primary school entrance age"
   - Net_intake_rate_in_grade_1:
-    - description: "female (% of official school-age population)"
+    - description:
+      - "female (% of official school-age population)"
   - Net_intake_rate_in_grade_1:
-    - description: "male (% of official school-age population)"
+    - description:
+      - "male (% of official school-age population)"
   - Net_investment_in_nonfinancial_assets_(%_of_GDP):
-    - description: "Net investment in government nonfinancial assets includes fixed assets"
+    - description:
+      - "Net investment in government nonfinancial assets includes fixed assets"
   - Net_investment_in_nonfinancial_assets_(current_LCU):
-    - description: "Net investment in government nonfinancial assets includes fixed assets"
+    - description:
+      - "Net investment in government nonfinancial assets includes fixed assets"
   - Net_lending_(+)_/_net_borrowing_(-)_(%_of_GDP):
-    - description: "Net lending (+) / net borrowing (-) equals government revenue minus expense"
+    - description:
+      - "Net lending (+) / net borrowing (-) equals government revenue minus expense"
   - Net_lending_(+)_/_net_borrowing_(-)_(current_LCU):
-    - description: "Net lending (+) / net borrowing (-) equals government revenue minus expense"
+    - description:
+      - "Net lending (+) / net borrowing (-) equals government revenue minus expense"
   - Net_migration:
-    - description: "Net migration is the net total of migrants during the period"
+    - description:
+      - "Net migration is the net total of migrants during the period"
   - Net_ODA_provided_to_the_least_developed_countries_(%_of_GNI):
-    - description: "Net Official development assistance (ODA) comprises grants or loans to developing countries and territories on the OECD/DAC list of aid recipients that are undertaken by the official sector with promotion of economic development and welfare as the main objective and at concessional financial terms. The list of least developed countries (LDCs) has been agreed by the General Assembly"
+    - description:
+      - "Net Official development assistance (ODA) comprises grants or loans to developing countries and territories on the OECD/DAC list of aid recipients that are undertaken by the official sector with promotion of economic development and welfare as the main objective and at concessional financial terms. The list of least developed countries (LDCs) has been agreed by the General Assembly"
   - Net_ODA_provided:
-    - description: "to the least developed countries (current US$)"
+    - description:
+      - "to the least developed countries (current US$)"
   - Net_ODA_provided:
-    - description: "total (% of GNI)"
+    - description:
+      - "total (% of GNI)"
   - Net_ODA_provided:
-    - description: "total (constant 2015 US$)"
+    - description:
+      - "total (constant 2015 US$)"
   - Net_ODA_provided:
-    - description: "total (current US$)"
+    - description:
+      - "total (current US$)"
   - Net_ODA_received_(%_of_central_government_expense):
-    - description: "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
+    - description:
+      - "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
   - Net_ODA_received_(%_of_GNI):
-    - description: "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
+    - description:
+      - "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
   - Net_ODA_received_(%_of_gross_capital_formation):
-    - description: "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
+    - description:
+      - "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
   - Net_ODA_received_(%_of_imports_of_goods:
-    - description: "services and primary income)"
+    - description:
+      - "services and primary income)"
   - Net_ODA_received_per_capita_(current_US$):
-    - description: "Net official development assistance (ODA) per capita consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
+    - description:
+      - "Net official development assistance (ODA) per capita consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
   - Net_official_aid_received_(constant_2014_US$):
-    - description: "Net official aid refers to aid flows (net of repayments) from official donors to countries and territories in part II of the DAC list of recipients: more advanced countries of Central and Eastern Europe"
+    - description:
+      - "Net official aid refers to aid flows (net of repayments) from official donors to countries and territories in part II of the DAC list of recipients: more advanced countries of Central and Eastern Europe"
   - Net_official_aid_received_(current_US$):
-    - description: "Net official aid refers to aid flows (net of repayments) from official donors to countries and territories in part II of the DAC list of recipients: more advanced countries of Central and Eastern Europe"
+    - description:
+      - "Net official aid refers to aid flows (net of repayments) from official donors to countries and territories in part II of the DAC list of recipients: more advanced countries of Central and Eastern Europe"
   - Net_official_development_assistance_and_official_aid_received_(constant_2013_US$):
-    - description: "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
+    - description:
+      - "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
   - Net_official_development_assistance_and_official_aid_received_(current_US$):
-    - description: "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
+    - description:
+      - "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
   - Net_official_development_assistance_received_(constant_2014_US$):
-    - description: "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
+    - description:
+      - "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
   - Net_official_development_assistance_received_(current_US$):
-    - description: "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
+    - description:
+      - "Net official development assistance (ODA) consists of disbursements of loans made on concessional terms (net of repayments of principal) and grants by official agencies of the members of the Development Assistance Committee (DAC)"
   - Net_official_flows_from_UN_agencies:
-    - description: "FAO (current US$)"
+    - description:
+      - "FAO (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "IAEA (current US$)"
+    - description:
+      - "IAEA (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "IFAD (current US$)"
+    - description:
+      - "IFAD (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "ILO (current US$)"
+    - description:
+      - "ILO (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNAIDS (current US$)"
+    - description:
+      - "UNAIDS (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNDP (current US$)"
+    - description:
+      - "UNDP (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNECE (current US$)"
+    - description:
+      - "UNECE (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNFPA (current US$)"
+    - description:
+      - "UNFPA (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNHCR (current US$)"
+    - description:
+      - "UNHCR (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNICEF (current US$)"
+    - description:
+      - "UNICEF (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNPBF (current US$)"
+    - description:
+      - "UNPBF (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNRWA (current US$)"
+    - description:
+      - "UNRWA (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "UNTA (current US$)"
+    - description:
+      - "UNTA (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "WFP (current US$)"
+    - description:
+      - "WFP (current US$)"
   - Net_official_flows_from_UN_agencies:
-    - description: "WHO (current US$)"
+    - description:
+      - "WHO (current US$)"
   - Net_primary_income_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Net_secondary_income_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Net_taxes_on_products_(constant_LCU):
-    - description: "Net taxes on products (net indirect taxes) are the sum of product taxes less subsidies. Product taxes are those taxes payable by producers that relate to the production"
+    - description:
+      - "Net taxes on products (net indirect taxes) are the sum of product taxes less subsidies. Product taxes are those taxes payable by producers that relate to the production"
   - Net_taxes_on_products_(current_LCU):
-    - description: "Net taxes on products (net indirect taxes) are the sum of product taxes less subsidies. Product taxes are those taxes payable by producers that relate to the production"
+    - description:
+      - "Net taxes on products (net indirect taxes) are the sum of product taxes less subsidies. Product taxes are those taxes payable by producers that relate to the production"
   - Net_taxes_on_products_(current_US$):
-    - description: "Net taxes on products (net indirect taxes) are the sum of product taxes less subsidies. Product taxes are those taxes payable by producers that relate to the production"
+    - description:
+      - "Net taxes on products (net indirect taxes) are the sum of product taxes less subsidies. Product taxes are those taxes payable by producers that relate to the production"
   - Net_trade_in_goods_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Net_trade_in_goods_and_services_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Net_transfers_on_external_debt:
-    - description: "long-term (NTR"
+    - description:
+      - "long-term (NTR"
   - Net_transfers_on_external_debt:
-    - description: "private nonguaranteed (PNG) (NTR"
+    - description:
+      - "private nonguaranteed (PNG) (NTR"
   - Net_transfers_on_external_debt:
-    - description: "public and publicly guaranteed (PPG) (NTR"
+    - description:
+      - "public and publicly guaranteed (PPG) (NTR"
   - Net_transfers_on_external_debt:
-    - description: "total (NTR"
+    - description:
+      - "total (NTR"
   - New_business_density_(new_registrations_per_1:
-    - description: "000 people ages 15-64)"
+    - description:
+      - "000 people ages 15-64)"
   - New_businesses_registered_(number):
-    - description: "New businesses registered are the number of new limited liability corporations registered in the calendar year."
+    - description:
+      - "New businesses registered are the number of new limited liability corporations registered in the calendar year."
   - Newborns_protected_against_tetanus_(%):
-    - description: "Newborns protected against tetanus are the percentage of births by women of child-bearing age who are immunized against tetanus."
+    - description:
+      - "Newborns protected against tetanus are the percentage of births by women of child-bearing age who are immunized against tetanus."
   - Nitrous_oxide_emissions_(%_change_from_1990):
-    - description: "Nitrous oxide emissions are emissions from agricultural biomass burning"
+    - description:
+      - "Nitrous oxide emissions are emissions from agricultural biomass burning"
   - Nitrous_oxide_emissions_(thousand_metric_tons_of_CO2_equivalent):
-    - description: "Nitrous oxide emissions are emissions from agricultural biomass burning"
+    - description:
+      - "Nitrous oxide emissions are emissions from agricultural biomass burning"
   - Nitrous_oxide_emissions_in_energy_sector_(%_of_total):
-    - description: "Nitrous oxide emissions from energy processes are emissions produced by the combustion of fossil fuels and biofuels."
+    - description:
+      - "Nitrous oxide emissions from energy processes are emissions produced by the combustion of fossil fuels and biofuels."
   - Nitrous_oxide_emissions_in_energy_sector_(thousand_metric_tons_of_CO2_equivalent):
-    - description: "Nitrous oxide emissions from energy processes are emissions produced by the combustion of fossil fuels and biofuels."
+    - description:
+      - "Nitrous oxide emissions from energy processes are emissions produced by the combustion of fossil fuels and biofuels."
   - Nondiscrimination_clause_mentions_gender_in_the_constitution_(1=yes;_0=no):
-    - description: "Nondiscrimination clause mentions gender in the constitution is whether there is a nondiscrimination clause in the constitution which mentions gender. For the answer to be Yes"
+    - description:
+      - "Nondiscrimination clause mentions gender in the constitution is whether there is a nondiscrimination clause in the constitution which mentions gender. For the answer to be Yes"
   - Nonpregnant_and_nonnursing_women_can_do_the_same_jobs_as_men_(1=yes;_0=no):
-    - description: "Non-pregnant and non-nursing women can do the same jobs as men indicates whether there are specific jobs that women explicitly or implicitly cannot perform except in limited circumstances. Both partial and full restrictions on women's work are counted as restrictions. For example"
+    - description:
+      - "Non-pregnant and non-nursing women can do the same jobs as men indicates whether there are specific jobs that women explicitly or implicitly cannot perform except in limited circumstances. Both partial and full restrictions on women's work are counted as restrictions. For example"
   - Number_of_deaths_ages_5-14_years:
-    - description: "Number of deaths of children ages 5-14 years"
+    - description:
+      - "Number of deaths of children ages 5-14 years"
   - Number_of_infant_deaths:
-    - description: "Number of infants dying before reaching one year of age."
+    - description:
+      - "Number of infants dying before reaching one year of age."
   - Number_of_maternal_deaths:
-    - description: "A maternal death refers to the death of a woman while pregnant or within 42 days of termination of pregnancy"
+    - description:
+      - "A maternal death refers to the death of a woman while pregnant or within 42 days of termination of pregnancy"
   - Number_of_neonatal_deaths:
-    - description: "Number of neonates dying before reaching 28 days of age."
+    - description:
+      - "Number of neonates dying before reaching 28 days of age."
   - Number_of_people_pushed_below_the_$1.90_($_2011_PPP)_poverty_line_by_out-of-pocket_health_care_expenditure:
-    - description: "Number of people pushed below the $1.90 ($ 2011 PPP) poverty line by out-of-pocket health care expenditure"
+    - description:
+      - "Number of people pushed below the $1.90 ($ 2011 PPP) poverty line by out-of-pocket health care expenditure"
   - Number_of_people_pushed_below_the_$3.10_($_2011_PPP)_poverty_line_by_out-of-pocket_health_care_expenditure:
-    - description: "Number of people pushed below the $3.10 ($ 2011 PPP) poverty line by out-of-pocket health care expenditure"
+    - description:
+      - "Number of people pushed below the $3.10 ($ 2011 PPP) poverty line by out-of-pocket health care expenditure"
   - Number_of_people_spending_more_than_10%_of_household_consumption_or_income_on_out-of-pocket_health_care_expenditure:
-    - description: "Number of people spending more than 10% of household consumption or income on out-of-pocket health care expenditure"
+    - description:
+      - "Number of people spending more than 10% of household consumption or income on out-of-pocket health care expenditure"
   - Number_of_people_spending_more_than_25%_of_household_consumption_or_income_on_out-of-pocket_health_care_expenditure:
-    - description: "Number of people spending more than 25% of household consumption or income on out-of-pocket health care expenditure"
+    - description:
+      - "Number of people spending more than 25% of household consumption or income on out-of-pocket health care expenditure"
   - Number_of_surgical_procedures_(per_100:
-    - description: "000 population)"
+    - description:
+      - "000 population)"
   - Number_of_under-five_deaths:
-    - description: "Number of children dying before reaching age five."
+    - description:
+      - "Number of children dying before reaching age five."
   - Number_of_visits_or_required_meetings_with_tax_officials_(average_for_affected_firms):
-    - description: "Average number of visits or required meetings with tax officials during the year. The value represents the average number of visits for all firms which reported being visited or required to meet with tax officials (please see indicator IC.FRM.METG.ZS)."
+    - description:
+      - "Average number of visits or required meetings with tax officials during the year. The value represents the average number of visits for all firms which reported being visited or required to meet with tax officials (please see indicator IC.FRM.METG.ZS)."
   - Nurses_and_midwives_(per_1:
-    - description: "000 people)"
+    - description:
+      - "000 people)"
   - Official_exchange_rate_(LCU_per_US$:
-    - description: "period average)"
+    - description:
+      - "period average)"
   - Oil_rents_(%_of_GDP):
-    - description: "Oil rents are the difference between the value of crude oil production at world prices and total costs of production."
+    - description:
+      - "Oil rents are the difference between the value of crude oil production at world prices and total costs of production."
   - Ores_and_metals_exports_(%_of_merchandise_exports):
-    - description: "Ores and metals comprise the commodities in SITC sections 27 (crude fertilizer"
+    - description:
+      - "Ores and metals comprise the commodities in SITC sections 27 (crude fertilizer"
   - Ores_and_metals_imports_(%_of_merchandise_imports):
-    - description: "Ores and metals comprise commodities in SITC sections 27 (crude fertilizer"
+    - description:
+      - "Ores and metals comprise commodities in SITC sections 27 (crude fertilizer"
   - Other_expense_(%_of_expense):
-    - description: "Other expense is spending on dividends"
+    - description:
+      - "Other expense is spending on dividends"
   - Other_expense_(current_LCU):
-    - description: "Other expense is spending on dividends"
+    - description:
+      - "Other expense is spending on dividends"
   - Other_greenhouse_gas_emissions_(%_change_from_1990):
-    - description: "Other greenhouse gas emissions are by-product emissions of hydrofluorocarbons"
+    - description:
+      - "Other greenhouse gas emissions are by-product emissions of hydrofluorocarbons"
   - Other_greenhouse_gas_emissions:
-    - description: "HFC"
+    - description:
+      - "HFC"
   - Other_manufacturing_(%_of_value_added_in_manufacturing):
-    - description: "Value added in manufacturing is the sum of gross output less the value of intermediate inputs used in production for industries classified in ISIC major division D. Other manufacturing"
+    - description:
+      - "Value added in manufacturing is the sum of gross output less the value of intermediate inputs used in production for industries classified in ISIC major division D. Other manufacturing"
   - Other_taxes_(%_of_revenue):
-    - description: "Other taxes include employer payroll or labor taxes"
+    - description:
+      - "Other taxes include employer payroll or labor taxes"
   - Other_taxes_(current_LCU):
-    - description: "Other taxes include employer payroll or labor taxes"
+    - description:
+      - "Other taxes include employer payroll or labor taxes"
   - Other_taxes_payable_by_businesses_(%_of_commercial_profits):
-    - description: "Other taxes payable by businesses include the amounts paid for property taxes"
+    - description:
+      - "Other taxes payable by businesses include the amounts paid for property taxes"
   - Out-of-pocket_expenditure_(%_of_current_health_expenditure):
-    - description: "Share of out-of-pocket payments of total current health expenditures.  Out-of-pocket payments are spending on health directly out-of-pocket by households."
+    - description:
+      - "Share of out-of-pocket payments of total current health expenditures.  Out-of-pocket payments are spending on health directly out-of-pocket by households."
   - Out-of-pocket_expenditure_per_capita_(current_US$):
-    - description: "Health expenditure through out-of-pocket payments per capita in USD.  Out of pocket payments are spending on health directly out of pocket by households in each country."
+    - description:
+      - "Health expenditure through out-of-pocket payments per capita in USD.  Out of pocket payments are spending on health directly out of pocket by households in each country."
   - Out-of-pocket_expenditure_per_capita:
-    - description: "PPP (current international $)"
+    - description:
+      - "PPP (current international $)"
   - Over-age_students:
-    - description: "primary (% of enrollment)"
+    - description:
+      - "primary (% of enrollment)"
   - Over-age_students:
-    - description: "primary"
+    - description:
+      - "primary"
   - Over-age_students:
-    - description: "primary"
+    - description:
+      - "primary"
   - Overall_level_of_statistical_capacity_(scale_0_-_100):
-    - description: "The Statistical Capacity Indicator is a composite score assessing the capacity of a country's statistical system. It is based on a diagnostic framework assessing the following areas: methodology; data sources; and periodicity and timeliness. Countries are scored against 25 criteria in these areas"
+    - description:
+      - "The Statistical Capacity Indicator is a composite score assessing the capacity of a country's statistical system. It is based on a diagnostic framework assessing the following areas: methodology; data sources; and periodicity and timeliness. Countries are scored against 25 criteria in these areas"
   - Part_time_employment:
-    - description: "female (% of total female employment)"
+    - description:
+      - "female (% of total female employment)"
   - Part_time_employment:
-    - description: "male (% of total male employment)"
+    - description:
+      - "male (% of total male employment)"
   - Part_time_employment:
-    - description: "total (% of total employment)"
+    - description:
+      - "total (% of total employment)"
   - Patent_applications:
-    - description: "nonresidents"
+    - description:
+      - "nonresidents"
   - Patent_applications:
-    - description: "residents"
+    - description:
+      - "residents"
   - People_practicing_open_defecation_(%_of_population):
-    - description: "People practicing open defecation refers to the percentage of the population defecating in the open"
+    - description:
+      - "People practicing open defecation refers to the percentage of the population defecating in the open"
   - People_practicing_open_defecation:
-    - description: "rural (% of rural population)"
+    - description:
+      - "rural (% of rural population)"
   - People_practicing_open_defecation:
-    - description: "urban (% of urban population)"
+    - description:
+      - "urban (% of urban population)"
   - People_using_at_least_basic_drinking_water_services_(%_of_population):
-    - description: "The percentage of people using at least basic water services.  This indicator encompasses both people using basic water services as well as those using safely managed water services.  Basic drinking water services is defined as drinking water from an improved source"
+    - description:
+      - "The percentage of people using at least basic water services.  This indicator encompasses both people using basic water services as well as those using safely managed water services.  Basic drinking water services is defined as drinking water from an improved source"
   - People_using_at_least_basic_drinking_water_services:
-    - description: "rural (% of rural population)"
+    - description:
+      - "rural (% of rural population)"
   - People_using_at_least_basic_drinking_water_services:
-    - description: "urban (% of urban population)"
+    - description:
+      - "urban (% of urban population)"
   - People_using_at_least_basic_sanitation_services_(%_of_population):
-    - description: "The percentage of people using at least basic sanitation services"
+    - description:
+      - "The percentage of people using at least basic sanitation services"
   - People_using_at_least_basic_sanitation_services:
-    - description: "rural (% of rural population)"
+    - description:
+      - "rural (% of rural population)"
   - People_using_at_least_basic_sanitation_services:
-    - description: "urban (% of urban population)"
+    - description:
+      - "urban (% of urban population)"
   - People_using_safely_managed_drinking_water_services_(%_of_population):
-    - description: "The percentage of people using drinking water from an improved source that is accessible on premises"
+    - description:
+      - "The percentage of people using drinking water from an improved source that is accessible on premises"
   - People_using_safely_managed_drinking_water_services:
-    - description: "rural (% of rural population)"
+    - description:
+      - "rural (% of rural population)"
   - People_using_safely_managed_drinking_water_services:
-    - description: "urban (% of urban population)"
+    - description:
+      - "urban (% of urban population)"
   - People_using_safely_managed_sanitation_services_(%_of_population):
-    - description: "The percentage of people using improved sanitation facilities that are not shared with other households and where excreta are safely disposed of in situ or transported and treated offsite. Improved sanitation facilities include flush/pour flush to piped sewer systems"
+    - description:
+      - "The percentage of people using improved sanitation facilities that are not shared with other households and where excreta are safely disposed of in situ or transported and treated offsite. Improved sanitation facilities include flush/pour flush to piped sewer systems"
   - People_using_safely_managed_sanitation_services:
-    - description: "rural (% of rural population)"
+    - description:
+      - "rural (% of rural population)"
   - People_using_safely_managed_sanitation_services:
-    - description: "urban  (% of urban population)"
+    - description:
+      - "urban  (% of urban population)"
   - People_with_basic_handwashing_facilities_including_soap_and_water_(%_of_population):
-    - description: "The percentage of people living in households that have a handwashing facility with soap and water available on the premises. Handwashing facilities may be fixed or mobile and include a sink with tap water"
+    - description:
+      - "The percentage of people living in households that have a handwashing facility with soap and water available on the premises. Handwashing facilities may be fixed or mobile and include a sink with tap water"
   - People_with_basic_handwashing_facilities_including_soap_and_water:
-    - description: "rural (% of rural population)"
+    - description:
+      - "rural (% of rural population)"
   - People_with_basic_handwashing_facilities_including_soap_and_water:
-    - description: "urban (% of urban population)"
+    - description:
+      - "urban (% of urban population)"
   - Periodicity_and_timeliness_assessment_of_statistical_capacity_(scale_0_-_100):
-    - description: "The periodicity and timeliness indicator assesses the availability and periodicity of key socioeconomic indicators. It measures the extent to which data are made accessible to users through transformation of source data into timely statistical outputs. The periodicity score is calculated as the weighted average of 10 underlying indicator scores. The final periodicity score contributes 1/3 of the overall Statistical Capacity Indicator score."
+    - description:
+      - "The periodicity and timeliness indicator assesses the availability and periodicity of key socioeconomic indicators. It measures the extent to which data are made accessible to users through transformation of source data into timely statistical outputs. The periodicity score is calculated as the weighted average of 10 underlying indicator scores. The final periodicity score contributes 1/3 of the overall Statistical Capacity Indicator score."
   - Permanent_cropland_(%_of_land_area):
-    - description: "Permanent cropland is land cultivated with crops that occupy the land for long periods and need not be replanted after each harvest"
+    - description:
+      - "Permanent cropland is land cultivated with crops that occupy the land for long periods and need not be replanted after each harvest"
   - Persistence_to_grade_5:
-    - description: "female (% of cohort)"
+    - description:
+      - "female (% of cohort)"
   - Persistence_to_grade_5:
-    - description: "male (% of cohort)"
+    - description:
+      - "male (% of cohort)"
   - Persistence_to_grade_5:
-    - description: "total (% of cohort)"
+    - description:
+      - "total (% of cohort)"
   - Persistence_to_last_grade_of_primary:
-    - description: "female (% of cohort)"
+    - description:
+      - "female (% of cohort)"
   - Persistence_to_last_grade_of_primary:
-    - description: "male (% of cohort)"
+    - description:
+      - "male (% of cohort)"
   - Persistence_to_last_grade_of_primary:
-    - description: "total (% of cohort)"
+    - description:
+      - "total (% of cohort)"
   - Personal_remittances:
-    - description: "paid (current US$)"
+    - description:
+      - "paid (current US$)"
   - Personal_remittances:
-    - description: "received (% of GDP)"
+    - description:
+      - "received (% of GDP)"
   - Personal_remittances:
-    - description: "received (current US$)"
+    - description:
+      - "received (current US$)"
   - Personal_transfers:
-    - description: "receipts (BoP"
+    - description:
+      - "receipts (BoP"
   - PFC_gas_emissions_(thousand_metric_tons_of_CO2_equivalent):
-    - description: "Perfluorocarbons"
+    - description:
+      - "Perfluorocarbons"
   - Physicians_(per_1:
-    - description: "000 people)"
+    - description:
+      - "000 people)"
   - Plant_species_(higher):
-    - description: "threatened"
+    - description:
+      - "threatened"
   - PM2.5_air_pollution:
-    - description: "mean annual exposure (micrograms per cubic meter)"
+    - description:
+      - "mean annual exposure (micrograms per cubic meter)"
   - PM2.5_air_pollution:
-    - description: "population exposed to levels exceeding WHO guideline value (% of total)"
+    - description:
+      - "population exposed to levels exceeding WHO guideline value (% of total)"
   - PM2.5_pollution:
-    - description: "population exposed to levels exceeding WHO Interim Target-1 value (% of total)"
+    - description:
+      - "population exposed to levels exceeding WHO Interim Target-1 value (% of total)"
   - PM2.5_pollution:
-    - description: "population exposed to levels exceeding WHO Interim Target-2 value (% of total)"
+    - description:
+      - "population exposed to levels exceeding WHO Interim Target-2 value (% of total)"
   - PM2.5_pollution:
-    - description: "population exposed to levels exceeding WHO Interim Target-3 value (% of total)"
+    - description:
+      - "population exposed to levels exceeding WHO Interim Target-3 value (% of total)"
   - PNG:
-    - description: "bonds (AMT"
+    - description:
+      - "bonds (AMT"
   - PNG:
-    - description: "bonds (DIS"
+    - description:
+      - "bonds (DIS"
   - PNG:
-    - description: "bonds (DOD"
+    - description:
+      - "bonds (DOD"
   - PNG:
-    - description: "bonds (INT"
+    - description:
+      - "bonds (INT"
   - PNG:
-    - description: "bonds (NFL"
+    - description:
+      - "bonds (NFL"
   - PNG:
-    - description: "bonds (NTR"
+    - description:
+      - "bonds (NTR"
   - PNG:
-    - description: "bonds (TDS"
+    - description:
+      - "bonds (TDS"
   - PNG:
-    - description: "commercial banks and other creditors (AMT"
+    - description:
+      - "commercial banks and other creditors (AMT"
   - PNG:
-    - description: "commercial banks and other creditors (DIS"
+    - description:
+      - "commercial banks and other creditors (DIS"
   - PNG:
-    - description: "commercial banks and other creditors (DOD"
+    - description:
+      - "commercial banks and other creditors (DOD"
   - PNG:
-    - description: "commercial banks and other creditors (INT"
+    - description:
+      - "commercial banks and other creditors (INT"
   - PNG:
-    - description: "commercial banks and other creditors (NFL"
+    - description:
+      - "commercial banks and other creditors (NFL"
   - PNG:
-    - description: "commercial banks and other creditors (NTR"
+    - description:
+      - "commercial banks and other creditors (NTR"
   - PNG:
-    - description: "commercial banks and other creditors (TDS"
+    - description:
+      - "commercial banks and other creditors (TDS"
   - Population_ages_0-14_(%_of_total):
-    - description: "Population between the ages 0 to 14 as a percentage of the total population. Population is based on the de facto definition of population."
+    - description:
+      - "Population between the ages 0 to 14 as a percentage of the total population. Population is based on the de facto definition of population."
   - Population_ages_0-14:
-    - description: "female"
+    - description:
+      - "female"
   - Population_ages_0-14:
-    - description: "female (% of total)"
+    - description:
+      - "female (% of total)"
   - Population_ages_0-14:
-    - description: "male"
+    - description:
+      - "male"
   - Population_ages_0-14:
-    - description: "male (% of total)"
+    - description:
+      - "male (% of total)"
   - Population_ages_0-14:
-    - description: "total"
+    - description:
+      - "total"
   - Population_ages_0-4:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_0-4:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_10-14:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_10-14:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_15-19:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_15-19:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_15-64_(%_of_total):
-    - description: "Total population between the ages 15 to 64 as a percentage of the total population. Population is based on the de facto definition of population"
+    - description:
+      - "Total population between the ages 15 to 64 as a percentage of the total population. Population is based on the de facto definition of population"
   - Population_ages_15-64:
-    - description: "female"
+    - description:
+      - "female"
   - Population_ages_15-64:
-    - description: "female (% of total)"
+    - description:
+      - "female (% of total)"
   - Population_ages_15-64:
-    - description: "male"
+    - description:
+      - "male"
   - Population_ages_15-64:
-    - description: "male (% of total)"
+    - description:
+      - "male (% of total)"
   - Population_ages_15-64:
-    - description: "total"
+    - description:
+      - "total"
   - Population_ages_20-24:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_20-24:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_25-29:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_25-29:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_30-34:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_30-34:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_35-39:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_35-39:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_40-44:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_40-44:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_45-49:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_45-49:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_50-54:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_50-54:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_55-59:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_55-59:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_5-9:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_5-9:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_60-64:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_60-64:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_65_and_above_(%_of_total):
-    - description: "Population ages 65 and above as a percentage of the total population. Population is based on the de facto definition of population"
+    - description:
+      - "Population ages 65 and above as a percentage of the total population. Population is based on the de facto definition of population"
   - Population_ages_65_and_above:
-    - description: "female"
+    - description:
+      - "female"
   - Population_ages_65_and_above:
-    - description: "female (% of total)"
+    - description:
+      - "female (% of total)"
   - Population_ages_65_and_above:
-    - description: "male"
+    - description:
+      - "male"
   - Population_ages_65_and_above:
-    - description: "male (% of total)"
+    - description:
+      - "male (% of total)"
   - Population_ages_65_and_above:
-    - description: "total"
+    - description:
+      - "total"
   - Population_ages_65-69:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_65-69:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_70-74:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_70-74:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_75-79:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_75-79:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_ages_80_and_above:
-    - description: "female (% of female population)"
+    - description:
+      - "female (% of female population)"
   - Population_ages_80_and_above:
-    - description: "male (% of male population)"
+    - description:
+      - "male (% of male population)"
   - Population_density_(people_per_sq._km_of_land_area):
-    - description: "Population density is midyear population divided by land area in square kilometers. Population is based on the de facto definition of population"
+    - description:
+      - "Population density is midyear population divided by land area in square kilometers. Population is based on the de facto definition of population"
   - Population_growth_(annual_%):
-    - description: "Annual population growth rate for year t is the exponential rate of growth of midyear population from year t-1 to t"
+    - description:
+      - "Annual population growth rate for year t is the exponential rate of growth of midyear population from year t-1 to t"
   - Population_in_largest_city:
-    - description: "Population in largest city is the urban population living in the country's largest metropolitan area."
+    - description:
+      - "Population in largest city is the urban population living in the country's largest metropolitan area."
   - Population_in_the_largest_city_(%_of_urban_population):
-    - description: "Population in largest city is the percentage of a country's urban population living in that country's largest metropolitan area."
+    - description:
+      - "Population in largest city is the percentage of a country's urban population living in that country's largest metropolitan area."
   - Population_in_urban_agglomerations_of_more_than_1_million:
-    - description: "Population in urban agglomerations of more than one million is the country's population living in metropolitan areas that in 2000 had a population of more than one million people."
+    - description:
+      - "Population in urban agglomerations of more than one million is the country's population living in metropolitan areas that in 2000 had a population of more than one million people."
   - Population_in_urban_agglomerations_of_more_than_1_million_(%_of_total_population):
-    - description: "Population in urban agglomerations of more than one million is the percentage of a country's population living in metropolitan areas that in 2000 had a population of more than one million people."
+    - description:
+      - "Population in urban agglomerations of more than one million is the percentage of a country's population living in metropolitan areas that in 2000 had a population of more than one million people."
   - Population_living_in_areas_where_elevation_is_below_5_meters_(%_of_total_population):
-    - description: "Population below 5m is the percentage of the total population living in areas where the elevation is 5 meters or less."
+    - description:
+      - "Population below 5m is the percentage of the total population living in areas where the elevation is 5 meters or less."
   - Population_living_in_slums_(%_of_urban_population):
-    - description: "Population living in slums is the proportion of the urban population living in slum households. A slum household is defined as a group of individuals living under the same roof lacking one or more of the following conditions: access to improved water"
+    - description:
+      - "Population living in slums is the proportion of the urban population living in slum households. A slum household is defined as a group of individuals living under the same roof lacking one or more of the following conditions: access to improved water"
   - Population:
-    - description: "female"
+    - description:
+      - "female"
   - Population:
-    - description: "female (% of total)"
+    - description:
+      - "female (% of total)"
   - Population:
-    - description: "male"
+    - description:
+      - "male"
   - Population:
-    - description: "male (% of total)"
+    - description:
+      - "male (% of total)"
   - Population:
-    - description: "total"
+    - description:
+      - "total"
   - Portfolio_equity:
-    - description: "net inflows (BoP"
+    - description:
+      - "net inflows (BoP"
   - Portfolio_investment:
-    - description: "bonds (PPG + PNG) (NFL"
+    - description:
+      - "bonds (PPG + PNG) (NFL"
   - Portfolio_Investment:
-    - description: "net (BoP"
+    - description:
+      - "net (BoP"
   - Poverty_gap_at_$1.90_a_day_(2011_PPP)_(%):
-    - description: "Poverty gap at $1.90 a day (2011 PPP) is the mean shortfall in income or consumption from the poverty line $1.90 a day (counting the nonpoor as having zero shortfall)"
+    - description:
+      - "Poverty gap at $1.90 a day (2011 PPP) is the mean shortfall in income or consumption from the poverty line $1.90 a day (counting the nonpoor as having zero shortfall)"
   - Poverty_gap_at_$3.20_a_day_(2011_PPP)_(%):
-    - description: "Poverty gap at $3.20 a day (2011 PPP) is the mean shortfall in income or consumption from the poverty line $3.20 a day (counting the nonpoor as having zero shortfall)"
+    - description:
+      - "Poverty gap at $3.20 a day (2011 PPP) is the mean shortfall in income or consumption from the poverty line $3.20 a day (counting the nonpoor as having zero shortfall)"
   - Poverty_gap_at_$5.50_a_day_(2011_PPP)_(%):
-    - description: "Poverty gap at $5.50 a day (2011 PPP) is the mean shortfall in income or consumption from the poverty line $5.50 a day (counting the nonpoor as having zero shortfall)"
+    - description:
+      - "Poverty gap at $5.50 a day (2011 PPP) is the mean shortfall in income or consumption from the poverty line $5.50 a day (counting the nonpoor as having zero shortfall)"
   - Poverty_gap_at_national_poverty_lines_(%):
-    - description: "Poverty gap at national poverty lines is the mean shortfall from the poverty lines (counting the nonpoor as having zero shortfall) as a percentage of the poverty lines. This measure reflects the depth of poverty as well as its incidence."
+    - description:
+      - "Poverty gap at national poverty lines is the mean shortfall from the poverty lines (counting the nonpoor as having zero shortfall) as a percentage of the poverty lines. This measure reflects the depth of poverty as well as its incidence."
   - Poverty_headcount_ratio_at_$1.90_a_day_(2011_PPP)_(%_of_population):
-    - description: "Poverty headcount ratio at $1.90 a day is the percentage of the population living on less than $1.90 a day at 2011 international prices. As a result of revisions in PPP exchange rates"
+    - description:
+      - "Poverty headcount ratio at $1.90 a day is the percentage of the population living on less than $1.90 a day at 2011 international prices. As a result of revisions in PPP exchange rates"
   - Poverty_headcount_ratio_at_$3.20_a_day_(2011_PPP)_(%_of_population):
-    - description: "Poverty headcount ratio at $3.20 a day is the percentage of the population living on less than $3.20 a day at 2011 international prices. As a result of revisions in PPP exchange rates"
+    - description:
+      - "Poverty headcount ratio at $3.20 a day is the percentage of the population living on less than $3.20 a day at 2011 international prices. As a result of revisions in PPP exchange rates"
   - Poverty_headcount_ratio_at_$5.50_a_day_(2011_PPP)_(%_of_population):
-    - description: "Poverty headcount ratio at $5.50 a day is the percentage of the population living on less than $5.50 a day at 2011 international prices. As a result of revisions in PPP exchange rates"
+    - description:
+      - "Poverty headcount ratio at $5.50 a day is the percentage of the population living on less than $5.50 a day at 2011 international prices. As a result of revisions in PPP exchange rates"
   - Poverty_headcount_ratio_at_national_poverty_lines_(%_of_population):
-    - description: "National poverty headcount ratio is the percentage of the population living below the national poverty lines. National estimates are based on population-weighted subgroup estimates from household surveys."
+    - description:
+      - "National poverty headcount ratio is the percentage of the population living below the national poverty lines. National estimates are based on population-weighted subgroup estimates from household surveys."
   - Power_outages_in_firms_in_a_typical_month_(number):
-    - description: "Power outages are the average number of power outages that establishments experience in a typical month."
+    - description:
+      - "Power outages are the average number of power outages that establishments experience in a typical month."
   - PPG:
-    - description: "bilateral (AMT"
+    - description:
+      - "bilateral (AMT"
   - PPG:
-    - description: "bilateral (DIS"
+    - description:
+      - "bilateral (DIS"
   - PPG:
-    - description: "bilateral (DOD"
+    - description:
+      - "bilateral (DOD"
   - PPG:
-    - description: "bilateral (INT"
+    - description:
+      - "bilateral (INT"
   - PPG:
-    - description: "bilateral (NTR"
+    - description:
+      - "bilateral (NTR"
   - PPG:
-    - description: "bilateral (TDS"
+    - description:
+      - "bilateral (TDS"
   - PPG:
-    - description: "bilateral concessional (AMT"
+    - description:
+      - "bilateral concessional (AMT"
   - PPG:
-    - description: "bilateral concessional (DIS"
+    - description:
+      - "bilateral concessional (DIS"
   - PPG:
-    - description: "bilateral concessional (DOD"
+    - description:
+      - "bilateral concessional (DOD"
   - PPG:
-    - description: "bilateral concessional (INT"
+    - description:
+      - "bilateral concessional (INT"
   - PPG:
-    - description: "bilateral concessional (NFL"
+    - description:
+      - "bilateral concessional (NFL"
   - PPG:
-    - description: "bilateral concessional (NTR"
+    - description:
+      - "bilateral concessional (NTR"
   - PPG:
-    - description: "bilateral concessional (TDS"
+    - description:
+      - "bilateral concessional (TDS"
   - PPG:
-    - description: "bonds (AMT"
+    - description:
+      - "bonds (AMT"
   - PPG:
-    - description: "bonds (DIS"
+    - description:
+      - "bonds (DIS"
   - PPG:
-    - description: "bonds (DOD"
+    - description:
+      - "bonds (DOD"
   - PPG:
-    - description: "bonds (INT"
+    - description:
+      - "bonds (INT"
   - PPG:
-    - description: "bonds (NFL"
+    - description:
+      - "bonds (NFL"
   - PPG:
-    - description: "bonds (NTR"
+    - description:
+      - "bonds (NTR"
   - PPG:
-    - description: "bonds (TDS"
+    - description:
+      - "bonds (TDS"
   - PPG:
-    - description: "commercial banks (AMT"
+    - description:
+      - "commercial banks (AMT"
   - PPG:
-    - description: "commercial banks (DIS"
+    - description:
+      - "commercial banks (DIS"
   - PPG:
-    - description: "commercial banks (DOD"
+    - description:
+      - "commercial banks (DOD"
   - PPG:
-    - description: "commercial banks (INT"
+    - description:
+      - "commercial banks (INT"
   - PPG:
-    - description: "commercial banks (NFL"
+    - description:
+      - "commercial banks (NFL"
   - PPG:
-    - description: "commercial banks (NTR"
+    - description:
+      - "commercial banks (NTR"
   - PPG:
-    - description: "commercial banks (TDS"
+    - description:
+      - "commercial banks (TDS"
   - PPG:
-    - description: "IBRD (AMT"
+    - description:
+      - "IBRD (AMT"
   - PPG:
-    - description: "IBRD (DIS"
+    - description:
+      - "IBRD (DIS"
   - PPG:
-    - description: "IBRD (DOD"
+    - description:
+      - "IBRD (DOD"
   - PPG:
-    - description: "IBRD (INT"
+    - description:
+      - "IBRD (INT"
   - PPG:
-    - description: "IBRD (NTR"
+    - description:
+      - "IBRD (NTR"
   - PPG:
-    - description: "IBRD (TDS"
+    - description:
+      - "IBRD (TDS"
   - PPG:
-    - description: "IDA (AMT"
+    - description:
+      - "IDA (AMT"
   - PPG:
-    - description: "IDA (DIS"
+    - description:
+      - "IDA (DIS"
   - PPG:
-    - description: "IDA (DOD"
+    - description:
+      - "IDA (DOD"
   - PPG:
-    - description: "IDA (INT"
+    - description:
+      - "IDA (INT"
   - PPG:
-    - description: "IDA (NTR"
+    - description:
+      - "IDA (NTR"
   - PPG:
-    - description: "IDA (TDS"
+    - description:
+      - "IDA (TDS"
   - PPG:
-    - description: "multilateral (AMT"
+    - description:
+      - "multilateral (AMT"
   - PPG:
-    - description: "multilateral (DIS"
+    - description:
+      - "multilateral (DIS"
   - PPG:
-    - description: "multilateral (DOD"
+    - description:
+      - "multilateral (DOD"
   - PPG:
-    - description: "multilateral (INT"
+    - description:
+      - "multilateral (INT"
   - PPG:
-    - description: "multilateral (NTR"
+    - description:
+      - "multilateral (NTR"
   - PPG:
-    - description: "multilateral concessional (AMT"
+    - description:
+      - "multilateral concessional (AMT"
   - PPG:
-    - description: "multilateral concessional (DIS"
+    - description:
+      - "multilateral concessional (DIS"
   - PPG:
-    - description: "multilateral concessional (DOD"
+    - description:
+      - "multilateral concessional (DOD"
   - PPG:
-    - description: "multilateral concessional (INT"
+    - description:
+      - "multilateral concessional (INT"
   - PPG:
-    - description: "multilateral concessional (NFL"
+    - description:
+      - "multilateral concessional (NFL"
   - PPG:
-    - description: "multilateral concessional (NTR"
+    - description:
+      - "multilateral concessional (NTR"
   - PPG:
-    - description: "multilateral concessional (TDS"
+    - description:
+      - "multilateral concessional (TDS"
   - PPG:
-    - description: "official creditors (AMT"
+    - description:
+      - "official creditors (AMT"
   - PPG:
-    - description: "official creditors (DIS"
+    - description:
+      - "official creditors (DIS"
   - PPG:
-    - description: "official creditors (DOD"
+    - description:
+      - "official creditors (DOD"
   - PPG:
-    - description: "official creditors (INT"
+    - description:
+      - "official creditors (INT"
   - PPG:
-    - description: "official creditors (NFL"
+    - description:
+      - "official creditors (NFL"
   - PPG:
-    - description: "official creditors (NTR"
+    - description:
+      - "official creditors (NTR"
   - PPG:
-    - description: "official creditors (TDS"
+    - description:
+      - "official creditors (TDS"
   - PPG:
-    - description: "other private creditors (AMT"
+    - description:
+      - "other private creditors (AMT"
   - PPG:
-    - description: "other private creditors (DIS"
+    - description:
+      - "other private creditors (DIS"
   - PPG:
-    - description: "other private creditors (DOD"
+    - description:
+      - "other private creditors (DOD"
   - PPG:
-    - description: "other private creditors (INT"
+    - description:
+      - "other private creditors (INT"
   - PPG:
-    - description: "other private creditors (NFL"
+    - description:
+      - "other private creditors (NFL"
   - PPG:
-    - description: "other private creditors (NTR"
+    - description:
+      - "other private creditors (NTR"
   - PPG:
-    - description: "other private creditors (TDS"
+    - description:
+      - "other private creditors (TDS"
   - PPG:
-    - description: "private creditors (AMT"
+    - description:
+      - "private creditors (AMT"
   - PPG:
-    - description: "private creditors (DIS"
+    - description:
+      - "private creditors (DIS"
   - PPG:
-    - description: "private creditors (DOD"
+    - description:
+      - "private creditors (DOD"
   - PPG:
-    - description: "private creditors (INT"
+    - description:
+      - "private creditors (INT"
   - PPG:
-    - description: "private creditors (NFL"
+    - description:
+      - "private creditors (NFL"
   - PPG:
-    - description: "private creditors (NTR"
+    - description:
+      - "private creditors (NTR"
   - PPG:
-    - description: "private creditors (TDS"
+    - description:
+      - "private creditors (TDS"
   - PPP_conversion_factor:
-    - description: "GDP (LCU per international $)"
+    - description:
+      - "GDP (LCU per international $)"
   - PPP_conversion_factor:
-    - description: "private consumption (LCU per international $)"
+    - description:
+      - "private consumption (LCU per international $)"
   - Pregnant_women_receiving_prenatal_care_(%):
-    - description: "Pregnant women receiving prenatal care are the percentage of women attended at least once during pregnancy by skilled health personnel for reasons related to pregnancy."
+    - description:
+      - "Pregnant women receiving prenatal care are the percentage of women attended at least once during pregnancy by skilled health personnel for reasons related to pregnancy."
   - Preprimary_education:
-    - description: "duration (years)"
+    - description:
+      - "duration (years)"
   - Presence_of_peace_keepers_(number_of_troops:
-    - description: "police"
+    - description:
+      - "police"
   - Present_value_of_external_debt_(%_of_exports_of_goods:
-    - description: "services and income)"
+    - description:
+      - "services and income)"
   - Present_value_of_external_debt_(%_of_GNI):
-    - description: "Present value of debt is the sum of short-term external debt plus the discounted sum of total debt service payments due on public"
+    - description:
+      - "Present value of debt is the sum of short-term external debt plus the discounted sum of total debt service payments due on public"
   - Present_value_of_external_debt_(current_US$):
-    - description: "Present value of debt is the sum of short-term external debt plus the discounted sum of total debt service payments due on public"
+    - description:
+      - "Present value of debt is the sum of short-term external debt plus the discounted sum of total debt service payments due on public"
   - Prevalence_of_anemia_among_children_(%_of_children_under_5):
-    - description: "Prevalence of anemia"
+    - description:
+      - "Prevalence of anemia"
   - Prevalence_of_anemia_among_non-pregnant_women_(%_of_women_ages_15-49):
-    - description: "Prevalence of anemia"
+    - description:
+      - "Prevalence of anemia"
   - Prevalence_of_anemia_among_pregnant_women_(%):
-    - description: "Prevalence of anemia"
+    - description:
+      - "Prevalence of anemia"
   - Prevalence_of_anemia_among_women_of_reproductive_age_(%_of_women_ages_15-49):
-    - description: "Prevalence of anemia among women of reproductive age refers to the combined prevalence of both non-pregnant with haemoglobin levels below 12 g/dL and pregnant women with haemoglobin levels below 11 g/dL."
+    - description:
+      - "Prevalence of anemia among women of reproductive age refers to the combined prevalence of both non-pregnant with haemoglobin levels below 12 g/dL and pregnant women with haemoglobin levels below 11 g/dL."
   - Prevalence_of_HIV:
-    - description: "female (% ages 15-24)"
+    - description:
+      - "female (% ages 15-24)"
   - Prevalence_of_HIV:
-    - description: "male (% ages 15-24)"
+    - description:
+      - "male (% ages 15-24)"
   - Prevalence_of_HIV:
-    - description: "total (% of population ages 15-49)"
+    - description:
+      - "total (% of population ages 15-49)"
   - Prevalence_of_overweight:
-    - description: "weight for height (% of children under 5)"
+    - description:
+      - "weight for height (% of children under 5)"
   - Prevalence_of_overweight:
-    - description: "weight for height"
+    - description:
+      - "weight for height"
   - Prevalence_of_overweight:
-    - description: "weight for height"
+    - description:
+      - "weight for height"
   - Prevalence_of_severe_wasting:
-    - description: "weight for height (% of children under 5)"
+    - description:
+      - "weight for height (% of children under 5)"
   - Prevalence_of_severe_wasting:
-    - description: "weight for height"
+    - description:
+      - "weight for height"
   - Prevalence_of_severe_wasting:
-    - description: "weight for height"
+    - description:
+      - "weight for height"
   - Prevalence_of_stunting:
-    - description: "height for age (% of children under 5)"
+    - description:
+      - "height for age (% of children under 5)"
   - Prevalence_of_stunting:
-    - description: "height for age"
+    - description:
+      - "height for age"
   - Prevalence_of_stunting:
-    - description: "height for age"
+    - description:
+      - "height for age"
   - Prevalence_of_undernourishment_(%_of_population):
-    - description: "Population below minimum level of dietary energy consumption (also referred to as prevalence of undernourishment) shows the percentage of the population whose food intake is insufficient to meet dietary energy requirements continuously. Data showing as 5 may signify a prevalence of undernourishment below 5%."
+    - description:
+      - "Population below minimum level of dietary energy consumption (also referred to as prevalence of undernourishment) shows the percentage of the population whose food intake is insufficient to meet dietary energy requirements continuously. Data showing as 5 may signify a prevalence of undernourishment below 5%."
   - Prevalence_of_underweight:
-    - description: "weight for age (% of children under 5)"
+    - description:
+      - "weight for age (% of children under 5)"
   - Prevalence_of_underweight:
-    - description: "weight for age"
+    - description:
+      - "weight for age"
   - Prevalence_of_underweight:
-    - description: "weight for age"
+    - description:
+      - "weight for age"
   - Prevalence_of_wasting:
-    - description: "weight for height (% of children under 5)"
+    - description:
+      - "weight for height (% of children under 5)"
   - Prevalence_of_wasting:
-    - description: "weight for height"
+    - description:
+      - "weight for height"
   - Prevalence_of_wasting:
-    - description: "weight for height"
+    - description:
+      - "weight for height"
   - Price_level_ratio_of_PPP_conversion_factor_(GDP)_to_market_exchange_rate:
-    - description: "Purchasing power parity conversion factor is the number of units of a country's currency required to buy the same amount of goods and services in the domestic market as a U.S. dollar would buy in the United States. The ratio of PPP conversion factor to market exchange rate is the result obtained by dividing the PPP conversion factor by the market exchange rate. The ratio"
+    - description:
+      - "Purchasing power parity conversion factor is the number of units of a country's currency required to buy the same amount of goods and services in the domestic market as a U.S. dollar would buy in the United States. The ratio of PPP conversion factor to market exchange rate is the result obtained by dividing the PPP conversion factor by the market exchange rate. The ratio"
   - Primary_completion_rate:
-    - description: "female (% of relevant age group)"
+    - description:
+      - "female (% of relevant age group)"
   - Primary_completion_rate:
-    - description: "male (% of relevant age group)"
+    - description:
+      - "male (% of relevant age group)"
   - Primary_completion_rate:
-    - description: "total (% of relevant age group)"
+    - description:
+      - "total (% of relevant age group)"
   - Primary_education:
-    - description: "duration (years)"
+    - description:
+      - "duration (years)"
   - Primary_education:
-    - description: "pupils"
+    - description:
+      - "pupils"
   - Primary_education:
-    - description: "pupils (% female)"
+    - description:
+      - "pupils (% female)"
   - Primary_education:
-    - description: "teachers"
+    - description:
+      - "teachers"
   - Primary_education:
-    - description: "teachers (% female)"
+    - description:
+      - "teachers (% female)"
   - Primary_income_on_FDI_(current_US$):
-    - description: "Primary income on foreign direct investment covers payments of direct investment income (debit side)"
+    - description:
+      - "Primary income on foreign direct investment covers payments of direct investment income (debit side)"
   - Primary_income_payments_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Primary_income_receipts_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Primary_school_starting_age_(years):
-    - description: "Primary school starting age is the age at which students would enter primary education"
+    - description:
+      - "Primary school starting age is the age at which students would enter primary education"
   - Principal_arrears:
-    - description: "official creditors (current US$)"
+    - description:
+      - "official creditors (current US$)"
   - Principal_arrears:
-    - description: "private creditors (current US$)"
+    - description:
+      - "private creditors (current US$)"
   - Principal_arrears:
-    - description: "public and publicly guaranteed (current US$)"
+    - description:
+      - "public and publicly guaranteed (current US$)"
   - Principal_forgiven_(current_US$):
-    - description: "Principal forgiven is the amount of principal due or in arrears that was written off or forgiven in any given year. It includes debt forgiven within and outside Paris Club agreements"
+    - description:
+      - "Principal forgiven is the amount of principal due or in arrears that was written off or forgiven in any given year. It includes debt forgiven within and outside Paris Club agreements"
   - Principal_repayments_on_external_debt:
-    - description: "long-term (AMT"
+    - description:
+      - "long-term (AMT"
   - Principal_repayments_on_external_debt:
-    - description: "long-term + IMF (AMT"
+    - description:
+      - "long-term + IMF (AMT"
   - Principal_repayments_on_external_debt:
-    - description: "private nonguaranteed (PNG) (AMT"
+    - description:
+      - "private nonguaranteed (PNG) (AMT"
   - Principal_repayments_on_external_debt:
-    - description: "public and publicly guaranteed (PPG) (AMT"
+    - description:
+      - "public and publicly guaranteed (PPG) (AMT"
   - Principal_rescheduled_(current_US$):
-    - description: "Principal rescheduled is the amount of principal due or in arrears that was rescheduled in any given year. Data are in current U.S. dollars."
+    - description:
+      - "Principal rescheduled is the amount of principal due or in arrears that was rescheduled in any given year. Data are in current U.S. dollars."
   - Principal_rescheduled:
-    - description: "official (current US$)"
+    - description:
+      - "official (current US$)"
   - Principal_rescheduled:
-    - description: "private (current US$)"
+    - description:
+      - "private (current US$)"
   - Private_credit_bureau_coverage_(%_of_adults):
-    - description: "Private credit bureau coverage reports the number of individuals or firms listed by a private credit bureau with current information on repayment history"
+    - description:
+      - "Private credit bureau coverage reports the number of individuals or firms listed by a private credit bureau with current information on repayment history"
   - Probability_of_dying_at_age_5-14_years_(per_1:
-    - description: "000 children age 5)"
+    - description:
+      - "000 children age 5)"
   - Procedures_to_build_a_warehouse_(number):
-    - description: "Number of procedures to build a warehouse is the number of interactions of a company's employees or managers with external parties"
+    - description:
+      - "Number of procedures to build a warehouse is the number of interactions of a company's employees or managers with external parties"
   - Procedures_to_register_property_(number):
-    - description: "Number of procedures to register property is the number of procedures required for a businesses to secure rights to property."
+    - description:
+      - "Number of procedures to register property is the number of procedures required for a businesses to secure rights to property."
   - Profit_tax_(%_of_commercial_profits):
-    - description: "Profit tax is the amount of taxes on profits paid by the business."
+    - description:
+      - "Profit tax is the amount of taxes on profits paid by the business."
   - Progression_to_secondary_school_(%):
-    - description: "Progression to secondary school refers to the number of new entrants to the first grade of secondary school in a given year as a percentage of the number of students enrolled in the final grade of primary school in the previous year (minus the number of repeaters from the last grade of primary education in the given year)."
+    - description:
+      - "Progression to secondary school refers to the number of new entrants to the first grade of secondary school in a given year as a percentage of the number of students enrolled in the final grade of primary school in the previous year (minus the number of repeaters from the last grade of primary education in the given year)."
   - Progression_to_secondary_school:
-    - description: "female (%)"
+    - description:
+      - "female (%)"
   - Progression_to_secondary_school:
-    - description: "male (%)"
+    - description:
+      - "male (%)"
   - Proportion_of_population_pushed_below_the_$1.90_($_2011_PPP)_poverty_line_by_out-of-pocket_health_care_expenditure_(%):
-    - description: "Proportion of population pushed below the $1.90 ($ 2011 PPP) poverty line by out-of-pocket health care expenditure"
+    - description:
+      - "Proportion of population pushed below the $1.90 ($ 2011 PPP) poverty line by out-of-pocket health care expenditure"
   - Proportion_of_population_pushed_below_the_$3.10_($_2011_PPP)_poverty_line_by_out-of-pocket_health_care_expenditure_(%):
-    - description: "Proportion of population pushed below the $3.10 ($ 2011 PPP) poverty line by out-of-pocket health care expenditure"
+    - description:
+      - "Proportion of population pushed below the $3.10 ($ 2011 PPP) poverty line by out-of-pocket health care expenditure"
   - Proportion_of_population_spending_more_than_10%_of_household_consumption_or_income_on_out-of-pocket_health_care_expenditure_(%):
-    - description: "Proportion of population spending more than 10% of household consumption or income on out-of-pocket health care expenditure"
+    - description:
+      - "Proportion of population spending more than 10% of household consumption or income on out-of-pocket health care expenditure"
   - Proportion_of_population_spending_more_than_25%_of_household_consumption_or_income_on_out-of-pocket_health_care_expenditure_(%):
-    - description: "Proportion of population spending more than 25% of household consumption or income on out-of-pocket health care expenditure"
+    - description:
+      - "Proportion of population spending more than 25% of household consumption or income on out-of-pocket health care expenditure"
   - Proportion_of_seats_held_by_women_in_national_parliaments_(%):
-    - description: "Women in parliaments are the percentage of parliamentary seats in a single or lower chamber held by women."
+    - description:
+      - "Women in parliaments are the percentage of parliamentary seats in a single or lower chamber held by women."
   - Proportion_of_time_spent_on_unpaid_domestic_and_care_work:
-    - description: "female (% of 24 hour day)"
+    - description:
+      - "female (% of 24 hour day)"
   - Proportion_of_time_spent_on_unpaid_domestic_and_care_work:
-    - description: "male (% of 24 hour day)"
+    - description:
+      - "male (% of 24 hour day)"
   - Proportion_of_women_subjected_to_physical_and/or_sexual_violence_in_the_last_12_months_(%_of_women_age_15-49):
-    - description: "Proportion of women subjected to physical and/or sexual violence in the last 12 months is the percentage of ever partnered women age 15-49 who are subjected to physical violence"
+    - description:
+      - "Proportion of women subjected to physical and/or sexual violence in the last 12 months is the percentage of ever partnered women age 15-49 who are subjected to physical violence"
   - Public_and_publicly_guaranteed_debt_service_(%_of_exports_of_goods:
-    - description: "services and primary income)"
+    - description:
+      - "services and primary income)"
   - Public_and_publicly_guaranteed_debt_service_(%_of_GNI):
-    - description: "Public and publicly guaranteed debt service is the sum of principal repayments and interest actually paid in currency"
+    - description:
+      - "Public and publicly guaranteed debt service is the sum of principal repayments and interest actually paid in currency"
   - Public_credit_registry_coverage_(%_of_adults):
-    - description: "Public credit registry coverage reports the number of individuals and firms listed in a public credit registry with current information on repayment history"
+    - description:
+      - "Public credit registry coverage reports the number of individuals and firms listed in a public credit registry with current information on repayment history"
   - Public_private_partnerships_investment_in_energy_(current_US$):
-    - description: "Public Private Partnerships in energy (current US$)  refers to commitments to  infrastructure projects in energy (electricity and natural gas transmission and distribution) that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects such as windmills are excluded. The types of projects included are  management and lease contracts"
+    - description:
+      - "Public Private Partnerships in energy (current US$)  refers to commitments to  infrastructure projects in energy (electricity and natural gas transmission and distribution) that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects such as windmills are excluded. The types of projects included are  management and lease contracts"
   - Public_private_partnerships_investment_in_ICT_(current_US$):
-    - description: "Public Private Partnerships in ICT (current US$) refers to commitments to projects in ICT backbone infrastructure (including land based and submarine cables) that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are management and lease contracts"
+    - description:
+      - "Public Private Partnerships in ICT (current US$) refers to commitments to projects in ICT backbone infrastructure (including land based and submarine cables) that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are management and lease contracts"
   - Public_private_partnerships_investment_in_telecom_(current_US$):
-    - description: "Public Private Partnerships in telecom (current US$) refers to commitments to infrastructure projects in telecommunications that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are operations and management and lease contracts"
+    - description:
+      - "Public Private Partnerships in telecom (current US$) refers to commitments to infrastructure projects in telecommunications that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are operations and management and lease contracts"
   - Public_private_partnerships_investment_in_transport_(current_US$):
-    - description: "Public Private Partnerships in transport (current US$) refers to commitments to  infrastructure projects in transport that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are  management and lease contracts"
+    - description:
+      - "Public Private Partnerships in transport (current US$) refers to commitments to  infrastructure projects in transport that have reached financial closure and directly or indirectly serve the public. Movable assets and small projects are excluded. The types of projects included are  management and lease contracts"
   - Public_private_partnerships_investment_in_water_and_sanitation_(current_US$):
-    - description: "Public Private Partnerships in water and sanitation (current US$) refers to commitments to  infrastructure projects in water and sanitation that have reached financial closure and directly or indirectly serve the public. Movable assets"
+    - description:
+      - "Public Private Partnerships in water and sanitation (current US$) refers to commitments to  infrastructure projects in water and sanitation that have reached financial closure and directly or indirectly serve the public. Movable assets"
   - Pump_price_for_diesel_fuel_(US$_per_liter):
-    - description: "Fuel prices refer to the pump prices of the most widely sold grade of diesel fuel. Prices have been converted from the local currency to U.S. dollars."
+    - description:
+      - "Fuel prices refer to the pump prices of the most widely sold grade of diesel fuel. Prices have been converted from the local currency to U.S. dollars."
   - Pump_price_for_gasoline_(US$_per_liter):
-    - description: "Fuel prices refer to the pump prices of the most widely sold grade of gasoline. Prices have been converted from the local currency to U.S. dollars."
+    - description:
+      - "Fuel prices refer to the pump prices of the most widely sold grade of gasoline. Prices have been converted from the local currency to U.S. dollars."
   - Pupil-teacher_ratio:
-    - description: "lower secondary"
+    - description:
+      - "lower secondary"
   - Pupil-teacher_ratio:
-    - description: "preprimary"
+    - description:
+      - "preprimary"
   - Pupil-teacher_ratio:
-    - description: "primary"
+    - description:
+      - "primary"
   - Pupil-teacher_ratio:
-    - description: "secondary"
+    - description:
+      - "secondary"
   - Pupil-teacher_ratio:
-    - description: "tertiary"
+    - description:
+      - "tertiary"
   - Pupil-teacher_ratio:
-    - description: "upper secondary"
+    - description:
+      - "upper secondary"
   - Quality_of_port_infrastructure:
-    - description: "WEF (1=extremely underdeveloped to 7=well developed and efficient by international standards)"
+    - description:
+      - "WEF (1=extremely underdeveloped to 7=well developed and efficient by international standards)"
   - Rail_lines_(total_route-km):
-    - description: "Rail lines are the length of railway route available for train service"
+    - description:
+      - "Rail lines are the length of railway route available for train service"
   - Railways:
-    - description: "goods transported (million ton-km)"
+    - description:
+      - "goods transported (million ton-km)"
   - Railways:
-    - description: "passengers carried (million passenger-km)"
+    - description:
+      - "passengers carried (million passenger-km)"
   - Ratio_of_female_to_male_labor_force_participation_rate_(%)_(modeled_ILO_estimate):
-    - description: "Labor force participation rate is the proportion of the population ages 15 and older that is economically active: all people who supply labor for the production of goods and services during a specified period. Ratio of female to male labor force participation rate is calculated by dividing female labor force participation rate by male labor force participation rate and multiplying by 100."
+    - description:
+      - "Labor force participation rate is the proportion of the population ages 15 and older that is economically active: all people who supply labor for the production of goods and services during a specified period. Ratio of female to male labor force participation rate is calculated by dividing female labor force participation rate by male labor force participation rate and multiplying by 100."
   - Ratio_of_female_to_male_labor_force_participation_rate_(%)_(national_estimate):
-    - description: "Labor force participation rate is the proportion of the population ages 15 and older that is economically active: all people who supply labor for the production of goods and services during a specified period. Ratio of female to male labor force participation rate is calculated by dividing female labor force participation rate by male labor force participation rate and multiplying by 100."
+    - description:
+      - "Labor force participation rate is the proportion of the population ages 15 and older that is economically active: all people who supply labor for the production of goods and services during a specified period. Ratio of female to male labor force participation rate is calculated by dividing female labor force participation rate by male labor force participation rate and multiplying by 100."
   - Real_effective_exchange_rate_index_(2010_=_100):
-    - description: "Real effective exchange rate is the nominal effective exchange rate (a measure of the value of a currency against a weighted average of several foreign currencies) divided by a price deflator or index of costs."
+    - description:
+      - "Real effective exchange rate is the nominal effective exchange rate (a measure of the value of a currency against a weighted average of several foreign currencies) divided by a price deflator or index of costs."
   - Real_interest_rate_(%):
-    - description: "Real interest rate is the lending interest rate adjusted for inflation as measured by the GDP deflator. The terms and conditions attached to lending rates differ by country"
+    - description:
+      - "Real interest rate is the lending interest rate adjusted for inflation as measured by the GDP deflator. The terms and conditions attached to lending rates differ by country"
   - Refugee_population_by_country_or_territory_of_asylum:
-    - description: "Refugees are people who are recognized as refugees under the 1951 Convention Relating to the Status of Refugees or its 1967 Protocol"
+    - description:
+      - "Refugees are people who are recognized as refugees under the 1951 Convention Relating to the Status of Refugees or its 1967 Protocol"
   - Refugee_population_by_country_or_territory_of_origin:
-    - description: "Refugees are people who are recognized as refugees under the 1951 Convention Relating to the Status of Refugees or its 1967 Protocol"
+    - description:
+      - "Refugees are people who are recognized as refugees under the 1951 Convention Relating to the Status of Refugees or its 1967 Protocol"
   - Renewable_electricity_output_(%_of_total_electricity_output):
-    - description: "Renewable electricity is the share of electrity generated by renewable power plants in total electricity generated by all types of plants."
+    - description:
+      - "Renewable electricity is the share of electrity generated by renewable power plants in total electricity generated by all types of plants."
   - Renewable_energy_consumption_(%_of_total_final_energy_consumption):
-    - description: "Renewable energy consumption is the share of renewables energy in total final energy consumption."
+    - description:
+      - "Renewable energy consumption is the share of renewables energy in total final energy consumption."
   - Renewable_internal_freshwater_resources_per_capita_(cubic_meters):
-    - description: "Renewable internal freshwater resources flows refer to internal renewable resources (internal river flows and groundwater from rainfall) in the country. Renewable internal freshwater resources per capita are calculated using the World Bank's population estimates."
+    - description:
+      - "Renewable internal freshwater resources flows refer to internal renewable resources (internal river flows and groundwater from rainfall) in the country. Renewable internal freshwater resources per capita are calculated using the World Bank's population estimates."
   - Renewable_internal_freshwater_resources:
-    - description: "total (billion cubic meters)"
+    - description:
+      - "total (billion cubic meters)"
   - Repeaters:
-    - description: "primary"
+    - description:
+      - "primary"
   - Repeaters:
-    - description: "primary"
+    - description:
+      - "primary"
   - Repeaters:
-    - description: "primary"
+    - description:
+      - "primary"
   - Research_and_development_expenditure_(%_of_GDP):
-    - description: "Gloss domestic expenditures on research and development (R&D)"
+    - description:
+      - "Gloss domestic expenditures on research and development (R&D)"
   - Researchers_in_R&D_(per_million_people):
-    - description: "The number of researchers engaged in Research &Development (R&D)"
+    - description:
+      - "The number of researchers engaged in Research &Development (R&D)"
   - Reserves_and_related_items_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Residual:
-    - description: "debt stock-flow reconciliation (current US$)"
+    - description:
+      - "debt stock-flow reconciliation (current US$)"
   - Revenue:
-    - description: "excluding grants (% of GDP)"
+    - description:
+      - "excluding grants (% of GDP)"
   - Revenue:
-    - description: "excluding grants (current LCU)"
+    - description:
+      - "excluding grants (current LCU)"
   - Risk_of_catastrophic_expenditure_for_surgical_care_(%_of_people_at_risk):
-    - description: "The proportion of population at risk of catastrophic expenditure when surgical care is required. Catastrophic expenditure is defined as direct out of pocket payments for surgical and anaesthesia care exceeding 10% of total income."
+    - description:
+      - "The proportion of population at risk of catastrophic expenditure when surgical care is required. Catastrophic expenditure is defined as direct out of pocket payments for surgical and anaesthesia care exceeding 10% of total income."
   - Risk_of_impoverishing_expenditure_for_surgical_care_(%_of_people_at_risk):
-    - description: "The proportion of population at risk of impoverishing expenditure when surgical care is required. Impoverishing expenditure is defined as direct out of pocket payments for surgical and anaesthesia care which drive people below a poverty threshold (using a threshold of $1.25 PPP/day)."
+    - description:
+      - "The proportion of population at risk of impoverishing expenditure when surgical care is required. Impoverishing expenditure is defined as direct out of pocket payments for surgical and anaesthesia care which drive people below a poverty threshold (using a threshold of $1.25 PPP/day)."
   - Risk_premium_on_lending_(lending_rate_minus_treasury_bill_rate:
-    - description: "%)"
+    - description:
+      - "%)"
   - Rural_land_area_(sq._km):
-    - description: "Rural land area in square kilometers"
+    - description:
+      - "Rural land area in square kilometers"
   - Rural_land_area_where_elevation_is_below_5_meters_(%_of_total_land_area):
-    - description: "Rural land area below 5m is the percentage of total land where the rural land elevation is 5 meters or less."
+    - description:
+      - "Rural land area below 5m is the percentage of total land where the rural land elevation is 5 meters or less."
   - Rural_land_area_where_elevation_is_below_5_meters_(sq._km):
-    - description: "Rural land area below 5m is the total rural land area in square kilometers where the elevation is 5 meters or less."
+    - description:
+      - "Rural land area below 5m is the total rural land area in square kilometers where the elevation is 5 meters or less."
   - Rural_population:
-    - description: "Rural population refers to people living in rural areas as defined by national statistical offices. It is calculated as the difference between total population and urban population. Aggregation of urban and rural population may not add up to total population because of different country coverages."
+    - description:
+      - "Rural population refers to people living in rural areas as defined by national statistical offices. It is calculated as the difference between total population and urban population. Aggregation of urban and rural population may not add up to total population because of different country coverages."
   - Rural_population_(%_of_total_population):
-    - description: "Rural population refers to people living in rural areas as defined by national statistical offices. It is calculated as the difference between total population and urban population."
+    - description:
+      - "Rural population refers to people living in rural areas as defined by national statistical offices. It is calculated as the difference between total population and urban population."
   - Rural_population_growth_(annual_%):
-    - description: "Rural population refers to people living in rural areas as defined by national statistical offices. It is calculated as the difference between total population and urban population."
+    - description:
+      - "Rural population refers to people living in rural areas as defined by national statistical offices. It is calculated as the difference between total population and urban population."
   - Rural_population_living_in_areas_where_elevation_is_below_5_meters_(%_of_total_population):
-    - description: "Rural population below 5m is the percentage of the total population"
+    - description:
+      - "Rural population below 5m is the percentage of the total population"
   - Rural_poverty_gap_at_national_poverty_lines_(%):
-    - description: "Rural poverty gap at national poverty lines is the rural population's mean shortfall from the poverty lines (counting the nonpoor as having zero shortfall) as a percentage of the poverty lines. This measure reflects the depth of poverty as well as its incidence."
+    - description:
+      - "Rural poverty gap at national poverty lines is the rural population's mean shortfall from the poverty lines (counting the nonpoor as having zero shortfall) as a percentage of the poverty lines. This measure reflects the depth of poverty as well as its incidence."
   - Rural_poverty_headcount_ratio_at_national_poverty_lines_(%_of_rural_population):
-    - description: "Rural poverty headcount ratio is the percentage of the rural population living below the national poverty lines."
+    - description:
+      - "Rural poverty headcount ratio is the percentage of the rural population living below the national poverty lines."
   - S&P_Global_Equity_Indices_(annual_%_change):
-    - description: "S&P Global Equity Indices measure the U.S. dollar price change in the stock markets covered by the S&P/IFCI and S&P/Frontier BMI country indices."
+    - description:
+      - "S&P Global Equity Indices measure the U.S. dollar price change in the stock markets covered by the S&P/IFCI and S&P/Frontier BMI country indices."
   - School_enrollment:
-    - description: "preprimary (% gross)"
+    - description:
+      - "preprimary (% gross)"
   - School_enrollment:
-    - description: "preprimary"
+    - description:
+      - "preprimary"
   - School_enrollment:
-    - description: "preprimary"
+    - description:
+      - "preprimary"
   - School_enrollment:
-    - description: "primary (% gross)"
+    - description:
+      - "primary (% gross)"
   - School_enrollment:
-    - description: "primary (% net)"
+    - description:
+      - "primary (% net)"
   - School_enrollment:
-    - description: "primary (gross)"
+    - description:
+      - "primary (gross)"
   - School_enrollment:
-    - description: "primary and secondary (gross)"
+    - description:
+      - "primary and secondary (gross)"
   - School_enrollment:
-    - description: "primary"
+    - description:
+      - "primary"
   - School_enrollment:
-    - description: "primary"
+    - description:
+      - "primary"
   - School_enrollment:
-    - description: "primary"
+    - description:
+      - "primary"
   - School_enrollment:
-    - description: "primary"
+    - description:
+      - "primary"
   - School_enrollment:
-    - description: "primary"
+    - description:
+      - "primary"
   - School_enrollment:
-    - description: "secondary (% gross)"
+    - description:
+      - "secondary (% gross)"
   - School_enrollment:
-    - description: "secondary (% net)"
+    - description:
+      - "secondary (% net)"
   - School_enrollment:
-    - description: "secondary (gross)"
+    - description:
+      - "secondary (gross)"
   - School_enrollment:
-    - description: "secondary"
+    - description:
+      - "secondary"
   - School_enrollment:
-    - description: "secondary"
+    - description:
+      - "secondary"
   - School_enrollment:
-    - description: "secondary"
+    - description:
+      - "secondary"
   - School_enrollment:
-    - description: "secondary"
+    - description:
+      - "secondary"
   - School_enrollment:
-    - description: "secondary"
+    - description:
+      - "secondary"
   - School_enrollment:
-    - description: "tertiary (% gross)"
+    - description:
+      - "tertiary (% gross)"
   - School_enrollment:
-    - description: "tertiary (gross)"
+    - description:
+      - "tertiary (gross)"
   - School_enrollment:
-    - description: "tertiary"
+    - description:
+      - "tertiary"
   - School_enrollment:
-    - description: "tertiary"
+    - description:
+      - "tertiary"
   - Scientific_and_technical_journal_articles:
-    - description: "Scientific and technical journal articles refer to the number of scientific and engineering articles published in the following fields: physics"
+    - description:
+      - "Scientific and technical journal articles refer to the number of scientific and engineering articles published in the following fields: physics"
   - Secondary_education:
-    - description: "duration (years)"
+    - description:
+      - "duration (years)"
   - Secondary_education:
-    - description: "general pupils"
+    - description:
+      - "general pupils"
   - Secondary_education:
-    - description: "general pupils (% female)"
+    - description:
+      - "general pupils (% female)"
   - Secondary_education:
-    - description: "pupils"
+    - description:
+      - "pupils"
   - Secondary_education:
-    - description: "pupils (% female)"
+    - description:
+      - "pupils (% female)"
   - Secondary_education:
-    - description: "teachers"
+    - description:
+      - "teachers"
   - Secondary_education:
-    - description: "teachers (% female)"
+    - description:
+      - "teachers (% female)"
   - Secondary_education:
-    - description: "teachers"
+    - description:
+      - "teachers"
   - Secondary_education:
-    - description: "vocational pupils"
+    - description:
+      - "vocational pupils"
   - Secondary_education:
-    - description: "vocational pupils (% female)"
+    - description:
+      - "vocational pupils (% female)"
   - Secondary_income_receipts_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Secondary_income:
-    - description: "other sectors"
+    - description:
+      - "other sectors"
   - Secure_Internet_servers:
-    - description: "Secure servers are servers using encryption technology in Internet transactions."
+    - description:
+      - "Secure servers are servers using encryption technology in Internet transactions."
   - Secure_Internet_servers_(per_1_million_people):
-    - description: "Secure servers are servers using encryption technology in Internet transactions."
+    - description:
+      - "Secure servers are servers using encryption technology in Internet transactions."
   - Self-employed:
-    - description: "female (% of female employment) (modeled ILO estimate)"
+    - description:
+      - "female (% of female employment) (modeled ILO estimate)"
   - Self-employed:
-    - description: "male (% of male employment) (modeled ILO estimate)"
+    - description:
+      - "male (% of male employment) (modeled ILO estimate)"
   - Self-employed:
-    - description: "total (% of total employment) (modeled ILO estimate)"
+    - description:
+      - "total (% of total employment) (modeled ILO estimate)"
   - Service_exports_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Service_imports_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Services:
-    - description: "etc."
+    - description:
+      - "etc."
   - Services:
-    - description: "etc."
+    - description:
+      - "etc."
   - Services:
-    - description: "etc."
+    - description:
+      - "etc."
   - Services:
-    - description: "etc."
+    - description:
+      - "etc."
   - Services:
-    - description: "etc."
+    - description:
+      - "etc."
   - Services:
-    - description: "etc."
+    - description:
+      - "etc."
   - Services:
-    - description: "value added per worker (constant 2010 US$)"
+    - description:
+      - "value added per worker (constant 2010 US$)"
   - Sex_ratio_at_birth_(male_births_per_female_births):
-    - description: "Sex ratio at birth refers to male births per female births. The data are 5 year averages."
+    - description:
+      - "Sex ratio at birth refers to male births per female births. The data are 5 year averages."
   - SF6_gas_emissions_(thousand_metric_tons_of_CO2_equivalent):
-    - description: "Sulfur hexafluoride is used largely to insulate high-voltage electric power equipment."
+    - description:
+      - "Sulfur hexafluoride is used largely to insulate high-voltage electric power equipment."
   - Share_of_tariff_lines_with_international_peaks:
-    - description: "all products (%)"
+    - description:
+      - "all products (%)"
   - Share_of_tariff_lines_with_international_peaks:
-    - description: "manufactured products (%)"
+    - description:
+      - "manufactured products (%)"
   - Share_of_tariff_lines_with_international_peaks:
-    - description: "primary products (%)"
+    - description:
+      - "primary products (%)"
   - Share_of_tariff_lines_with_specific_rates:
-    - description: "all products (%)"
+    - description:
+      - "all products (%)"
   - Share_of_tariff_lines_with_specific_rates:
-    - description: "manufactured products (%)"
+    - description:
+      - "manufactured products (%)"
   - Share_of_tariff_lines_with_specific_rates:
-    - description: "primary products (%)"
+    - description:
+      - "primary products (%)"
   - Share_of_youth_not_in_education:
-    - description: "employment or training"
+    - description:
+      - "employment or training"
   - Share_of_youth_not_in_education:
-    - description: "employment or training"
+    - description:
+      - "employment or training"
   - Share_of_youth_not_in_education:
-    - description: "employment or training"
+    - description:
+      - "employment or training"
   - Short-term_debt_(%_of_exports_of_goods:
-    - description: "services and primary income)"
+    - description:
+      - "services and primary income)"
   - Short-term_debt_(%_of_total_external_debt):
-    - description: "Short-term debt includes all debt having an original maturity of one year or less and interest in arrears on long-term debt. Total external debt is debt owed to nonresidents repayable in currency"
+    - description:
+      - "Short-term debt includes all debt having an original maturity of one year or less and interest in arrears on long-term debt. Total external debt is debt owed to nonresidents repayable in currency"
   - Short-term_debt_(%_of_total_reserves):
-    - description: "Short-term debt includes all debt having an original maturity of one year or less and interest in arrears on long-term debt. Total reserves includes gold."
+    - description:
+      - "Short-term debt includes all debt having an original maturity of one year or less and interest in arrears on long-term debt. Total reserves includes gold."
   - Smoking_prevalence:
-    - description: "females (% of adults)"
+    - description:
+      - "females (% of adults)"
   - Smoking_prevalence:
-    - description: "males (% of adults)"
+    - description:
+      - "males (% of adults)"
   - Social_contributions_(%_of_revenue):
-    - description: "Social contributions include social security contributions by employees"
+    - description:
+      - "Social contributions include social security contributions by employees"
   - Social_contributions_(current_LCU):
-    - description: "Social contributions include social security contributions by employees"
+    - description:
+      - "Social contributions include social security contributions by employees"
   - Source_data_assessment_of_statistical_capacity_(scale_0_-_100):
-    - description: "The source data indicator reflects whether a country conducts data collection activities in line with internationally recommended periodicity"
+    - description:
+      - "The source data indicator reflects whether a country conducts data collection activities in line with internationally recommended periodicity"
   - Specialist_surgical_workforce_(per_100:
-    - description: "000 population)"
+    - description:
+      - "000 population)"
   - Start-up_procedures_to_register_a_business_(number):
-    - description: "Start-up procedures are those required to start a business"
+    - description:
+      - "Start-up procedures are those required to start a business"
   - Start-up_procedures_to_register_a_business:
-    - description: "female (number)"
+    - description:
+      - "female (number)"
   - Start-up_procedures_to_register_a_business:
-    - description: "male (number)"
+    - description:
+      - "male (number)"
   - Stocks_traded:
-    - description: "total value (% of GDP)"
+    - description:
+      - "total value (% of GDP)"
   - Stocks_traded:
-    - description: "total value (current US$)"
+    - description:
+      - "total value (current US$)"
   - Stocks_traded:
-    - description: "turnover ratio of domestic shares (%)"
+    - description:
+      - "turnover ratio of domestic shares (%)"
   - Strength_of_legal_rights_index_(0=weak_to_12=strong):
-    - description: "Strength of legal rights index measures the degree to which collateral and bankruptcy laws protect the rights of borrowers and lenders and thus facilitate lending. The index ranges from 0 to 12"
+    - description:
+      - "Strength of legal rights index measures the degree to which collateral and bankruptcy laws protect the rights of borrowers and lenders and thus facilitate lending. The index ranges from 0 to 12"
   - Subsidies_and_other_transfers_(%_of_expense):
-    - description: "Subsidies"
+    - description:
+      - "Subsidies"
   - Subsidies_and_other_transfers_(current_LCU):
-    - description: "Subsidies"
+    - description:
+      - "Subsidies"
   - Suicide_mortality_rate_(per_100:
-    - description: "000 population)"
+    - description:
+      - "000 population)"
   - Surface_area_(sq._km):
-    - description: "Surface area is a country's total area"
+    - description:
+      - "Surface area is a country's total area"
   - Survey_mean_consumption_or_income_per_capita:
-    - description: "bottom 40% of population (2011 PPP $ per day)"
+    - description:
+      - "bottom 40% of population (2011 PPP $ per day)"
   - Survey_mean_consumption_or_income_per_capita:
-    - description: "total population (2011 PPP $ per day)"
+    - description:
+      - "total population (2011 PPP $ per day)"
   - Survival_to_age_65:
-    - description: "female (% of cohort)"
+    - description:
+      - "female (% of cohort)"
   - Survival_to_age_65:
-    - description: "male (% of cohort)"
+    - description:
+      - "male (% of cohort)"
   - Tariff_rate:
-    - description: "applied"
+    - description:
+      - "applied"
   - Tariff_rate:
-    - description: "applied"
+    - description:
+      - "applied"
   - Tariff_rate:
-    - description: "applied"
+    - description:
+      - "applied"
   - Tariff_rate:
-    - description: "applied"
+    - description:
+      - "applied"
   - Tariff_rate:
-    - description: "applied"
+    - description:
+      - "applied"
   - Tariff_rate:
-    - description: "applied"
+    - description:
+      - "applied"
   - Tariff_rate:
-    - description: "most favored nation"
+    - description:
+      - "most favored nation"
   - Tariff_rate:
-    - description: "most favored nation"
+    - description:
+      - "most favored nation"
   - Tariff_rate:
-    - description: "most favored nation"
+    - description:
+      - "most favored nation"
   - Tariff_rate:
-    - description: "most favored nation"
+    - description:
+      - "most favored nation"
   - Tariff_rate:
-    - description: "most favored nation"
+    - description:
+      - "most favored nation"
   - Tariff_rate:
-    - description: "most favored nation"
+    - description:
+      - "most favored nation"
   - Tax_payments_(number):
-    - description: "Tax payments by businesses are the total number of taxes paid by businesses"
+    - description:
+      - "Tax payments by businesses are the total number of taxes paid by businesses"
   - Tax_revenue_(%_of_GDP):
-    - description: "Tax revenue refers to compulsory transfers to the central government for public purposes. Certain compulsory transfers such as fines"
+    - description:
+      - "Tax revenue refers to compulsory transfers to the central government for public purposes. Certain compulsory transfers such as fines"
   - Tax_revenue_(current_LCU):
-    - description: "Tax revenue refers to compulsory transfers to the central government for public purposes. Certain compulsory transfers such as fines"
+    - description:
+      - "Tax revenue refers to compulsory transfers to the central government for public purposes. Certain compulsory transfers such as fines"
   - Taxes_on_exports_(%_of_tax_revenue):
-    - description: "Taxes on exports are all levies on goods being transported out of the country or services being delivered to nonresidents by residents. Rebates on exported goods that are repayments of previously paid general consumption taxes"
+    - description:
+      - "Taxes on exports are all levies on goods being transported out of the country or services being delivered to nonresidents by residents. Rebates on exported goods that are repayments of previously paid general consumption taxes"
   - Taxes_on_exports_(current_LCU):
-    - description: "Taxes on exports are all levies on goods being transported out of the country or services being delivered to nonresidents by residents. Rebates on exported goods that are repayments of previously paid general consumption taxes"
+    - description:
+      - "Taxes on exports are all levies on goods being transported out of the country or services being delivered to nonresidents by residents. Rebates on exported goods that are repayments of previously paid general consumption taxes"
   - Taxes_on_goods_and_services_(%_of_revenue):
-    - description: "Taxes on goods and services include general sales and turnover or value added taxes"
+    - description:
+      - "Taxes on goods and services include general sales and turnover or value added taxes"
   - Taxes_on_goods_and_services_(%_value_added_of_industry_and_services):
-    - description: "Taxes on goods and services include general sales and turnover or value added taxes"
+    - description:
+      - "Taxes on goods and services include general sales and turnover or value added taxes"
   - Taxes_on_goods_and_services_(current_LCU):
-    - description: "Taxes on goods and services include general sales and turnover or value added taxes"
+    - description:
+      - "Taxes on goods and services include general sales and turnover or value added taxes"
   - Taxes_on_income:
-    - description: "profits and capital gains (% of revenue)"
+    - description:
+      - "profits and capital gains (% of revenue)"
   - Taxes_on_income:
-    - description: "profits and capital gains (% of total taxes)"
+    - description:
+      - "profits and capital gains (% of total taxes)"
   - Taxes_on_income:
-    - description: "profits and capital gains (current LCU)"
+    - description:
+      - "profits and capital gains (current LCU)"
   - Taxes_on_international_trade_(%_of_revenue):
-    - description: "Taxes on international trade include import duties"
+    - description:
+      - "Taxes on international trade include import duties"
   - Taxes_on_international_trade_(current_LCU):
-    - description: "Taxes on international trade include import duties"
+    - description:
+      - "Taxes on international trade include import duties"
   - Technical_cooperation_grants_(BoP:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Technicians_in_R&D_(per_million_people):
-    - description: "The number of technicians participated in Research & Development (R&D)"
+    - description:
+      - "The number of technicians participated in Research & Development (R&D)"
   - Teenage_mothers_(%_of_women_ages_15-19_who_have_had_children_or_are_currently_pregnant):
-    - description: "Teenage mothers are the percentage of women ages 15-19 who already have children or are currently pregnant."
+    - description:
+      - "Teenage mothers are the percentage of women ages 15-19 who already have children or are currently pregnant."
   - Terms_of_trade_adjustment_(constant_LCU):
-    - description: "The terms of trade effect equals capacity to import less exports of goods and services in constant prices. Data are in constant local currency."
+    - description:
+      - "The terms of trade effect equals capacity to import less exports of goods and services in constant prices. Data are in constant local currency."
   - Terrestrial_and_marine_protected_areas_(%_of_total_territorial_area):
-    - description: "Terrestrial protected areas are totally or partially protected areas of at least 1"
+    - description:
+      - "Terrestrial protected areas are totally or partially protected areas of at least 1"
   - Terrestrial_protected_areas_(%_of_total_land_area):
-    - description: "Terrestrial protected areas are totally or partially protected areas of at least 1"
+    - description:
+      - "Terrestrial protected areas are totally or partially protected areas of at least 1"
   - Tertiary_education:
-    - description: "academic staff (% female)"
+    - description:
+      - "academic staff (% female)"
   - Textiles_and_clothing_(%_of_value_added_in_manufacturing):
-    - description: "Value added in manufacturing is the sum of gross output less the value of intermediate inputs used in production for industries classified in ISIC major division D. Textiles and clothing correspond to ISIC divisions 17-19."
+    - description:
+      - "Value added in manufacturing is the sum of gross output less the value of intermediate inputs used in production for industries classified in ISIC major division D. Textiles and clothing correspond to ISIC divisions 17-19."
   - Time_required_to_build_a_warehouse_(days):
-    - description: "Time required to build a warehouse is the number of calendar days needed to complete the required procedures for building a warehouse. If a procedure can be speeded up at additional cost"
+    - description:
+      - "Time required to build a warehouse is the number of calendar days needed to complete the required procedures for building a warehouse. If a procedure can be speeded up at additional cost"
   - Time_required_to_enforce_a_contract_(days):
-    - description: "Time required to enforce a contract is the number of calendar days from the filing of the lawsuit in court until the final determination and"
+    - description:
+      - "Time required to enforce a contract is the number of calendar days from the filing of the lawsuit in court until the final determination and"
   - Time_required_to_get_electricity_(days):
-    - description: "Time required to get electricity is the number of days to obtain a permanent electricity connection. The measure captures the median duration that the electricity utility and experts indicate is necessary in practice"
+    - description:
+      - "Time required to get electricity is the number of days to obtain a permanent electricity connection. The measure captures the median duration that the electricity utility and experts indicate is necessary in practice"
   - Time_required_to_obtain_an_operating_license_(days):
-    - description: "Time required to obtain operating license is the average wait to obtain an operating license from the day the establishment applied for it to the day it was granted."
+    - description:
+      - "Time required to obtain operating license is the average wait to obtain an operating license from the day the establishment applied for it to the day it was granted."
   - Time_required_to_register_property_(days):
-    - description: "Time required to register property is the number of calendar days needed for businesses to secure rights to property."
+    - description:
+      - "Time required to register property is the number of calendar days needed for businesses to secure rights to property."
   - Time_required_to_start_a_business_(days):
-    - description: "Time required to start a business is the number of calendar days needed to complete the procedures to legally operate a business. If a procedure can be speeded up at additional cost"
+    - description:
+      - "Time required to start a business is the number of calendar days needed to complete the procedures to legally operate a business. If a procedure can be speeded up at additional cost"
   - Time_required_to_start_a_business:
-    - description: "female (days)"
+    - description:
+      - "female (days)"
   - Time_required_to_start_a_business:
-    - description: "male (days)"
+    - description:
+      - "male (days)"
   - Time_spent_dealing_with_the_requirements_of_government_regulations_(%_of_senior_management_time):
-    - description: "Time spent dealing with the requirements of government regulations is the proportion of senior management's time"
+    - description:
+      - "Time spent dealing with the requirements of government regulations is the proportion of senior management's time"
   - Time_to_export_(days):
-    - description: "Time to export is the time necessary to comply with all procedures required to export goods. Time is recorded in calendar days. The time calculation for a procedure starts from the moment it is initiated and runs until it is completed. If a procedure can be accelerated for an additional cost"
+    - description:
+      - "Time to export is the time necessary to comply with all procedures required to export goods. Time is recorded in calendar days. The time calculation for a procedure starts from the moment it is initiated and runs until it is completed. If a procedure can be accelerated for an additional cost"
   - Time_to_export:
-    - description: "border compliance (hours)"
+    - description:
+      - "border compliance (hours)"
   - Time_to_export:
-    - description: "documentary compliance (hours)"
+    - description:
+      - "documentary compliance (hours)"
   - Time_to_import_(days):
-    - description: "Time to import is the time necessary to comply with all procedures required to import goods. Time is recorded in calendar days. The time calculation for a procedure starts from the moment it is initiated and runs until it is completed. If a procedure can be accelerated for an additional cost"
+    - description:
+      - "Time to import is the time necessary to comply with all procedures required to import goods. Time is recorded in calendar days. The time calculation for a procedure starts from the moment it is initiated and runs until it is completed. If a procedure can be accelerated for an additional cost"
   - Time_to_import:
-    - description: "border compliance (hours)"
+    - description:
+      - "border compliance (hours)"
   - Time_to_import:
-    - description: "documentary compliance (hours)"
+    - description:
+      - "documentary compliance (hours)"
   - Time_to_prepare_and_pay_taxes_(hours):
-    - description: "Time to prepare and pay taxes is the time"
+    - description:
+      - "Time to prepare and pay taxes is the time"
   - Time_to_resolve_insolvency_(years):
-    - description: "Time to resolve insolvency is the number of years from the filing for insolvency in court until the resolution of distressed assets."
+    - description:
+      - "Time to resolve insolvency is the number of years from the filing for insolvency in court until the resolution of distressed assets."
   - Total_alcohol_consumption_per_capita_(liters_of_pure_alcohol:
-    - description: "projected estimates"
+    - description:
+      - "projected estimates"
   - Total_amount_of_debt_rescheduled_(current_US$):
-    - description: "Total amount of debt rescheduled includes the debt stock"
+    - description:
+      - "Total amount of debt rescheduled includes the debt stock"
   - Total_change_in_external_debt_stocks_(current_US$):
-    - description: "Total change in debt stocks shows the variation in debt stock between two consecutive years. Data are in current U.S. dollars."
+    - description:
+      - "Total change in debt stocks shows the variation in debt stock between two consecutive years. Data are in current U.S. dollars."
   - Total_debt_service_(%_of_exports_of_goods:
-    - description: "services and primary income)"
+    - description:
+      - "services and primary income)"
   - Total_debt_service_(%_of_GNI):
-    - description: "Total debt service is the sum of principal repayments and interest actually paid in currency"
+    - description:
+      - "Total debt service is the sum of principal repayments and interest actually paid in currency"
   - Total_fisheries_production_(metric_tons):
-    - description: "Total fisheries production measures the volume of aquatic species caught by a country for all commercial"
+    - description:
+      - "Total fisheries production measures the volume of aquatic species caught by a country for all commercial"
   - Total_greenhouse_gas_emissions_(%_change_from_1990):
-    - description: "Total greenhouse gas emissions are composed of CO2 totals excluding short-cycle biomass burning (such as agricultural waste burning and Savannah burning) but including other biomass burning (such as forest fires"
+    - description:
+      - "Total greenhouse gas emissions are composed of CO2 totals excluding short-cycle biomass burning (such as agricultural waste burning and Savannah burning) but including other biomass burning (such as forest fires"
   - Total_greenhouse_gas_emissions_(kt_of_CO2_equivalent):
-    - description: "Total greenhouse gas emissions in kt of CO2 equivalent are composed of CO2 totals excluding short-cycle biomass burning (such as agricultural waste burning and Savannah burning) but including other biomass burning (such as forest fires"
+    - description:
+      - "Total greenhouse gas emissions in kt of CO2 equivalent are composed of CO2 totals excluding short-cycle biomass burning (such as agricultural waste burning and Savannah burning) but including other biomass burning (such as forest fires"
   - Total_natural_resources_rents_(%_of_GDP):
-    - description: "Total natural resources rents are the sum of oil rents"
+    - description:
+      - "Total natural resources rents are the sum of oil rents"
   - Total_reserves_(%_of_total_external_debt):
-    - description: "International reserves to total external debt stocks."
+    - description:
+      - "International reserves to total external debt stocks."
   - Total_reserves_(includes_gold:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Total_reserves_in_months_of_imports:
-    - description: "Total reserves comprise holdings of monetary gold"
+    - description:
+      - "Total reserves comprise holdings of monetary gold"
   - Total_reserves_minus_gold_(current_US$):
-    - description: "Total reserves minus gold comprise special drawing rights"
+    - description:
+      - "Total reserves minus gold comprise special drawing rights"
   - Total_tax_rate_(%_of_commercial_profits):
-    - description: "Total tax rate measures the amount of taxes and mandatory contributions payable by businesses after accounting for allowable deductions and exemptions as a share of commercial profits. Taxes withheld (such as personal income tax) or collected and remitted to tax authorities (such as value added taxes"
+    - description:
+      - "Total tax rate measures the amount of taxes and mandatory contributions payable by businesses after accounting for allowable deductions and exemptions as a share of commercial profits. Taxes withheld (such as personal income tax) or collected and remitted to tax authorities (such as value added taxes"
   - Trade_(%_of_GDP):
-    - description: "Trade is the sum of exports and imports of goods and services measured as a share of gross domestic product."
+    - description:
+      - "Trade is the sum of exports and imports of goods and services measured as a share of gross domestic product."
   - Trade_in_services_(%_of_GDP):
-    - description: "Trade in services is the sum of service exports and imports divided by the value of GDP"
+    - description:
+      - "Trade in services is the sum of service exports and imports divided by the value of GDP"
   - Trademark_applications:
-    - description: "direct nonresident"
+    - description:
+      - "direct nonresident"
   - Trademark_applications:
-    - description: "direct resident"
+    - description:
+      - "direct resident"
   - Trademark_applications:
-    - description: "nonresident"
+    - description:
+      - "nonresident"
   - Trademark_applications:
-    - description: "resident"
+    - description:
+      - "resident"
   - Trademark_applications:
-    - description: "total"
+    - description:
+      - "total"
   - Trained_teachers_in_lower_secondary_education_(%_of_total_teachers):
-    - description: "Trained teachers in lower secondary education are the percentage of lower secondary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
+    - description:
+      - "Trained teachers in lower secondary education are the percentage of lower secondary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
   - Trained_teachers_in_lower_secondary_education:
-    - description: "female (% of female teachers)"
+    - description:
+      - "female (% of female teachers)"
   - Trained_teachers_in_lower_secondary_education:
-    - description: "male (% of male teachers)"
+    - description:
+      - "male (% of male teachers)"
   - Trained_teachers_in_preprimary_education_(%_of_total_teachers):
-    - description: "Trained teachers in preprimary education are the percentage of preprimary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
+    - description:
+      - "Trained teachers in preprimary education are the percentage of preprimary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
   - Trained_teachers_in_preprimary_education:
-    - description: "female (% of female teachers)"
+    - description:
+      - "female (% of female teachers)"
   - Trained_teachers_in_preprimary_education:
-    - description: "male (% of male teachers)"
+    - description:
+      - "male (% of male teachers)"
   - Trained_teachers_in_primary_education_(%_of_total_teachers):
-    - description: "Trained teachers in primary education are the percentage of primary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
+    - description:
+      - "Trained teachers in primary education are the percentage of primary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
   - Trained_teachers_in_primary_education:
-    - description: "female (% of female teachers)"
+    - description:
+      - "female (% of female teachers)"
   - Trained_teachers_in_primary_education:
-    - description: "male (% of male teachers)"
+    - description:
+      - "male (% of male teachers)"
   - Trained_teachers_in_secondary_education_(%_of_total_teachers):
-    - description: "Trained teachers in secondary education are the percentage of secondary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
+    - description:
+      - "Trained teachers in secondary education are the percentage of secondary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
   - Trained_teachers_in_secondary_education:
-    - description: "female (% of female teachers)"
+    - description:
+      - "female (% of female teachers)"
   - Trained_teachers_in_secondary_education:
-    - description: "male (% of male teachers)"
+    - description:
+      - "male (% of male teachers)"
   - Trained_teachers_in_upper_secondary_education_(%_of_total_teachers):
-    - description: "Trained teachers in upper secondary education are the percentage of upper secondary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
+    - description:
+      - "Trained teachers in upper secondary education are the percentage of upper secondary school teachers who have received the minimum organized teacher training (pre-service or in-service) required for teaching in a given country."
   - Trained_teachers_in_upper_secondary_education:
-    - description: "female (% of female teachers)"
+    - description:
+      - "female (% of female teachers)"
   - Trained_teachers_in_upper_secondary_education:
-    - description: "male (% of male teachers)"
+    - description:
+      - "male (% of male teachers)"
   - Transport_services_(%_of_commercial_service_exports):
-    - description: "Transport services (% of commercial service exports) covers all transport services (sea"
+    - description:
+      - "Transport services (% of commercial service exports) covers all transport services (sea"
   - Transport_services_(%_of_commercial_service_imports):
-    - description: "Transport services (% of commercial service imports) covers all transport services (sea"
+    - description:
+      - "Transport services (% of commercial service imports) covers all transport services (sea"
   - Transport_services_(%_of_service_exports:
-    - description: "BoP)"
+    - description:
+      - "BoP)"
   - Transport_services_(%_of_service_imports:
-    - description: "BoP)"
+    - description:
+      - "BoP)"
   - Travel_services_(%_of_commercial_service_exports):
-    - description: "Travel services (% of commercial service exports) covers goods and services acquired from an economy by travelers in that economy for their own use during visits of less than one year for business or personal purposes. Travel services include the goods and services consumed by travelers"
+    - description:
+      - "Travel services (% of commercial service exports) covers goods and services acquired from an economy by travelers in that economy for their own use during visits of less than one year for business or personal purposes. Travel services include the goods and services consumed by travelers"
   - Travel_services_(%_of_commercial_service_imports):
-    - description: "Travel services (% of commercial service imports) covers goods and services acquired from an economy by travelers in that economy for their own use during visits of less than one year for business or personal purposes. Travel services include the goods and services consumed by travelers"
+    - description:
+      - "Travel services (% of commercial service imports) covers goods and services acquired from an economy by travelers in that economy for their own use during visits of less than one year for business or personal purposes. Travel services include the goods and services consumed by travelers"
   - Travel_services_(%_of_service_exports:
-    - description: "BoP)"
+    - description:
+      - "BoP)"
   - Travel_services_(%_of_service_imports:
-    - description: "BoP)"
+    - description:
+      - "BoP)"
   - Tuberculosis_case_detection_rate_(%:
-    - description: "all forms)"
+    - description:
+      - "all forms)"
   - Tuberculosis_treatment_success_rate_(%_of_new_cases):
-    - description: "Tuberculosis treatment success rate is the percentage of all new tuberculosis cases (or new and relapse cases for some countries) registered under a national tuberculosis control programme in a given year that successfully completed treatment"
+    - description:
+      - "Tuberculosis treatment success rate is the percentage of all new tuberculosis cases (or new and relapse cases for some countries) registered under a national tuberculosis control programme in a given year that successfully completed treatment"
   - UHC_service_coverage_index:
-    - description: "Coverage of essential health services (defined as the average coverage of essential services based on tracer interventions that include reproductive"
+    - description:
+      - "Coverage of essential health services (defined as the average coverage of essential services based on tracer interventions that include reproductive"
   - Undisbursed_external_debt:
-    - description: "official creditors (UND"
+    - description:
+      - "official creditors (UND"
   - Undisbursed_external_debt:
-    - description: "private creditors (UND"
+    - description:
+      - "private creditors (UND"
   - Undisbursed_external_debt:
-    - description: "total (UND"
+    - description:
+      - "total (UND"
   - Unemployment_with_advanced_education_(%_of_total_labor_force_with_advanced_education):
-    - description: "The percentage of the labor force with an advanced level of education who are unemployed. Advanced education comprises short-cycle tertiary education"
+    - description:
+      - "The percentage of the labor force with an advanced level of education who are unemployed. Advanced education comprises short-cycle tertiary education"
   - Unemployment_with_advanced_education:
-    - description: "female (% of female labor force with advanced education)"
+    - description:
+      - "female (% of female labor force with advanced education)"
   - Unemployment_with_advanced_education:
-    - description: "male (% of male labor force with advanced education)"
+    - description:
+      - "male (% of male labor force with advanced education)"
   - Unemployment_with_basic_education_(%_of_total_labor_force_with_basic_education):
-    - description: "The percentage of the labor force with a basic level of education who are unemployed. Basic education comprises primary education or lower secondary education according to the International Standard Classification of Education 2011 (ISCED 2011)."
+    - description:
+      - "The percentage of the labor force with a basic level of education who are unemployed. Basic education comprises primary education or lower secondary education according to the International Standard Classification of Education 2011 (ISCED 2011)."
   - Unemployment_with_basic_education:
-    - description: "female (% of female labor force with basic education)"
+    - description:
+      - "female (% of female labor force with basic education)"
   - Unemployment_with_basic_education:
-    - description: "male (% of male labor force with basic education)"
+    - description:
+      - "male (% of male labor force with basic education)"
   - Unemployment_with_intermediate_education_(%_of_total_labor_force_with_intermediate_education):
-    - description: "The percentage of the labor force with an intermediate level of education who are unemployed. Intermediate education comprises upper secondary or post-secondary non tertiary education according to the International Standard Classification of Education 2011 (ISCED 2011)."
+    - description:
+      - "The percentage of the labor force with an intermediate level of education who are unemployed. Intermediate education comprises upper secondary or post-secondary non tertiary education according to the International Standard Classification of Education 2011 (ISCED 2011)."
   - Unemployment_with_intermediate_education:
-    - description: "female (% of female labor force with intermediate education)"
+    - description:
+      - "female (% of female labor force with intermediate education)"
   - Unemployment_with_intermediate_education:
-    - description: "male (% of male labor force with intermediate education)"
+    - description:
+      - "male (% of male labor force with intermediate education)"
   - Unemployment:
-    - description: "female (% of female labor force) (modeled ILO estimate)"
+    - description:
+      - "female (% of female labor force) (modeled ILO estimate)"
   - Unemployment:
-    - description: "female (% of female labor force) (national estimate)"
+    - description:
+      - "female (% of female labor force) (national estimate)"
   - Unemployment:
-    - description: "male (% of male labor force) (modeled ILO estimate)"
+    - description:
+      - "male (% of male labor force) (modeled ILO estimate)"
   - Unemployment:
-    - description: "male (% of male labor force) (national estimate)"
+    - description:
+      - "male (% of male labor force) (national estimate)"
   - Unemployment:
-    - description: "total (% of total labor force) (modeled ILO estimate)"
+    - description:
+      - "total (% of total labor force) (modeled ILO estimate)"
   - Unemployment:
-    - description: "total (% of total labor force) (national estimate)"
+    - description:
+      - "total (% of total labor force) (national estimate)"
   - Unemployment:
-    - description: "youth female (% of female labor force ages 15-24) (modeled ILO estimate)"
+    - description:
+      - "youth female (% of female labor force ages 15-24) (modeled ILO estimate)"
   - Unemployment:
-    - description: "youth female (% of female labor force ages 15-24) (national estimate)"
+    - description:
+      - "youth female (% of female labor force ages 15-24) (national estimate)"
   - Unemployment:
-    - description: "youth male (% of male labor force ages 15-24) (modeled ILO estimate)"
+    - description:
+      - "youth male (% of male labor force ages 15-24) (modeled ILO estimate)"
   - Unemployment:
-    - description: "youth male (% of male labor force ages 15-24) (national estimate)"
+    - description:
+      - "youth male (% of male labor force ages 15-24) (national estimate)"
   - Unemployment:
-    - description: "youth total (% of total labor force ages 15-24) (modeled ILO estimate)"
+    - description:
+      - "youth total (% of total labor force ages 15-24) (modeled ILO estimate)"
   - Unemployment:
-    - description: "youth total (% of total labor force ages 15-24) (national estimate)"
+    - description:
+      - "youth total (% of total labor force ages 15-24) (national estimate)"
   - Unmet_need_for_contraception_(%_of_married_women_ages_15-49):
-    - description: "Unmet need for contraception is the percentage of fertile"
+    - description:
+      - "Unmet need for contraception is the percentage of fertile"
   - Urban_land_area_(sq._km):
-    - description: "Urban land area in square kilometers"
+    - description:
+      - "Urban land area in square kilometers"
   - Urban_land_area_where_elevation_is_below_5_meters_(%_of_total_land_area):
-    - description: "Urban land area below 5m is the percentage of total land where the urban land elevation is 5 meters or less."
+    - description:
+      - "Urban land area below 5m is the percentage of total land where the urban land elevation is 5 meters or less."
   - Urban_land_area_where_elevation_is_below_5_meters_(sq._km):
-    - description: "Urban land area below 5m is the total urban land area in square kilometers where the elevation is 5 meters or less."
+    - description:
+      - "Urban land area below 5m is the total urban land area in square kilometers where the elevation is 5 meters or less."
   - Urban_population:
-    - description: "Urban population refers to people living in urban areas as defined by national statistical offices. It is calculated using World Bank population estimates and urban ratios from the United Nations World Urbanization Prospects. Aggregation of urban and rural population may not add up to total population because of different country coverages."
+    - description:
+      - "Urban population refers to people living in urban areas as defined by national statistical offices. It is calculated using World Bank population estimates and urban ratios from the United Nations World Urbanization Prospects. Aggregation of urban and rural population may not add up to total population because of different country coverages."
   - Urban_population_(%_of_total):
-    - description: "Urban population refers to people living in urban areas as defined by national statistical offices. The data are collected and smoothed by United Nations Population Division."
+    - description:
+      - "Urban population refers to people living in urban areas as defined by national statistical offices. The data are collected and smoothed by United Nations Population Division."
   - Urban_population_growth_(annual_%):
-    - description: "Urban population refers to people living in urban areas as defined by national statistical offices. It is calculated using World Bank population estimates and urban ratios from the United Nations World Urbanization Prospects."
+    - description:
+      - "Urban population refers to people living in urban areas as defined by national statistical offices. It is calculated using World Bank population estimates and urban ratios from the United Nations World Urbanization Prospects."
   - Urban_population_living_in_areas_where_elevation_is_below_5_meters_(%_of_total_population):
-    - description: "Urban population below 5m is the percentage of the total population"
+    - description:
+      - "Urban population below 5m is the percentage of the total population"
   - Urban_poverty_gap_at_national_poverty_lines_(%):
-    - description: "Urban poverty gap at national poverty lines is the urban population's mean shortfall from the poverty lines (counting the nonpoor as having zero shortfall) as a percentage of the poverty lines. This measure reflects the depth of poverty as well as its incidence."
+    - description:
+      - "Urban poverty gap at national poverty lines is the urban population's mean shortfall from the poverty lines (counting the nonpoor as having zero shortfall) as a percentage of the poverty lines. This measure reflects the depth of poverty as well as its incidence."
   - Urban_poverty_headcount_ratio_at_national_poverty_lines_(%_of_urban_population):
-    - description: "Urban poverty headcount ratio is the percentage of the urban population living below the national poverty lines."
+    - description:
+      - "Urban poverty headcount ratio is the percentage of the urban population living below the national poverty lines."
   - Use_of_IMF_credit_(DOD:
-    - description: "current US$)"
+    - description:
+      - "current US$)"
   - Use_of_insecticide-treated_bed_nets_(%_of_under-5_population):
-    - description: "Use of insecticide-treated bed nets refers to the percentage of children under age five who slept under an insecticide-treated bednet to prevent malaria."
+    - description:
+      - "Use of insecticide-treated bed nets refers to the percentage of children under age five who slept under an insecticide-treated bednet to prevent malaria."
   - Value_lost_due_to_electrical_outages_(%_of_sales_for_affected_firms):
-    - description: "Average losses due to electrical outages"
+    - description:
+      - "Average losses due to electrical outages"
   - Vitamin_A_supplementation_coverage_rate_(%_of_children_ages_6-59_months):
-    - description: "Vitamin A supplementation refers to the percentage of children ages 6-59 months old who received at least two doses of vitamin A in the previous year."
+    - description:
+      - "Vitamin A supplementation refers to the percentage of children ages 6-59 months old who received at least two doses of vitamin A in the previous year."
   - Vulnerable_employment:
-    - description: "female (% of female employment) (modeled ILO estimate)"
+    - description:
+      - "female (% of female employment) (modeled ILO estimate)"
   - Vulnerable_employment:
-    - description: "male (% of male employment) (modeled ILO estimate)"
+    - description:
+      - "male (% of male employment) (modeled ILO estimate)"
   - Vulnerable_employment:
-    - description: "total (% of total employment) (modeled ILO estimate)"
+    - description:
+      - "total (% of total employment) (modeled ILO estimate)"
   - Wage_and_salaried_workers:
-    - description: "female (% of female employment) (modeled ILO estimate)"
+    - description:
+      - "female (% of female employment) (modeled ILO estimate)"
   - Wage_and_salaried_workers:
-    - description: "male (% of male employment) (modeled ILO estimate)"
+    - description:
+      - "male (% of male employment) (modeled ILO estimate)"
   - Wage_and_salaried_workers:
-    - description: "total (% of total employment) (modeled ILO estimate)"
+    - description:
+      - "total (% of total employment) (modeled ILO estimate)"
   - Wanted_fertility_rate_(births_per_woman):
-    - description: "Wanted fertility rate is an estimate of what the total fertility rate would be if all unwanted births were avoided."
+    - description:
+      - "Wanted fertility rate is an estimate of what the total fertility rate would be if all unwanted births were avoided."
   - Water_productivity:
-    - description: "total (constant 2010 US$ GDP per cubic meter of total freshwater withdrawal)"
+    - description:
+      - "total (constant 2010 US$ GDP per cubic meter of total freshwater withdrawal)"
   - Wholesale_price_index_(2010_=_100):
-    - description: "Wholesale price index refers to a mix of agricultural and industrial goods at various stages of production and distribution"
+    - description:
+      - "Wholesale price index refers to a mix of agricultural and industrial goods at various stages of production and distribution"
   - Women_making_their_own_informed_decisions_regarding_sexual_relations:
-    - description: "contraceptive use and reproductive health care  (% of women age 15-49)"
+    - description:
+      - "contraceptive use and reproductive health care  (% of women age 15-49)"
   - Women_participating_in_the_three_decisions_(own_health_care:
-    - description: "major household purchases"
+    - description:
+      - "major household purchases"
   - Women_who_believe_a_husband_is_justified_in_beating_his_wife_(any_of_five_reasons)_(%):
-    - description: "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner for any of the following five reasons: argues with him; refuses to have sex; burns the food; goes out without telling him; or when she neglects the children."
+    - description:
+      - "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner for any of the following five reasons: argues with him; refuses to have sex; burns the food; goes out without telling him; or when she neglects the children."
   - Women_who_believe_a_husband_is_justified_in_beating_his_wife_when_she_argues_with_him_(%):
-    - description: "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she argues with him."
+    - description:
+      - "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she argues with him."
   - Women_who_believe_a_husband_is_justified_in_beating_his_wife_when_she_burns_the_food_(%):
-    - description: "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she burns the food."
+    - description:
+      - "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she burns the food."
   - Women_who_believe_a_husband_is_justified_in_beating_his_wife_when_she_goes_out_without_telling_him_(%):
-    - description: "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she goes out without telling him."
+    - description:
+      - "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she goes out without telling him."
   - Women_who_believe_a_husband_is_justified_in_beating_his_wife_when_she_neglects_the_children_(%):
-    - description: "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she neglects the children."
+    - description:
+      - "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she neglects the children."
   - Women_who_believe_a_husband_is_justified_in_beating_his_wife_when_she_refuses_sex_with_him_(%):
-    - description: "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she refuses sex with him."
+    - description:
+      - "Percentage of women ages 15-49 who believe a husband/partner is justified in hitting or beating his wife/partner when she refuses sex with him."
   - Women_who_were_first_married_by_age_15_(%_of_women_ages_20-24):
-    - description: "Women who were first married by age 15 refers to the percentage of women ages 20-24 who were first married by age 15."
+    - description:
+      - "Women who were first married by age 15 refers to the percentage of women ages 20-24 who were first married by age 15."
   - Women_who_were_first_married_by_age_18_(%_of_women_ages_20-24):
-    - description: "Women who were first married by age 18 refers to the percentage of women ages 20-24 who were first married by age 18."
+    - description:
+      - "Women who were first married by age 18 refers to the percentage of women ages 20-24 who were first married by age 18."
   - Women's_share_of_population_ages_15+_living_with_HIV_(%):
-    - description: "Prevalence of HIV is the percentage of people who are infected with HIV. Female rate is as a percentage of the total population ages 15+ who are living with HIV."
+    - description:
+      - "Prevalence of HIV is the percentage of people who are infected with HIV. Female rate is as a percentage of the total population ages 15+ who are living with HIV."

--- a/src/main/resources/org/clulab/wm/eidos/wdi_ontology.yml
+++ b/src/main/resources/org/clulab/wm/eidos/wdi_ontology.yml
@@ -1522,7 +1522,7 @@
   - Land_under_cereal_production_(hectares):
     - description: "Land under cereal production refers to harvested area"
   - Law_mandates_equal_remuneration_for_females_and_males_for_work_of_equal_value_(1=yes;_0=no):
-    - description: "Law mandates equal remuneration for females and males for work of equal value is whether there is a law that obligates employers to pay equal remuneration to male and female employees who do work of equal value."Remuneration" refers to the ordinary"
+    - description: "Law mandates equal remuneration for females and males for work of equal value is whether there is a law that obligates employers to pay equal remuneration to male and female employees who do work of equal value.\"Remuneration\" refers to the ordinary"
   - Law_mandates_nondiscrimination_based_on_gender_in_hiring_(1=yes;_0=no):
     - description: "Law mandates nondiscrimination based on gender in hiring is whether the law specifically prevents or penalizes gender-based discrimination in the hiring process; the law may prohibit discrimination in employment on the basis of gender but be silent about whether job applicants are protected from discrimination. Hiring refers to the process of employing a person for wages and making a selection by presenting a candidate with a job offer. Job advertisements"
   - Law_mandates_paid_or_unpaid_maternity_leave_(1=yes;_0=no):
@@ -1970,7 +1970,7 @@
   - Nitrous_oxide_emissions_in_energy_sector_(thousand_metric_tons_of_CO2_equivalent):
     - description: "Nitrous oxide emissions from energy processes are emissions produced by the combustion of fossil fuels and biofuels."
   - Nondiscrimination_clause_mentions_gender_in_the_constitution_(1=yes;_0=no):
-    - description: "Nondiscrimination clause mentions gender in the constitution is whether there is a nondiscrimination clause in the constitution which mentions gender. For the answer to be "Yes"
+    - description: "Nondiscrimination clause mentions gender in the constitution is whether there is a nondiscrimination clause in the constitution which mentions gender. For the answer to be Yes"
   - Nonpregnant_and_nonnursing_women_can_do_the_same_jobs_as_men_(1=yes;_0=no):
     - description: "Non-pregnant and non-nursing women can do the same jobs as men indicates whether there are specific jobs that women explicitly or implicitly cannot perform except in limited circumstances. Both partial and full restrictions on women's work are counted as restrictions. For example"
   - Number_of_deaths_ages_5-14_years:

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -30,7 +30,8 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
   var word2vec = getArgBoolean(getFullName("useW2V"), Some(false)) // Turn this on and off here
   protected val wordToVec = EidosWordToVec(
     word2vec,
-    getPath("wordToVecPath", "/org/clulab/wm/eidos/w2v/vectors.txt"),
+//    getPath("wordToVecPath", "/org/clulab/wm/eidos/w2v/vectors.txt"),
+    getPath("wordToVecPath", "/org/clulab/wm/eidos/w2v/glove.840B.300d.txt"), // NOTE: Moving to GLoVE vectors
     getArgInt(getFullName("topKNodeGroundings"), Some(10))
   )
 

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -68,7 +68,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
 
     val domainOntologyPath: String = getPath("domainOntologyPath", "/org/clulab/wm/eidos/ontology.yml")
     val     unOntologyPath: String = getPath(    "unOntologyPath", "/org/clulab/wm/eidos/un_ontology.yml")
-    val    wdiOntologyPath: String = getPath(   "wdiOntologyPath", "/org/clulab/wm/wdi_ontology.yml")
+    val    wdiOntologyPath: String = getPath(   "wdiOntologyPath", "/org/clulab/wm/eidos/wdi_ontology.yml")
     val    faoOntologyPath: String = getPath(       "faoOntology", "/org/clulab/wm/eidos/fao_variable_ontology.yml")
 
     // These are needed to construct some of the loadable attributes even though it isn't a path itself.

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -18,9 +18,9 @@ trait MultiOntologyGrounder {
   def groundOntology(mention: EidosMention): Aliases.Groundings
 }
 
-class EidosOntologyGrounder(var name: String, domainOntoPath: String, wordToVec: EidosWordToVec, filterOnPos: Boolean) extends OntologyGrounder {
+class EidosOntologyGrounder(var name: String, ontologyPath: String, wordToVec: EidosWordToVec, filterOnPos: Boolean) extends OntologyGrounder {
   protected val conceptEmbeddings =
-      DomainOntology(FileUtils.loadYamlFromResource(domainOntoPath), filterOnPos).iterateOntology(wordToVec)
+      DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos).iterateOntology(wordToVec)
 
   def groundOntology(mention: EidosMention): OntologyGrounding = {
     if (mention.odinMention.matches("Entity")) { // TODO: Store this string somewhere
@@ -38,7 +38,7 @@ class EidosOntologyGrounder(var name: String, domainOntoPath: String, wordToVec:
 class DomainOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
     extends EidosOntologyGrounder(name, ontologyPath, wordToVec, filterOnPos = false) {
   // This is the default grounder for when no other is specified.
-  // It uses the file specified in domainOntologyPath.
+  // It uses the file stored in domainOntologyPath.
 }
 
 class UNOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
@@ -55,4 +55,3 @@ class FAOOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWo
     // Note: Filter on POS tags as they contain descriptions
     extends EidosOntologyGrounder(name, ontologyPath, wordToVec, filterOnPos = true) {
 }
-

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -18,8 +18,9 @@ trait MultiOntologyGrounder {
   def groundOntology(mention: EidosMention): Aliases.Groundings
 }
 
-class EidosOntologyGrounder(var name: String, domainOntoPath: String, wordToVec: EidosWordToVec) extends OntologyGrounder {
-  val conceptEmbeddings = EidosOntologyGrounder.getConceptEmbeddings(domainOntoPath, wordToVec)
+class EidosOntologyGrounder(var name: String, domainOntoPath: String, wordToVec: EidosWordToVec, filterOnPos: Boolean) extends OntologyGrounder {
+  protected val conceptEmbeddings =
+      DomainOntology(FileUtils.loadYamlFromResource(domainOntoPath), filterOnPos).iterateOntology(wordToVec)
 
   def groundOntology(mention: EidosMention): OntologyGrounding = {
     if (mention.odinMention.matches("Entity")) { // TODO: Store this string somewhere
@@ -35,45 +36,23 @@ class EidosOntologyGrounder(var name: String, domainOntoPath: String, wordToVec:
 }
 
 class DomainOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
-    extends EidosOntologyGrounder(name, ontologyPath, wordToVec) {
-  // Override methods here //todo: What is to be done here ? is this UN ontology or other ?
+    extends EidosOntologyGrounder(name, ontologyPath, wordToVec, filterOnPos = false) {
+  // This is the default grounder for when no other is specified.
+  // It uses the file specified in domainOntologyPath.
 }
 
 class UNOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
-    extends EidosOntologyGrounder(name, ontologyPath, wordToVec) {
-
-  def getConceptEmbeddings(ontologyPath: String, wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
-    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos = false) // Note: No need to filter on POS tags as they contain examples
-
-    ontology.iterateOntology(wordToVec)
-  }
+    // Note: No need to filter on POS tags as they contain examples
+    extends EidosOntologyGrounder(name, ontologyPath, wordToVec, filterOnPos = false) {
 }
 
 class WDIOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
-    extends EidosOntologyGrounder(name, ontologyPath, wordToVec) {
-
-  def getConceptEmbeddings(ontologyPath: String, wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
-    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos = true) // Note: Filter on POS tags as they contain descriptions
-
-    ontology.iterateOntology(wordToVec)
-  }
+    // Note: Filter on POS tags as they contain descriptions
+    extends EidosOntologyGrounder(name, ontologyPath, wordToVec, filterOnPos = true) {
 }
 
 class FAOOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
-    extends EidosOntologyGrounder(name, ontologyPath, wordToVec) {
-
-  def getConceptEmbeddings(ontologyPath: String, wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
-    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos = true) // Note: Filter on POS tags as they contain descriptions
-
-    ontology.iterateOntology(wordToVec)
-  }
+    // Note: Filter on POS tags as they contain descriptions
+    extends EidosOntologyGrounder(name, ontologyPath, wordToVec, filterOnPos = true) {
 }
 
-object EidosOntologyGrounder {
-
-  def getConceptEmbeddings(ontologyPath: String, wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
-    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos = false)
-
-    ontology.iterateOntology(wordToVec)
-  }
-}

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -31,7 +31,7 @@ class EidosOntologyGrounder(var name: String, ontologyPath: String, wordToVec: E
       OntologyGrounding(wordToVec.calculateSimilarities(canonicalNameParts, conceptEmbeddings))
     }
     else
-      OntologyGrounding(Seq.empty)
+      OntologyGrounding()
   }
 }
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -1,7 +1,7 @@
 package org.clulab.wm.eidos.groundings
 
 import org.clulab.wm.eidos.mentions.EidosMention
-import org.clulab.wm.eidos.utils.{DomainOntology, FileUtils, Sourcer}
+import org.clulab.wm.eidos.utils.{DomainOntology, FileUtils}
 
 object Aliases {
   type Grounding = Seq[(String, Double)]
@@ -36,28 +36,43 @@ class EidosOntologyGrounder(var name: String, domainOntoPath: String, wordToVec:
 
 class DomainOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
     extends EidosOntologyGrounder(name, ontologyPath, wordToVec) {
-  // Override methods here
+  // Override methods here //todo: What is to be done here ? is this UN ontology or other ?
 }
 
 class UNOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
     extends EidosOntologyGrounder(name, ontologyPath, wordToVec) {
-  // Override methods here
+
+  def getConceptEmbeddings(ontologyPath: String, wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
+    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos = false) // Note: No need to filter on POS tags as they contain examples
+
+    ontology.iterateOntology(wordToVec)
+  }
 }
 
 class WDIOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
     extends EidosOntologyGrounder(name, ontologyPath, wordToVec) {
-  // Override methods here
+
+  def getConceptEmbeddings(ontologyPath: String, wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
+    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos = true) // Note: Filter on POS tags as they contain descriptions
+
+    ontology.iterateOntology(wordToVec)
+  }
 }
 
 class FAOOntologyGrounder(name: String, ontologyPath: String, wordToVec: EidosWordToVec)
     extends EidosOntologyGrounder(name, ontologyPath, wordToVec) {
-  // Override methods here
+
+  def getConceptEmbeddings(ontologyPath: String, wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
+    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos = true) // Note: Filter on POS tags as they contain descriptions
+
+    ontology.iterateOntology(wordToVec)
+  }
 }
 
 object EidosOntologyGrounder {
 
   def getConceptEmbeddings(ontologyPath: String, wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
-    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath))
+    val ontology = DomainOntology(FileUtils.loadYamlFromResource(ontologyPath), filterOnPos = false)
 
     ontology.iterateOntology(wordToVec)
   }

--- a/src/main/scala/org/clulab/wm/eidos/utils/DomainOntology.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/DomainOntology.scala
@@ -2,12 +2,13 @@ package org.clulab.wm.eidos.utils
 
 import java.util.{Collection, Map => JMap}
 
+import org.clulab.processors.fastnlp.FastNLPProcessor
 import org.clulab.wm.eidos.groundings.EidosWordToVec
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-class DomainOntology(concepts: Map[String, Seq[String]]){
+class DomainOntology(concepts: Map[String, Seq[String]], filterOnPos: Boolean = false){
 
   def iterateOntology(wordToVec: EidosWordToVec): Map[String, Seq[Double]] = {
     for ((concept, examples) <- concepts) yield {
@@ -20,16 +21,25 @@ class DomainOntology(concepts: Map[String, Seq[String]]){
 object DomainOntology {
   val ROOT = ""
 
-  def apply(forest: Collection[Any]): DomainOntology = new DomainOntology(parseOntology(forest))
+  lazy val nlpProc = new FastNLPProcessor
 
-  def parseOntology (nodes: Collection[Any]): Map[String, Seq[String]] = {
+  def apply(forest: Collection[Any], filterOnPos: Boolean): DomainOntology = new DomainOntology(parseOntology(forest, filterOnPos))
+
+  def parseOntology (nodes: Collection[Any], filterOnPos: Boolean = false): Map[String, Seq[String]] = {
     val concepts = mutable.Map.empty[String, Seq[String]]
-    parseOntology(nodes.asScala.toSeq, "", Seq(), concepts)
+    parseOntology(nodes.asScala.toSeq, "", Seq(), concepts, filterOnPos)
+    // Following lines are for testing the creation of the ontology nodes. Can be removed later
+//    val x = concepts.toMap
+//    println("--------------------")
+//    for (k <- x.keys){
+//      println(s"${k} --> ${x.get(k).get.mkString(", ")}")
+//    }
+//    println("--------------------")
     concepts.toMap
   }
 
   // Note: modifying the odin.Taxonomy's mkParents() method
-  def parseOntology (nodes: Seq[Any], path: String, terms: Seq[Any], preTerminals: mutable.Map[String, Seq[String]]): Unit = nodes match {
+  def parseOntology (nodes: Seq[Any], path: String, terms: Seq[Any], preTerminals: mutable.Map[String, Seq[String]], filterOnPos: Boolean): Unit = nodes match {
     case Nil =>
       if (path.isEmpty || terms.length == 0) {
         return
@@ -38,7 +48,23 @@ object DomainOntology {
       preTerminals.put(path.asInstanceOf[String], terms.asInstanceOf[Seq[String]])
 
     case (term: String) +: tail =>
-      parseOntology(tail, path, terms ++ Seq(term), preTerminals)
+//      println(s"Sentence: ${term}")
+      if (filterOnPos){
+        val posString = nlpProc.annotate(term)
+        val filteredTerms = posString.sentences.flatMap{sent =>
+             sent.words.zip(sent.tags.get).filter{w => w._2.contains("NN") || //filter by POS tags which need to be kept (Nouns, Adjectives and Verbs)
+                                                       w._2.contains("JJ") ||
+                                                       w._2.contains("VB")}
+                                          .map(_._1) // get only the words
+        }
+//        println(s"Filtered Terms: ${filteredTerms.mkString(", ")}")
+        parseOntology(tail, path, terms ++ filteredTerms, preTerminals, filterOnPos)
+      }
+      else{
+        parseOntology(tail, path, terms ++ Seq(term), preTerminals, filterOnPos)
+      }
+
+
     case head +: tail =>
       val map = head.asInstanceOf[JMap[String, Collection[Any]]].asScala
       if (map.keys.size != 1) {
@@ -51,9 +77,9 @@ object DomainOntology {
           val msg = s"taxonomy term '$term' has no children (looks like an extra ':')"
           throw new Exception(msg)
         case Some(children) =>
-          parseOntology(children.asScala.toSeq, path+"/"+term, terms, preTerminals)
+          parseOntology(children.asScala.toSeq, path+"/"+term, terms, preTerminals, filterOnPos)
       }
-      parseOntology(tail, path, terms, preTerminals)
+      parseOntology(tail, path, terms, preTerminals, filterOnPos)
   }
 
 }


### PR DESCRIPTION
- Reading multiple ontologies slightly differently
- Ontologies with examples are read as before
- Ontologies with descriptions: filter the descriptions to contain only nouns, verbs and adjectives and then read as before. 

@kwalcock: Have not yet tested loading the fao_variable_ontology.yml . Can I run a specific test for this ? Also, I assume now the framework for grounding (with your new modifications) is able to create a HashMap [onto_name, [grounding_list] ]. I have not tested explicitly. 

Will replace the gigaword embeddings with GLoVE in a subsequent commit. 
