### PR TITLE
Checkbox to toggle debug/demo modes

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -139,7 +139,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
   }
 
   // MAIN PIPELINE METHOD
-  def extractFromText(text: String, keepText: Boolean = true, returnAllMentions: Boolean = false): AnnotatedDocument = {
+  def extractFromText(text: String, keepText: Boolean = true, cagRelevantOnly: Boolean = true): AnnotatedDocument = {
     val doc = annotate(text, keepText)
     val odinMentions = extractFrom(doc)
     // Dig in and get any Mentions that currently exist only as arguments, so that they get to be part of the state
@@ -159,7 +159,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Conf
 
 
     //println(s"\nodinMentions() -- entities : \n\t${odinMentions.map(m => m.text).sorted.mkString("\n\t")}")
-    val cagRelevant = if (returnAllMentions) mentionsAndNestedArgs else keepCAGRelevant(mentionsAndNestedArgs)
+    val cagRelevant = if (cagRelevantOnly) keepCAGRelevant(mentionsAndNestedArgs) else mentionsAndNestedArgs
     val eidosMentions = EidosMention.asEidosMentions(cagRelevant, loadableAttributes.stopwordManager, this)
 
     new AnnotatedDocument(doc, cagRelevant, eidosMentions)

--- a/src/main/scala/org/clulab/wm/eidos/utils/StopwordManager.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/StopwordManager.scala
@@ -24,6 +24,7 @@ class StopwordManager(stopwordsPath: String, transparentPath: String) extends St
     //println(s"Checking mention: ${mention.text}")
     lemmas.indices.exists { i =>
       isContentPOS(tags(i)) &&
+      tags(i) != "VBN" && // we don't want entities/concepts which consist ONLY of a VBN
       !containsStopword(lemmas(i)) &&
         !StopwordManager.STOP_POS.contains(tags(i)) &&
         !StopwordManager.STOP_NER.contains(entities(i))
@@ -31,6 +32,7 @@ class StopwordManager(stopwordsPath: String, transparentPath: String) extends St
   }
 
   def isContentPOS(tag: String): Boolean = StopwordManager.CONTENT_POS_PREFIXES.exists(prefix => tag.startsWith(prefix))
+
 
   def filterStopTransparent(mentions: Seq[Mention]): Seq[Mention] =
       // Remove mentions which are entirely stop/transparent words

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEidosMention.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEidosMention.scala
@@ -24,7 +24,7 @@ class TestEidosMention extends Test with StopwordManaging with MultiOntologyGrou
         println(text)
     }
 
-    val extractedOdinMentions = ieSystem.extractFromText(text, returnAllMentions = true).odinMentions
+    val extractedOdinMentions = ieSystem.extractFromText(text, cagRelevantOnly = false).odinMentions
     val reachableOdinMentions = EidosMention.findReachableMentions(extractedOdinMentions)
 
     {

--- a/src/test/scala/org/clulab/wm/eidos/test/TestUtils.scala
+++ b/src/test/scala/org/clulab/wm/eidos/test/TestUtils.scala
@@ -89,5 +89,5 @@ object TestUtils {
   
   lazy val ieSystem = new EidosSystem()
 
-  def extractMentions(text: String): Seq[Mention] = ieSystem.extractFromText(text, returnAllMentions = true).odinMentions
+  def extractMentions(text: String): Seq[Mention] = ieSystem.extractFromText(text, cagRelevantOnly = false).odinMentions
 }

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -45,8 +45,8 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   }
 
   // Entry method
-  def parseSentence(text: String) = Action {
-    val (doc, eidosMentions, groundedEntities, causalEvents) = processPlaySentence(ieSystem, text)
+  def parseSentence(text: String, cagRelevantOnly: Boolean) = Action {
+    val (doc, eidosMentions, groundedEntities, causalEvents) = processPlaySentence(ieSystem, text, cagRelevantOnly)
     println(s"Sentence returned from processPlaySentence : ${doc.sentences.head.getSentenceText()}")
     val json = mkJson(text, doc, eidosMentions, groundedEntities, causalEvents) // we only handle a single sentence
     Ok(json)
@@ -55,7 +55,8 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
   // Method where eidos happens!
   def processPlaySentence(
     ieSystem: EidosSystem,
-    text: String): (Document, Vector[EidosMention], Vector[GroundedEntity], Vector[(Trigger, Map[String, String])]) = {
+    text: String,
+    cagRelevantOnly: Boolean): (Document, Vector[EidosMention], Vector[GroundedEntity], Vector[(Trigger, Map[String, String])]) = {
 
     // preprocessing
     println(s"Processing sentence : ${text}" )
@@ -64,7 +65,7 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
     // Debug
     println(s"DOC : ${doc}")
     // extract mentions from annotated document
-    val annotatedDocument = ieSystem.extractFromText(text, returnAllMentions = false)
+    val annotatedDocument = ieSystem.extractFromText(text, cagRelevantOnly = cagRelevantOnly)
     val mentions = annotatedDocument.eidosMentions.sortBy(m => (m.odinMention.sentence, m.getClass.getSimpleName)).toVector
 
 

--- a/webapp/app/views/index.scala.html
+++ b/webapp/app/views/index.scala.html
@@ -22,6 +22,7 @@
             <textarea name="text" rows="5" cols="120"></textarea>
             <br />
             <input type="submit">
+            <input type="checkbox" name="cagRelevantOnly" value="cagRelevantOnly">Show CAG relevant only<br>
         </form>
 
         <div id="eidosMentions"></div>

--- a/webapp/conf/routes
+++ b/webapp/conf/routes
@@ -5,7 +5,7 @@
 
 # An example controller showing a sample home page
 GET     /                           controllers.HomeController.index
-GET     /parseSentence              controllers.HomeController.parseSentence(sent: String)
+GET     /parseSentence              controllers.HomeController.parseSentence(sent: String, cagRelevantOnly: Boolean)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)

--- a/webapp/public/javascripts/main.js
+++ b/webapp/public/javascripts/main.js
@@ -388,7 +388,8 @@ head.ready(function() {
 
         // collect form data
         var formData = {
-            'sent': $('textarea[name=text]').val()
+            'sent': $('textarea[name=text]').val(),
+            'cagRelevantOnly': $('input[name=cagRelevantOnly]').is(':checked')
         }
 
         if (!formData.sent.trim()) {


### PR DESCRIPTION
Previously we were showing all concepts in the webapp bc it's primarily a debug tool.  But, when we demo, it begs the question "Why are you getting that???" 
So -- now this is optional.

I also added a constraint to require that a concept must contain something besides just a VBN (helps prevent "adjectivey" only concepts)

Minor change:
 - I rearranged the order of some methods in HomeController, and to make things semantically cleaner I swapped the polarity of the boolean for filtering CAG relevant in the EidosSystem extractFromText method

closes #375 