### PR TITLE
Expand better

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
@@ -12,7 +12,7 @@ import org.yaml.snakeyaml.constructor.Constructor
 
 import scala.annotation.tailrec
 import utils.DisplayUtils.{displayMention, shortDisplay}
-import EidosActions.{INVALID_INCOMING, INVALID_OUTGOING, VALID_OUTGOING}
+import EidosActions.{INVALID_INCOMING, INVALID_OUTGOING, VALID_INCOMING, VALID_OUTGOING}
 import org.clulab.wm.eidos.entities.{EntityConstraints, EntityHelper}
 
 import scala.collection.mutable.{Set => MutableSet}
@@ -566,8 +566,10 @@ class EidosActions(val taxonomy: Taxonomy) extends Actions with LazyLogging {
   //-- Entity expansion methods (brought in from EntityFinder)
   def expand(entity: Mention, maxHops: Int, stateFromAvoid: State): Mention = {
     val interval = traverseOutgoingLocal(entity, maxHops, stateFromAvoid, entity.sentenceObj)
-    val res = entity.asInstanceOf[TextBoundMention].copy(tokenInterval = interval)
-    res
+    val outgoingExpanded = entity.asInstanceOf[TextBoundMention].copy(tokenInterval = interval)
+    val interval2 = traverseIncomingLocal(outgoingExpanded, maxHops, stateFromAvoid, entity.sentenceObj)
+    val incomingExpanded = outgoingExpanded.asInstanceOf[TextBoundMention].copy(tokenInterval = interval2)
+    incomingExpanded
   }
 
 
@@ -605,6 +607,39 @@ class EidosActions(val taxonomy: Taxonomy) extends Actions with LazyLogging {
     traverseOutgoingLocal(Set.empty, m.tokenInterval.toSet, outgoingRelations = outgoing, incomingRelations = incoming, numHops, m.sentence, stateFromAvoid, sentence)
   }
 
+  /** Used by expand to selectively traverse the provided syntactic dependency graph **/
+  @tailrec
+  private def traverseIncomingLocal(
+                                     tokens: Set[Int],
+                                     newTokens: Set[Int],
+                                     incomingRelations: Array[Array[(Int, String)]],
+                                     remainingHops: Int,
+                                     sent: Int,
+                                     state: State,
+                                     sentence: Sentence
+
+                                   ): Interval = {
+    if (remainingHops == 0) {
+      val allTokens = tokens ++ newTokens
+      Interval(allTokens.min, allTokens.max + 1)
+    } else {
+      val newNewTokens = for{
+        tok <- newTokens
+        if incomingRelations.nonEmpty && tok < incomingRelations.length
+        (nextTok, dep) <- incomingRelations(tok)
+        if isValidIncomingDependency(dep)
+        if state.mentionsFor(sent, nextTok).isEmpty
+      } yield nextTok
+      traverseIncomingLocal(tokens ++ newTokens, newNewTokens, incomingRelations, remainingHops - 1, sent, state, sentence)
+    }
+  }
+  private def traverseIncomingLocal(m: Mention, numHops: Int, stateFromAvoid: State, sentence: Sentence): Interval = {
+    val incoming = incomingEdges(m.sentenceObj)
+    traverseIncomingLocal(Set.empty, m.tokenInterval.toSet, incomingRelations = incoming, numHops, m.sentence, stateFromAvoid, sentence)
+  }
+
+
+
   def outgoingEdges(s: Sentence): Array[Array[(Int, String)]] = s.dependencies match {
     case None => sys.error("sentence has no dependencies")
     case Some(dependencies) => dependencies.outgoingEdges
@@ -626,6 +661,11 @@ class EidosActions(val taxonomy: Taxonomy) extends Actions with LazyLogging {
       )
   }
 
+  /** Ensure incoming dependency may be safely traversed */
+  def isValidIncomingDependency(dep: String): Boolean = {
+    VALID_INCOMING.exists(pattern => pattern.findFirstIn(dep).nonEmpty)
+  }
+
   def notInvalidConjunction(dep: String, hopsRemaining: Int): Boolean = {
     // If it's not a coordination/conjunction, don't worry
     if (EntityConstraints.COORD_DEPS.exists(pattern => pattern.findFirstIn(dep).isEmpty)) {
@@ -638,10 +678,6 @@ class EidosActions(val taxonomy: Taxonomy) extends Actions with LazyLogging {
 
     false
   }
-
-//  def isValidOutgoingDependency(dep: String, token: String, hopsRemaining: Int): Boolean = {
-//    isValidOutgoingDependency(dep, token) //&& notInvalidConjunction(dep, hopsRemaining)
-//  }
 
   /** Ensure current token does not have any incoming dependencies that are invalid **/
   def hasValidIncomingDependencies(tokenIdx: Int, incomingDependencies: Array[Array[(Int, String)]]): Boolean = {
@@ -696,6 +732,10 @@ object EidosActions extends Actions {
 //    //    "case".r
 //    "^ccomp".r
     ".+".r
+  )
+
+  val VALID_INCOMING = Set[scala.util.matching.Regex](
+    "^compound$".r
   )
 
 

--- a/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
@@ -735,6 +735,7 @@ object EidosActions extends Actions {
   )
 
   val VALID_INCOMING = Set[scala.util.matching.Regex](
+    "^amod$".r,
     "^compound$".r
   )
 

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEntityFinder.scala
@@ -12,11 +12,15 @@ class TestEntityFinder extends Test {
   }
 
   "JJ entity" should "only be kept if following word was avoided as a trigger" in {
-    val text1 = "some economic caused the recession."
+    // Note -- this is a fake verb bc to test what the entityfinder is returning we don't want to trigger
+    // the argument expansion
+    val text1 = "some economic blarged the recession."
     val mentions1 = extractMentions(text1)
     mentions1.exists(_.text == "economic") should be (false)
 
-    val text2 = "some economic declines caused the recession."
+    // Note -- this is a fake verb bc to test what the entityfinder is returning we don't want to trigger
+    // the argument expansion
+    val text2 = "some economic declines blarged the recession."
     val mentions2 = extractMentions(text2)
     mentions2.exists(_.text == "economic") should be (true)
   }

--- a/src/test/scala/org/clulab/wm/eidos/system/TestGlobalAction.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestGlobalAction.scala
@@ -10,7 +10,7 @@ class TestGlobalAction extends Test {
 
     val tester = new Tester(text)
   
-    val rainfall = NodeSpec("rainfall", Dec("reduction"), Dec("deficits"))
+    val rainfall = NodeSpec("rainfall deficits", Dec("reduction"), Dec("deficits"))
 
     behavior of "a sentence requiring global action"
 

--- a/src/test/scala/org/clulab/wm/eidos/text/cag/TestCagP2.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/cag/TestCagP2.scala
@@ -44,9 +44,9 @@ class TestCagP2 extends Test {
   
     val conflict = NodeSpec("Conflict")
     val insecurity = NodeSpec("insecurity")
-    val marketDisruption = NodeSpec("market", Dec("disruption")) //newNodeSpec("market disruption")
-    val economic = NodeSpec("economic", Dec("downturn"))
-    val cropFailure = NodeSpec("localized crop", Dec("failures"))
+    val marketDisruption = NodeSpec("market disruption", Dec("disruption")) //newNodeSpec("market disruption")
+    val economic = NodeSpec("economic downturn", Dec("downturn"))
+    val cropFailure = NodeSpec("localized crop failures", Dec("failures"))
     val foodPrices = NodeSpec("record high food prices", Inc("high"), Quant("high", "record"))
     val hunger = NodeSpec("hunger", Inc("spread"))
 
@@ -76,7 +76,7 @@ class TestCagP2 extends Test {
     val tester = new Tester(p2s3)
 
     val conflict = NodeSpec("Conflict")
-    val economic = NodeSpec("economic", Dec("decline"))
+    val economic = NodeSpec("economic decline", Dec("decline"))
     val violence = NodeSpec("violence")
     val displacement = NodeSpec("displacement")
 

--- a/src/test/scala/org/clulab/wm/eidos/text/cag/TestCagP3.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/cag/TestCagP3.scala
@@ -41,7 +41,7 @@ class TestCagP3 extends Test {
    // tester.mentions.foreach(m => println("\t" + m.text))
 
     val impacts = NodeSpec("impacts of flooding")
-    val economic = NodeSpec("economic", Dec("collapse"))
+    val economic = NodeSpec("economic collapse", Dec("collapse"))
     val conflict = NodeSpec("conflict")
     val production = NodeSpec("agricultural production", Dec("reduced"))
     val insecurity = NodeSpec("2017, food insecurity in Unity, Jonglei and parts of Greater Equatoria and Greater Bahr el Ghazal remained critical", Quant("critical"))

--- a/src/test/scala/org/clulab/wm/eidos/text/eval6/TestDoc3.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/eval6/TestDoc3.scala
@@ -313,7 +313,7 @@ class TestDoc3 extends Test {
     val worm = NodeSpec("impact of Fall Armyworm, for which infestations have been reported in six regions of Ethiopia", Dec("reduce"))
     val rainfall4 = NodeSpec("Rainfall", Quant("moderate to heavy"))
     val flood2 = NodeSpec("potential for flooding")
-    val rainfallDeficit = NodeSpec("rainfall", Dec("deficits"), Dec("erase"))
+    val rainfallDeficit = NodeSpec("rainfall deficits", Dec("deficits"), Dec("erase"))
 
     // tests here
     passingTest should "have correct edges 1" taggedAs(Zheng) in {

--- a/src/test/scala/org/clulab/wm/eidos/text/eval6/TestDoc8.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/eval6/TestDoc8.scala
@@ -227,7 +227,7 @@ class TestDoc8 extends Test {
 
     val econCrisis = NodeSpec("Economic crisis")
     val hyperinflation = NodeSpec("drastic hyperinflation", Quant("drastic"))
-    val marketFailures = NodeSpec("market", Dec("failures"))
+    val marketFailures = NodeSpec("market failures", Dec("failures"))
     val foodSystems = NodeSpec("food systems", Dec("destabilised"))
     val accessToFood = NodeSpec("household access to food", Dec("destabilised"))
     val income = NodeSpec("income", Dec("destabilised"))

--- a/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/raps/TestRaps1.scala
@@ -79,7 +79,7 @@ class TestRaps1 extends Test {
     val sent23 = "The transformation however starts under extremely difficult conditions, characterized by large account deficit and liquidity challenges and limited direct foreign investment due to lack of clarity on investment security and high interest rates."
     val tester = new Tester(sent23)
 
-    val account = NodeSpec("account", Dec("deficit", "large"), Quant("large"))
+    val account = NodeSpec("account deficit", Dec("deficit", "large"), Quant("large"))
     val invest = NodeSpec("limited direct foreign investment", Dec("limited"))
     val noClarity = NodeSpec("clarity", Dec("lack"))
     val interestRates = NodeSpec("interest rates", Quant("high"), Inc("high"))


### PR DESCRIPTION
Improving entities -- by allowing to expand on incoming `compound` and `amod` we can recapture the whole NP chunk (which was prevented in the current entityfinder bc we are avoiding triggers).  If we remove the reliance on avoiding in the EntityFinder, this will not be necessary, but until then...

Updated tests to match.

Example of change:
OLD:
<img width="558" alt="image" src="https://user-images.githubusercontent.com/5384073/44997053-60c45180-af60-11e8-930f-928fb6229861.png">

NEW:
<img width="635" alt="image" src="https://user-images.githubusercontent.com/5384073/44997033-4be7be00-af60-11e8-9ead-1d7972fa0698.png">
