### PR TITLE
Canonicalize texts and ontology nodes the same way

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ language: scala
 scala:
   - 2.12.4
   - 2.11.11
-before_cache:
-  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-cache:
-  directories:
-    - $HOME/.gradle/caches/
-    - $HOME/.gradle/wrapper/
-    - $HOME/.ivy2
-    - $HOME/.m2
-    - $HOME/.sbt
+#before_cache:
+#  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+#  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+#cache:
+#  directories:
+#    - $HOME/.gradle/caches/
+#    - $HOME/.gradle/wrapper/
+#    - $HOME/.ivy2
+#    - $HOME/.m2
+#    - $HOME/.sbt

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -238,7 +238,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Stop
   def populateSameAsRelations(ms: Seq[Mention]): Seq[Mention] = {
 
     // Create an UndirectedRelation Mention to contain the sameAs grounding information
-    def sameAs(a: Mention, b: Mention, score: Double): Mention = {
+    def sameAs(a: Mention, b: Mention, score: Float): Mention = {
       // Build a Relation Mention (no trigger)
       new CrossSentenceMention(
         labels = Seq("SameAs"),
@@ -338,7 +338,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Stop
   /*
       Wrapper for using w2v on some strings
    */
-  def stringSimilarity(string1: String, string2: String): Double = wordToVec.stringSimilarity(string1, string2)
+  def stringSimilarity(string1: String, string2: String): Float = wordToVec.stringSimilarity(string1, string2)
 
   /*
      Debugging Methods

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -97,14 +97,16 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Stop
     def useTimeNorm: Boolean = eidosConf[Boolean]("useTimeNorm")
     def    useCache: Boolean = eidosConf[Boolean]("useCache")
 
+    val canonicalizer = new Canonicalizer(EidosSystem.this)
+
     protected def mkDomainOntology(name: String): DomainOntology = {
       val serializedPath: String = DomainOntologies.serializedPath(name, cacheDir)
 
       name match {
-        case   UN_NAMESPACE =>   UNOntology(  unOntologyPath, serializedPath, proc, useCache = useCache)
-        case  WDI_NAMESPACE =>  WDIOntology( wdiOntologyPath, serializedPath, proc, useCache = useCache)
-        case  FAO_NAMESPACE =>  FAOOntology( faoOntologyPath, serializedPath, proc, useCache = useCache)
-        case MESH_NAMESPACE => MeshOntology(meshOntologyPath, serializedPath, proc, useCache = useCache)
+        case   UN_NAMESPACE =>   UNOntology(  unOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
+        case  WDI_NAMESPACE =>  WDIOntology( wdiOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
+        case  FAO_NAMESPACE =>  FAOOntology( faoOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
+        case MESH_NAMESPACE => MeshOntology(meshOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
         case _ => throw new IllegalArgumentException("Ontology " + name + " is not recognized.")
       }
     }
@@ -201,7 +203,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Stop
 
     //println(s"\nodinMentions() -- entities : \n\t${odinMentions.map(m => m.text).sorted.mkString("\n\t")}")
     val cagRelevant = if (cagRelevantOnly) keepCAGRelevant(mentionsAndNestedArgs) else mentionsAndNestedArgs
-    val eidosMentions = EidosMention.asEidosMentions(cagRelevant, loadableAttributes.stopwordManager, this)
+    val eidosMentions = EidosMention.asEidosMentions(cagRelevant, new Canonicalizer(loadableAttributes.stopwordManager), this)
 
     new AnnotatedDocument(doc, cagRelevant, eidosMentions)
   }

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -97,7 +97,8 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Stop
     def useTimeNorm: Boolean = eidosConf[Boolean]("useTimeNorm")
     def    useCache: Boolean = eidosConf[Boolean]("useCache")
 
-    val canonicalizer = new Canonicalizer(EidosSystem.this)
+    val stopwordManager = StopwordManager(stopwordsPath, transparentPath)
+    val canonicalizer = new Canonicalizer(stopwordManager)
 
     protected def mkDomainOntology(name: String): DomainOntology = {
       val serializedPath: String = DomainOntologies.serializedPath(name, cacheDir)
@@ -142,7 +143,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Stop
 //        ExtractorEngine(masterRules, actions, actions.mergeAttachments), // ODIN component
         ExtractorEngine(masterRules, actions, actions.globalAction), // ODIN component
         LexiconNER(Seq(quantifierPath), caseInsensitiveMatching = true), //TODO: keep Quantifier...
-        StopwordManager(stopwordsPath, transparentPath),
+        stopwordManager,
         ontologyGrounders,
         timenorm
       )

--- a/src/main/scala/org/clulab/wm/eidos/apps/CacheOntologies.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/CacheOntologies.scala
@@ -7,6 +7,7 @@ import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.groundings.CompactDomainOntology.CompactDomainOntologyBuilder
 import org.clulab.wm.eidos.groundings.EidosOntologyGrounder.{FAO_NAMESPACE, MESH_NAMESPACE, UN_NAMESPACE, WDI_NAMESPACE}
 import org.clulab.wm.eidos.groundings._
+import org.clulab.wm.eidos.utils.Canonicalizer
 
 object CacheOntologies extends App {
 
@@ -23,16 +24,17 @@ object CacheOntologies extends App {
     throw new RuntimeException("No ontologies were specified, please check the config file.")
   else {
     val proc = reader.proc
+    val canonicalizer = new Canonicalizer(reader)
 
     println(s"Saving ontologies to $cacheDir...")
     ontologies.foreach { domainOntology =>
       val serializedPath = DomainOntologies.serializedPath(domainOntology, cacheDir)
 
       val ontology: DomainOntology = domainOntology match {
-        case   UN_NAMESPACE =>   UNOntology(loadableAttributes.unOntologyPath,   serializedPath, proc, useCache = false)
-        case  WDI_NAMESPACE =>  WDIOntology(loadableAttributes.wdiOntologyPath,  serializedPath, proc, useCache = false)
-        case  FAO_NAMESPACE =>  FAOOntology(loadableAttributes.faoOntologyPath,  serializedPath, proc, useCache = false)
-        case MESH_NAMESPACE => MeshOntology(loadableAttributes.meshOntologyPath, serializedPath, proc, useCache = false)
+        case   UN_NAMESPACE =>   UNOntology(loadableAttributes.unOntologyPath,   serializedPath, proc, canonicalizer, useCache = false)
+        case  WDI_NAMESPACE =>  WDIOntology(loadableAttributes.wdiOntologyPath,  serializedPath, proc, canonicalizer, useCache = false)
+        case  FAO_NAMESPACE =>  FAOOntology(loadableAttributes.faoOntologyPath,  serializedPath, proc, canonicalizer, useCache = false)
+        case MESH_NAMESPACE => MeshOntology(loadableAttributes.meshOntologyPath, serializedPath, proc, canonicalizer, useCache = false)
         case _ => throw new IllegalArgumentException("Ontology " + domainOntology + " is not recognized.")
       }
       val treeDomainOntology = ontology.asInstanceOf[TreeDomainOntology]

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExampleGenerator.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExampleGenerator.scala
@@ -3,6 +3,7 @@ package org.clulab.wm.eidos.apps
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.mentions.{EidosMention, EidosTextBoundMention}
 import org.clulab.wm.eidos.serialization.json.WMJSONSerializer
+import org.clulab.wm.eidos.utils.Canonicalizer
 import org.clulab.wm.eidos.utils.DisplayUtils.{displayMention, displayMentions}
 import org.json4s.jackson.JsonMethods._
 
@@ -20,7 +21,7 @@ object ExampleGenerator extends App {
 
   // extract mentions from annotated document
   val mentions = ieSystem.extractFrom(doc).sortBy(m => (m.sentence, m.getClass.getSimpleName))
-  val eidosMentions = EidosMention.asEidosMentions(mentions, ieSystem, ieSystem)
+  val eidosMentions = EidosMention.asEidosMentions(mentions, new Canonicalizer(ieSystem), ieSystem)
 
   // Display the groundings for all entities
   for (e <- eidosMentions.filter(_.odinMention matches "Entity")) {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/ConceptEmbedding.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/ConceptEmbedding.scala
@@ -3,4 +3,4 @@ package org.clulab.wm.eidos.groundings
 import org.clulab.wm.eidos.utils.Namer
 
 @SerialVersionUID(1000L)
-case class ConceptEmbedding(var namer: Namer, embedding: Array[Double]) extends Serializable
+case class ConceptEmbedding(var namer: Namer, embedding: Array[Float]) extends Serializable

--- a/src/main/scala/org/clulab/wm/eidos/groundings/DomainOntologies.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/DomainOntologies.scala
@@ -1,8 +1,8 @@
 package org.clulab.wm.eidos.groundings
 
 import org.clulab.processors.Processor
-import org.clulab.wm.eidos.groundings.CompactDomainOntology.CompactDomainOntologyBuilder
 import org.clulab.wm.eidos.groundings.TreeDomainOntology.TreeDomainOntologyBuilder
+import org.clulab.wm.eidos.utils.Canonicalizer
 import org.slf4j.LoggerFactory
 
 object DomainOntologies {
@@ -10,40 +10,40 @@ object DomainOntologies {
 
   def serializedPath(name: String, dir: String): String = s"$dir/$name.serialized"
 
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, filter: Boolean = true, useCache: Boolean = false): DomainOntology = {
+  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false): DomainOntology = {
     if (useCache) {
       logger.info(s"Processing cached yml ontology ${serializedPath}...")
       CompactDomainOntology.load(serializedPath)
     }
     else {
       logger.info(s"Processing yml ontology ${ontologyPath}..")
-      new TreeDomainOntologyBuilder(ontologyPath, proc, filter).build()
+      new TreeDomainOntologyBuilder(ontologyPath, proc, canonicalizer, filter).build()
     }
   }
 }
 
 // These are just here for when behavior might have to start differing.
 object UNOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, filter, useCache)
+  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
+      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
 }
 
 object WDIOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, filter, useCache)
+  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
+      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
 }
 
 object FAOOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, filter, useCache)
+  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
+      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
 }
 
 object TopoFlowOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, filter, useCache)
+  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
+      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
 }
 
 object MeshOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, filter, useCache)
+  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
+      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
 }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
@@ -45,9 +45,11 @@ class RealWordToVec(var w2v: CompactWord2Vec, topKNodeGroundings: Int) extends E
 
   def dotProduct(v1: Array[Float], v2: Array[Float]): Float = {
     assert(v1.length == v2.length) //should we always assume that v2 is longer? perhaps set shorter to length of longer...
+    // This would be way prettier, but it is ~20 times slower
+    // v1.indices.foldRight(0.0f)((i, sum) => sum + v1(i) * v2(i))
     var sum = 0.0f
     var i = 0
-    while(i < v1.length) {
+    while (i < v1.length) {
       sum += v1(i) * v2(i)
       i += 1
     }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
@@ -3,39 +3,38 @@ package org.clulab.wm.eidos.groundings
 import org.clulab.embeddings.word2vec.Word2Vec
 import org.clulab.odin.Mention
 import org.clulab.wm.eidos.utils.Namer
-import org.clulab.wm.eidos.utils.Sourcer
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 trait EidosWordToVec {
-  type Similarities = Seq[(Namer, Double)]
+  type Similarities = Seq[(Namer, Float)]
 
-  def stringSimilarity(string1: String, string2: String): Double
-  def calculateSimilarity(mention1: Mention, mention2: Mention): Double
+  def stringSimilarity(string1: String, string2: String): Float
+  def calculateSimilarity(mention1: Mention, mention2: Mention): Float
   def calculateSimilarities(canonicalNameParts: Array[String], conceptEmbeddings: Seq[ConceptEmbedding]): Similarities
-  def makeCompositeVector(t:Iterable[String]): Array[Double]
+  def makeCompositeVector(t:Iterable[String]): Array[Float]
 }
 
 class FakeWordToVec extends EidosWordToVec {
 
-  override def stringSimilarity(string1: String, string2: String): Double =
+  override def stringSimilarity(string1: String, string2: String): Float =
     throw new RuntimeException("Word2Vec wasn't loaded, please check configurations.")
 
-  def calculateSimilarity(mention1: Mention, mention2: Mention): Double = 0
+  def calculateSimilarity(mention1: Mention, mention2: Mention): Float = 0
 
   def calculateSimilarities(canonicalNameParts: Array[String], conceptEmbeddings: Seq[ConceptEmbedding]): Similarities = Seq.empty
-//  def calculateSimilarities(canonicalNameParts: Array[String], conceptEmbeddings: ConceptEmbeddings): Seq[(String, Double)] = Seq(("hello", 5.0d))
+//  def calculateSimilarities(canonicalNameParts: Array[String], conceptEmbeddings: ConceptEmbeddings): Seq[(String, Float)] = Seq(("hello", 5.0f))
 
-  def makeCompositeVector(t:Iterable[String]): Array[Double] = Array.emptyDoubleArray
+  def makeCompositeVector(t:Iterable[String]): Array[Float] = Array.emptyFloatArray
 }
 
 class RealWordToVec(var w2v: CompactWord2Vec, topKNodeGroundings: Int) extends EidosWordToVec {
 
   protected def split(string: String): Array[String] = string.split(" +")
 
-  def stringSimilarity(string1: String, string2: String): Double =
+  def stringSimilarity(string1: String, string2: String): Float =
       w2v.avgSimilarity(split(string1), split(string2))
 
-  def calculateSimilarity(mention1: Mention, mention2: Mention): Double = {
+  def calculateSimilarity(mention1: Mention, mention2: Mention): Float = {
     // avgSimilarity does sanitizeWord itself, so it is unnecessary here.
     val sanitisedM1 =  split(mention1.text)
     val sanitisedM2 =  split(mention2.text)
@@ -43,7 +42,18 @@ class RealWordToVec(var w2v: CompactWord2Vec, topKNodeGroundings: Int) extends E
     
     similarity
   }
-  
+
+  def dotProduct(v1: Array[Float], v2: Array[Float]): Float = {
+    assert(v1.length == v2.length) //should we always assume that v2 is longer? perhaps set shorter to length of longer...
+    var sum = 0.0f
+    var i = 0
+    while(i < v1.length) {
+      sum += v1(i) * v2(i)
+      i += 1
+    }
+    sum
+  }
+
   def calculateSimilarities(canonicalNameParts: Array[String], conceptEmbeddings: Seq[ConceptEmbedding]): Similarities = {
     val sanitizedNameParts = canonicalNameParts.map(Word2Vec.sanitizeWord(_))
     // It could be that the composite vectore below has all zeros even though some values are defined.
@@ -55,25 +65,25 @@ class RealWordToVec(var w2v: CompactWord2Vec, topKNodeGroundings: Int) extends E
     else {
       val nodeEmbedding = w2v.makeCompositeVector(sanitizedNameParts)
       val similarities = conceptEmbeddings.map { conceptEmbedding =>
-        (conceptEmbedding.namer, Word2Vec.dotProduct(conceptEmbedding.embedding, nodeEmbedding))
+        (conceptEmbedding.namer, dotProduct(conceptEmbedding.embedding, nodeEmbedding))
       }
 
       similarities.sortBy(-_._2).take(topKNodeGroundings)
     }
   }
 
-  def makeCompositeVector(t: Iterable[String]): Array[Double] = w2v.makeCompositeVector(t)
+  def makeCompositeVector(t: Iterable[String]): Array[Float] = w2v.makeCompositeVector(t)
 }
 
 object EidosWordToVec {
-  protected val logger = LoggerFactory.getLogger(this.getClass())
+  protected val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def makeCachedFilename(path: String, file: String): String =
       path + "/" + file.split('/').last + ".serialized"
 
   def apply(enabled: Boolean, wordToVecPath: String, topKNodeGroundings: Int, cachedPath: String, cached: Boolean = false): EidosWordToVec = {
     if (enabled) {
-      logger.info(s"Loading w2v from ${wordToVecPath}...")
+      logger.info(s"Loading w2v from $wordToVecPath...")
 
       val w2v =
         if (cached) CompactWord2Vec(makeCachedFilename(cachedPath, wordToVecPath), resource = false, cached)

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -5,8 +5,8 @@ import org.clulab.wm.eidos.utils.Namer
 import org.slf4j.LoggerFactory
 
 object Aliases {
-  type SingleGrounding = (Namer, Double) // Later (Int, Double)
-  type MultipleGrounding = Seq[SingleGrounding] // Later (Namer(Int), Seq(SingleGrounding)]
+  type SingleGrounding = (Namer, Float)
+  type MultipleGrounding = Seq[SingleGrounding]
   type Groundings = Map[String, OntologyGrounding]
 }
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
@@ -41,7 +41,7 @@ class OntologyBranchNode(nodeName: String, parent: OntologyBranchNode) extends O
 }
 
 @SerialVersionUID(1000L)
-class OntologyLeafNode(nodeName: String, parent: OntologyBranchNode, polarity: Double, names: Seq[String], examples: Option[Seq[String]] = None, descriptions: Option[Seq[String]] = None) extends OntologyNode(nodeName, parent) with Namer {
+class OntologyLeafNode(nodeName: String, parent: OntologyBranchNode, polarity: Float, names: Seq[String], examples: Option[Seq[String]] = None, descriptions: Option[Seq[String]] = None) extends OntologyNode(nodeName, parent) with Namer {
 
   def name: String = fullName
 
@@ -147,7 +147,7 @@ object TreeDomainOntology {
       val names = (name +: parent.nodeName +: parent.parents.map(_.nodeName)).map(unescape)
       val examples = yamlNodesToStrings(yamlNodes, TreeDomainOntology.EXAMPLES)
       val descriptions: Option[Seq[String]] = yamlNodesToStrings(yamlNodes, TreeDomainOntology.DESCRIPTION)
-      val polarity = yamlNodes.getOrElse(TreeDomainOntology.POLARITY, 1.0).asInstanceOf[Double]
+      val polarity = yamlNodes.getOrElse(TreeDomainOntology.POLARITY, 1.0d).asInstanceOf[Double].toFloat
 
       val filteredNames = names.flatMap(filtered)
       val filteredExamples = examples.map(_.flatMap(filtered))

--- a/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
@@ -7,7 +7,7 @@ import org.clulab.processors.clu.CluProcessor
 import org.clulab.processors.shallownlp.ShallowNLPProcessor
 import org.clulab.utils.Serializer
 import org.clulab.wm.eidos.utils.FileUtils.getTextFromResource
-import org.clulab.wm.eidos.utils.Namer
+import org.clulab.wm.eidos.utils.{Canonicalizer, Namer}
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.Constructor
 
@@ -28,7 +28,7 @@ class OntologyNode(var nodeName: String, var parent: OntologyBranchNode) extends
       if (parent != null) parent.fullName + DomainOntology.SEPARATOR + escaped
       else escaped
 
-  override def toString: String = fullName
+  override def toString(): String = fullName
 }
 
 @SerialVersionUID(1000L)
@@ -41,18 +41,14 @@ class OntologyBranchNode(nodeName: String, parent: OntologyBranchNode) extends O
 }
 
 @SerialVersionUID(1000L)
-class OntologyLeafNode(nodeName: String, parent: OntologyBranchNode, polarity: Double, examples: Option[Seq[String]] = None, descriptions: Option[Seq[String]] = None) extends OntologyNode(nodeName, parent) with Namer {
+class OntologyLeafNode(nodeName: String, parent: OntologyBranchNode, polarity: Double, names: Seq[String], examples: Option[Seq[String]] = None, descriptions: Option[Seq[String]] = None) extends OntologyNode(nodeName, parent) with Namer {
 
   def name: String = fullName
 
-  protected def split(values: Option[Seq[String]]): Seq[String] =
-      if (values.isEmpty) Seq.empty
-      else values.get.flatMap(_.split(" +"))
-
   // Right now it doesn't matter where these come from, so they can be combined.
-  val values: Array[String] = (split(examples) ++ split(descriptions)).toArray
+  val values: Array[String] = (names ++ examples.getOrElse(Seq.empty) ++ descriptions.getOrElse(Seq.empty)).toArray
 
-  override def toString: String = super.fullName + " = " + values.toList
+  override def toString(): String = super.fullName + " = " + values.toList
 }
 
 @SerialVersionUID(1000L)
@@ -83,7 +79,7 @@ object TreeDomainOntology {
   def load(path: String): TreeDomainOntology = DomainOntology.updatedLoad[TreeDomainOntology](path)
 
   // This is mostly here to capture proc so that it doesn't have to be passed around.
-  class TreeDomainOntologyBuilder(ontologyPath: String, proc: Processor, filter: Boolean) {
+  class TreeDomainOntologyBuilder(ontologyPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean) {
 
     def build(): TreeDomainOntology = {
       val text = getTextFromResource(ontologyPath)
@@ -105,28 +101,31 @@ object TreeDomainOntology {
         // This is the key difference.  Lemmatization must happen first.
         proc.lemmatize(doc)
         proc.tagPartsOfSpeech(doc)
+        proc.recognizeNamedEntities(doc)
         doc.sentences
       }
       case proc: ShallowNLPProcessor => text => {
         val doc = proc.mkDocument(text)
 
-        if (doc.sentences.nonEmpty)
+        if (doc.sentences.nonEmpty) {
           proc.tagPartsOfSpeech(doc)
-        // Lemmatization, if needed, would happen afterwards.
+          proc.lemmatize(doc)
+          proc.recognizeNamedEntities(doc)
+        }
         doc.sentences
       }
     }
 
     protected def realFiltered(text: String): Seq[String] = {
-      val sentences = getSentences(text)
+      getSentences(text).flatMap { sentence =>
+        val lemmas: Array[String] = sentence.lemmas.get
+        val tags: Array[String] = sentence.tags.get
+        val ners: Array[String] = sentence.entities.get
 
-      sentences.flatMap { sentence =>
-        sentence.words.zip(sentence.tags.get).filter { wordAndPos =>
-          // Filter by POS tags which need to be kept (Nouns, Adjectives, and Verbs).
-          wordAndPos._2.contains("NN") ||
-            wordAndPos._2.contains("JJ") ||
-            wordAndPos._2.contains("VB")
-        }.map(_._1) // Get only the words.
+        for {
+          i <- lemmas.indices
+          if canonicalizer.isCanonical(lemmas(i), tags(i), ners(i))
+        } yield lemmas(i)
       }
     }
 
@@ -137,16 +136,25 @@ object TreeDomainOntology {
     protected def yamlNodesToStrings(yamlNodes: mutable.Map[String, JCollection[Any]], name: String): Option[Seq[String]] =
       yamlNodes.get(name).map(_.asInstanceOf[JCollection[String]].asScala.toSeq)
 
+    protected def unescape(name: String): String = {
+      // Sometimes the words in names are concatenated with _
+      // TODO: We should avoid this practice
+      name.replace('_', ' ')
+    }
+
     protected def parseOntology(parent: OntologyBranchNode, yamlNodes: mutable.Map[String, JCollection[Any]]): OntologyLeafNode = {
       val name = yamlNodes(TreeDomainOntology.NAME).asInstanceOf[String]
+      val names = (name +: parent.nodeName +: parent.parents.map(_.nodeName)).map(unescape)
       val examples = yamlNodesToStrings(yamlNodes, TreeDomainOntology.EXAMPLES)
-      val descriptions = yamlNodesToStrings(yamlNodes, TreeDomainOntology.DESCRIPTION)
+      val descriptions: Option[Seq[String]] = yamlNodesToStrings(yamlNodes, TreeDomainOntology.DESCRIPTION)
       val polarity = yamlNodes.getOrElse(TreeDomainOntology.POLARITY, 1.0).asInstanceOf[Double]
-      val filteredDescriptions =
-          if (descriptions.isEmpty) descriptions
-          else Some(descriptions.get.flatMap(filtered))
 
-      new OntologyLeafNode(name, parent, polarity,  examples, filteredDescriptions)
+      val filteredNames = names.flatMap(filtered)
+      val filteredExamples = examples.map(_.flatMap(filtered))
+      val filteredDescriptions = descriptions.map(_.flatMap(filtered))
+
+      val res = new OntologyLeafNode(name, parent, polarity, filteredNames, filteredExamples, filteredDescriptions)
+      res
     }
 
     protected def parseOntology(parent: OntologyBranchNode, yamlNodes: Seq[Any]): Seq[OntologyLeafNode] = {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
@@ -41,12 +41,12 @@ class OntologyBranchNode(nodeName: String, parent: OntologyBranchNode) extends O
 }
 
 @SerialVersionUID(1000L)
-class OntologyLeafNode(nodeName: String, parent: OntologyBranchNode, polarity: Float, names: Seq[String], examples: Option[Seq[String]] = None, descriptions: Option[Seq[String]] = None) extends OntologyNode(nodeName, parent) with Namer {
+class OntologyLeafNode(nodeName: String, parent: OntologyBranchNode, polarity: Float, /*names: Seq[String],*/ examples: Option[Seq[String]] = None, descriptions: Option[Seq[String]] = None) extends OntologyNode(nodeName, parent) with Namer {
 
   def name: String = fullName
 
   // Right now it doesn't matter where these come from, so they can be combined.
-  val values: Array[String] = (names ++ examples.getOrElse(Seq.empty) ++ descriptions.getOrElse(Seq.empty)).toArray
+  val values: Array[String] = (/*names ++*/ examples.getOrElse(Seq.empty) ++ descriptions.getOrElse(Seq.empty)).toArray
 
   override def toString(): String = super.fullName + " = " + values.toList
 }
@@ -144,17 +144,18 @@ object TreeDomainOntology {
     }
 
     protected def parseOntology(parent: OntologyBranchNode, yamlNodes: mutable.Map[String, JCollection[Any]]): OntologyLeafNode = {
+      /* We're going without the names for now. */
       val name = yamlNodes(TreeDomainOntology.NAME).asInstanceOf[String]
-      val names = (name +: parent.nodeName +: parent.parents.map(_.nodeName)).map(unescape)
+      /*val names = (name +: parent.nodeName +: parent.parents.map(_.nodeName)).map(unescape)*/
       val examples = yamlNodesToStrings(yamlNodes, TreeDomainOntology.EXAMPLES)
       val descriptions: Option[Seq[String]] = yamlNodesToStrings(yamlNodes, TreeDomainOntology.DESCRIPTION)
       val polarity = yamlNodes.getOrElse(TreeDomainOntology.POLARITY, 1.0d).asInstanceOf[Double].toFloat
 
-      val filteredNames = names.flatMap(filtered)
+      /*val filteredNames = names.flatMap(filtered)*/
       val filteredExamples = examples.map(_.flatMap(filtered))
       val filteredDescriptions = descriptions.map(_.flatMap(filtered))
 
-      val res = new OntologyLeafNode(name, parent, polarity, filteredNames, filteredExamples, filteredDescriptions)
+      val res = new OntologyLeafNode(name, parent, polarity, /*filteredNames,*/ filteredExamples, filteredDescriptions)
       res
     }
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
@@ -117,7 +117,7 @@ object TreeDomainOntology {
     }
 
     protected def realFiltered(text: String): Seq[String] = {
-      getSentences(text).flatMap { sentence =>
+      val result = getSentences(text).flatMap { sentence =>
         val lemmas: Array[String] = sentence.lemmas.get
         val tags: Array[String] = sentence.tags.get
         val ners: Array[String] = sentence.entities.get
@@ -127,6 +127,7 @@ object TreeDomainOntology {
           if canonicalizer.isCanonical(lemmas(i), tags(i), ners(i))
         } yield lemmas(i)
       }
+      result // breakpoint
     }
 
     protected def fakeFiltered(text: String): Seq[String] = text.split(" +")

--- a/src/main/scala/org/clulab/wm/eidos/mentions/EidosMention.scala
+++ b/src/main/scala/org/clulab/wm/eidos/mentions/EidosMention.scala
@@ -4,10 +4,9 @@ import java.util.IdentityHashMap
 
 import org.clulab.odin._
 import org.clulab.wm.eidos.groundings._
-import org.clulab.wm.eidos.groundings.Aliases.Groundings
 import org.clulab.struct.Interval
 import org.clulab.wm.eidos.attachments.EidosAttachment
-import org.clulab.wm.eidos.utils.{StopwordManager, StopwordManaging}
+import org.clulab.wm.eidos.utils.Canonicalizer
 
 import scala.collection.mutable.HashMap
 
@@ -77,7 +76,7 @@ class IdentityBagger[T] extends Bagger[T] {
   def size: Int = map.size
 }
 
-abstract class EidosMention(val odinMention: Mention, stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder,
+abstract class EidosMention(val odinMention: Mention, canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder,
     mentionMapper: MentionMapper) /* extends Mention if really needs to */ {
   type StringAndStart = (String, Int)
 
@@ -91,21 +90,21 @@ abstract class EidosMention(val odinMention: Mention, stopwordManaging: Stopword
   val odinArguments: Map[String, Seq[Mention]] = odinMention.arguments
 
   // Access to new and improved Eidos arguments
-  val eidosArguments: Map[String, Seq[EidosMention]] = remapOdinArguments(odinArguments, stopwordManaging, ontologyGrounder, mentionMapper)
+  val eidosArguments: Map[String, Seq[EidosMention]] = remapOdinArguments(odinArguments, canonicalizer, ontologyGrounder, mentionMapper)
 
   val eidosMentionsFromAttachments: Seq[EidosMention] = {
     val attachmentMentions = odinMention.attachments.toSeq.flatMap(_.asInstanceOf[EidosAttachment].attachmentMentions)
 
-    EidosMention.asEidosMentions(attachmentMentions, stopwordManaging, ontologyGrounder, mentionMapper)
+    EidosMention.asEidosMentions(attachmentMentions, canonicalizer, ontologyGrounder, mentionMapper)
   }
 
-  protected def remapOdinArguments(odinArguments: Map[String, Seq[Mention]], stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder,
+  protected def remapOdinArguments(odinArguments: Map[String, Seq[Mention]], canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder,
       mentionMapper: MentionMapper): Map[String, Seq[EidosMention]] = {
-    odinArguments.mapValues(odinMentions => EidosMention.asEidosMentions(odinMentions, stopwordManaging, ontologyGrounder, mentionMapper))
+    odinArguments.mapValues(odinMentions => EidosMention.asEidosMentions(odinMentions, canonicalizer, ontologyGrounder, mentionMapper))
   }
 
-  protected def remapOdinMention(odinMention: Mention, stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder, mentionMapper: MentionMapper): EidosMention =
-      EidosMention.asEidosMentions(Seq(odinMention), stopwordManaging, ontologyGrounder, mentionMapper)(0)
+  protected def remapOdinMention(odinMention: Mention, canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder, mentionMapper: MentionMapper): EidosMention =
+      EidosMention.asEidosMentions(Seq(odinMention), canonicalizer, ontologyGrounder, mentionMapper)(0)
 
   // This is lazy because canonicalMentions is called and that may be overridden in the derived class.
   // The overriden method will not be called in this constructor.
@@ -137,16 +136,13 @@ abstract class EidosMention(val odinMention: Mention, stopwordManaging: Stopword
 
   /* Methods for canonicalForms of Mentions */
   protected def canonicalFormSimple(m: Mention): String = {
-    def isContentTag(tag: String) = tag.startsWith("NN") || tag.startsWith("VB")
-    def removeNER(ner: String) = StopwordManager.STOP_NER.contains(ner)
+    val lemmas = m.lemmas.get
+    val tags = m.tags.get
+    val ners = m.entities.get
     val contentLemmas = for {
-      (lemma, i) <- m.lemmas.get.zipWithIndex
-      tag = m.tags.get(i)
-      ner = m.entities.get(i)
-      if isContentTag(tag)
-      if !stopwordManaging.containsStopword(lemma)
-      if !removeNER(ner)
-    } yield lemma
+      i <- lemmas.indices
+      if canonicalizer.isCanonical(lemmas(i), tags(i), ners(i))
+    } yield lemmas(i)
 
     if (contentLemmas.isEmpty)
       m.text // fixme -- better and cleaner backoff
@@ -164,28 +160,28 @@ object EidosMention {
   protected def newMentionBagger() = new HashCodeBagger[Mention]()
 //  protected def newMentionBagger() = new IdentityBagger[Mention]()
 
-  def newEidosMention(odinMention: Mention, stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder,
+  def newEidosMention(odinMention: Mention, canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder,
       mentionMapper: MentionMapper): EidosMention = {
     odinMention match {
-      case mention: TextBoundMention => new EidosTextBoundMention(mention, stopwordManaging, ontologyGrounder, mentionMapper)
-      case mention: EventMention => new EidosEventMention(mention, stopwordManaging, ontologyGrounder, mentionMapper)
-      case mention: RelationMention => new EidosRelationMention(mention, stopwordManaging, ontologyGrounder, mentionMapper)
-      case mention: CrossSentenceMention => new EidosCrossSentenceMention(mention, stopwordManaging, ontologyGrounder, mentionMapper)
+      case mention: TextBoundMention => new EidosTextBoundMention(mention, canonicalizer, ontologyGrounder, mentionMapper)
+      case mention: EventMention => new EidosEventMention(mention, canonicalizer, ontologyGrounder, mentionMapper)
+      case mention: RelationMention => new EidosRelationMention(mention, canonicalizer, ontologyGrounder, mentionMapper)
+      case mention: CrossSentenceMention => new EidosCrossSentenceMention(mention, canonicalizer, ontologyGrounder, mentionMapper)
       case _ => throw new IllegalArgumentException("Unknown Mention: " + odinMention)
     }
   }
 
-  def asEidosMentions(odinMentions: Seq[Mention], stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder,
+  def asEidosMentions(odinMentions: Seq[Mention], canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder,
       mentionMapper: MentionMapper): Seq[EidosMention] = {
     val eidosMentions = odinMentions.map { odinMention =>
-      mentionMapper.getOrElse(odinMention, newEidosMention(odinMention, stopwordManaging, ontologyGrounder, mentionMapper))
+      mentionMapper.getOrElse(odinMention, newEidosMention(odinMention, canonicalizer, ontologyGrounder, mentionMapper))
     }
     eidosMentions
   }
 
-  def asEidosMentions(odinMentions: Seq[Mention], stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder): Seq[EidosMention] =
+  def asEidosMentions(odinMentions: Seq[Mention], canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder): Seq[EidosMention] =
       // One could optionally keep this map around
-      asEidosMentions(odinMentions, stopwordManaging, ontologyGrounder, newMentionMapper()): Seq[EidosMention]
+      asEidosMentions(odinMentions, canonicalizer, ontologyGrounder, newMentionMapper()): Seq[EidosMention]
 
   def findReachableMentions(surfaceMentions: Seq[Mention]): Seq[Mention] = {
     val mentionBagger = newMentionBagger()
@@ -222,41 +218,41 @@ object EidosMention {
   def hasUnderlyingMentions(surfaceMentions: Seq[Mention]): Boolean = findUnderlyingMentions(surfaceMentions).nonEmpty
 }
 
-class EidosTextBoundMention(val odinTextBoundMention: TextBoundMention, stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder,
+class EidosTextBoundMention(val odinTextBoundMention: TextBoundMention, canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder,
     mentionMapper: MentionMapper)
-    extends EidosMention(odinTextBoundMention, stopwordManaging, ontologyGrounder, mentionMapper) {
+    extends EidosMention(odinTextBoundMention, canonicalizer, ontologyGrounder, mentionMapper) {
 
   protected override def canonicalMentions: Seq[Mention] = Seq(odinMention)
 }
 
-class EidosEventMention(val odinEventMention: EventMention, stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder,
+class EidosEventMention(val odinEventMention: EventMention, canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder,
     mentionMapper: MentionMapper)
-    extends EidosMention(odinEventMention, stopwordManaging, ontologyGrounder, mentionMapper) {
+    extends EidosMention(odinEventMention, canonicalizer, ontologyGrounder, mentionMapper) {
 
   val odinTrigger = odinEventMention.trigger
 
-  val eidosTrigger = remapOdinMention(odinTrigger, stopwordManaging, ontologyGrounder, mentionMapper)
+  val eidosTrigger = remapOdinMention(odinTrigger, canonicalizer, ontologyGrounder, mentionMapper)
 
   protected override def canonicalMentions: Seq[Mention] =
       super.canonicalMentions ++ Seq(odinTrigger)
 }
 
-class EidosRelationMention(val odinRelationMention: RelationMention, stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder,
+class EidosRelationMention(val odinRelationMention: RelationMention, canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder,
     mentionMapper: MentionMapper)
-    extends EidosMention(odinRelationMention, stopwordManaging, ontologyGrounder, mentionMapper) {
+    extends EidosMention(odinRelationMention, canonicalizer, ontologyGrounder, mentionMapper) {
 }
 
-class EidosCrossSentenceMention(val odinCrossSentenceMention: CrossSentenceMention, stopwordManaging: StopwordManaging, ontologyGrounder: MultiOntologyGrounder,
+class EidosCrossSentenceMention(val odinCrossSentenceMention: CrossSentenceMention, canonicalizer: Canonicalizer, ontologyGrounder: MultiOntologyGrounder,
     mentionMapper: MentionMapper)
-    extends EidosMention(odinCrossSentenceMention, stopwordManaging, ontologyGrounder, mentionMapper) {
+    extends EidosMention(odinCrossSentenceMention, canonicalizer, ontologyGrounder, mentionMapper) {
 
   val odinAnchor = odinCrossSentenceMention.anchor
 
-  val eidosAnchor = remapOdinMention(odinAnchor, stopwordManaging, ontologyGrounder, mentionMapper)
+  val eidosAnchor = remapOdinMention(odinAnchor, canonicalizer, ontologyGrounder, mentionMapper)
 
   val odinNeighbor = odinCrossSentenceMention.neighbor
 
-  val eidosNeighbor = remapOdinMention(odinNeighbor, stopwordManaging, ontologyGrounder, mentionMapper)
+  val eidosNeighbor = remapOdinMention(odinNeighbor, canonicalizer, ontologyGrounder, mentionMapper)
 
   protected override def canonicalMentions: Seq[Mention] =
     Seq(odinAnchor, odinNeighbor)

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
@@ -153,7 +153,7 @@ object JLDArgument {
   val plural = "arguments"
 }
 
-class JLDOntologyGrounding(serializer: JLDSerializer, name: String, value: Double)
+class JLDOntologyGrounding(serializer: JLDSerializer, name: String, value: Float)
     extends JLDObject(serializer, "Grounding") {
 
   override def toJObject: JObject =

--- a/src/main/scala/org/clulab/wm/eidos/utils/Canonicalizer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/Canonicalizer.scala
@@ -6,10 +6,8 @@ class Canonicalizer(stopwordManaging: StopwordManaging) {
       tag.startsWith("NN") ||
       tag.startsWith("VB")
 
-  protected def removeNER(ner: String) = StopwordManager.STOP_NER.contains(ner)
-
   def isCanonical(lemma: String, tag: String, ner: String): Boolean =
     isContentTag(tag) &&
     !stopwordManaging.containsStopword(lemma) &&
-    !removeNER(ner)
+    !StopwordManager.STOP_NER.contains(ner)
 }

--- a/src/main/scala/org/clulab/wm/eidos/utils/Canonicalizer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/Canonicalizer.scala
@@ -1,0 +1,15 @@
+package org.clulab.wm.eidos.utils
+
+class Canonicalizer(stopwordManaging: StopwordManaging) {
+
+  protected def isContentTag(tag: String) =
+      tag.startsWith("NN") ||
+      tag.startsWith("VB")
+
+  protected def removeNER(ner: String) = StopwordManager.STOP_NER.contains(ner)
+
+  def isCanonical(lemma: String, tag: String, ner: String): Boolean =
+    isContentTag(tag) &&
+    !stopwordManaging.containsStopword(lemma) &&
+    !removeNER(ner)
+}

--- a/src/main/scala/org/clulab/wm/eidos/utils/Timer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/Timer.scala
@@ -7,14 +7,24 @@ object Timer {
 
   // See http://biercoff.com/easily-measuring-code-execution-time-in-scala/
   def time[R](description: String)(block: => R): R = {
-    logger.info("Start: " + description)
-
     val t0 = System.currentTimeMillis()
-    val result: R = block    // call-by-name
-    val t1 = System.currentTimeMillis()
+    logger.info("Start " + t0 + " ms: " + description)
 
-    logger.info("Stop: " + description)
-    logger.info(s"Time: " + (t1 - t0) / 1000 + " sec.")
+    val result: R = block    // call-by-name
+
+    val t1 = System.currentTimeMillis()
+    logger.info(" Stop " + t1 + " ms: " + description)
+
+    val diff = t1 - t0
+    logger.info(s" Diff " + diff + " ms: " + description)
+
+    val  days = (diff / (1000 * 60 * 60 * 24))
+    val hours = (diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60)
+    val  mins = (diff % (1000 * 60 * 60)) / (1000 * 60)
+    val  secs = (diff % (1000 * 60)) / (1000)
+    val msecs = (diff % (1000))
+
+    logger.info(f" Time $days:$hours%02d:$mins%02d:$secs%02d.$msecs%03d")
     result
   }
 }

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDSerializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDSerializer.scala
@@ -9,6 +9,7 @@ import org.clulab.wm.eidos.serialization.json.{JLDCorpus => JLDEidosCorpus}
 import org.clulab.wm.eidos.test.TestUtils
 import org.clulab.wm.eidos.test.TestUtils.Test
 import org.clulab.wm.eidos.text.cag.CAG._
+import org.clulab.wm.eidos.utils.Canonicalizer
 
 import scala.collection.Seq
 
@@ -130,7 +131,7 @@ class TestJLDSerializer extends Test {
         Set.empty
       )
       val nextOdinMentions = crossSentenceMention +: prevOdinMentions
-      val nextEidosMentions = EidosMention.asEidosMentions(nextOdinMentions, TestUtils.ieSystem.loadableAttributes.stopwordManager, TestUtils.ieSystem)
+      val nextEidosMentions = EidosMention.asEidosMentions(nextOdinMentions, new Canonicalizer(TestUtils.ieSystem.loadableAttributes.stopwordManager), TestUtils.ieSystem)
       val nextAnnotatedDocument = AnnotatedDocument(firstMention.document, nextOdinMentions, nextEidosMentions)
 
       nextAnnotatedDocument

--- a/src/test/scala/org/clulab/wm/eidos/system/TestDomainOntology.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestDomainOntology.scala
@@ -1,10 +1,12 @@
 package org.clulab.wm.eidos.system
 
+import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.clulab.processors.fastnlp.FastNLPProcessor
+import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.groundings.CompactDomainOntology.CompactDomainOntologyBuilder
 import org.clulab.wm.eidos.groundings._
 import org.clulab.wm.eidos.test.TestUtils._
-import org.clulab.wm.eidos.utils.Timer
+import org.clulab.wm.eidos.utils.{Canonicalizer, Timer}
 
 class TestDomainOntology extends Test {
 
@@ -28,7 +30,11 @@ class TestDomainOntology extends Test {
   }
 
   val baseDir = "/org/clulab/wm/eidos/english/ontologies"
-  val proc = new FastNLPProcessor()
+  val config = ConfigFactory.load("eidos")
+      .withValue("EidosSystem.useW2V", ConfigValueFactory.fromAnyRef(false, "Don't use vectors when caching ontologies."))
+  val reader = new EidosSystem(config)
+  val proc = reader.proc
+  val canonicalizer = new Canonicalizer(reader)
   val convert = true
   val filter = true
 
@@ -53,7 +59,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/un_ontology.yml"
 
     val newOntology = Timer.time("Load UN without cache") {
-      UNOntology(path, "", proc, filter, useCache = false)
+      UNOntology(path, "", proc, canonicalizer, filter, useCache = false)
     }
     val newerOntology =
       if (convert)
@@ -62,7 +68,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load UN from cache") {
-          UNOntology(path, "", proc, filter, useCache = true)
+          UNOntology(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 //    val newestOntology = Timer.time("Load UN from cache") {
@@ -80,7 +86,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/fao_variable_ontology.yml"
 
     val newOntology = Timer.time("Load FAO without cache") {
-      FAOOntology(path, "", proc, filter, useCache =false)
+      FAOOntology(path, "", proc, canonicalizer, filter, useCache =false)
     }
     val newerOntology =
       if (convert)
@@ -89,7 +95,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load FAO from cache") {
-          FAOOntology(path, "", proc, filter, useCache = true)
+          FAOOntology(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 
@@ -108,7 +114,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/wdi_ontology.yml"
 
     val newOntology = Timer.time("Load WDI without cache") {
-      WDIOntology(path, "", proc, filter, useCache = false)
+      WDIOntology(path, "", proc, canonicalizer, filter, useCache = false)
     }
     val newerOntology =
       if (convert)
@@ -117,7 +123,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load WDI from cache") {
-          WDIOntology(path, "", proc, filter, useCache = true)
+          WDIOntology(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 //    val newestOntology = Timer.time("Load WDI with cache") {
@@ -136,7 +142,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/topoflow_ontology.yml"
 
     val newOntology = Timer.time("Load TOPO without cache") {
-      TopoFlowOntology(path, "", proc, filter, useCache = false)
+      TopoFlowOntology(path, "", proc, canonicalizer, filter, useCache = false)
     }
 
     hasDuplicates("topo", newOntology) should be (false)
@@ -147,7 +153,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/mesh_ontology.yml"
 
     val newOntology = Timer.time("Load MeSH without cache") {
-      MeshOntology(path, "", proc, filter, useCache = false)
+      MeshOntology(path, "", proc, canonicalizer, filter, useCache = false)
     }
     val newerOntology =
       if (convert)
@@ -156,7 +162,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load MeSH from cache") {
-          MeshOntology(path, "", proc, filter, useCache = true)
+          MeshOntology(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 //    val newestOntology = Timer.time("Load MeSH with cache") {

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEidosMention.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEidosMention.scala
@@ -9,7 +9,7 @@ import org.clulab.wm.eidos.mentions.{HashCodeBagger, IdentityBagger}
 import org.clulab.wm.eidos.test.TestUtils
 import org.clulab.wm.eidos.test.TestUtils._
 import org.clulab.wm.eidos.text.cag.CAG._
-import org.clulab.wm.eidos.utils.StopwordManaging
+import org.clulab.wm.eidos.utils.{Canonicalizer, StopwordManaging}
 
 class TestEidosMention extends Test with StopwordManaging with MultiOntologyGrounder {
   
@@ -44,7 +44,7 @@ class TestEidosMention extends Test with StopwordManaging with MultiOntologyGrou
 
     val odinMentions = reachableOdinMentions // These should already be distinct
     val distinctOdinMentions = new HashCodeBagger[Mention].put(odinMentions).get() // This shouldn't make a difference
-    val eidosMentions = EidosMention.asEidosMentions(odinMentions, this, this)
+    val eidosMentions = EidosMention.asEidosMentions(odinMentions, new Canonicalizer(this), this)
     odinMentions.size should be (distinctOdinMentions.size)
     odinMentions.size should be (eidosMentions.size)
 
@@ -93,7 +93,7 @@ than in the corresponding period two years earlier.
   it should "properly make canonical form" in {
     val text3 = "The seasonal rainfall in July was decreased by the government policy."
     val odinMentions3 = TestUtils.extractMentions(text3)
-    val eidosMentions3 = EidosMention.asEidosMentions(odinMentions3, this, this)
+    val eidosMentions3 = EidosMention.asEidosMentions(odinMentions3, new Canonicalizer(this), this)
 
 //    eidosMentions3.foreach(m => println(s"\t${m.odinMention.text}\tcanonical: ${m.canonicalName}"))
 

--- a/src/test/scala/org/clulab/wm/eidos/util/TestLoop.scala
+++ b/src/test/scala/org/clulab/wm/eidos/util/TestLoop.scala
@@ -1,0 +1,35 @@
+package org.clulab.wm.eidos.util
+
+import org.clulab.wm.eidos.test.TestUtils._
+import org.clulab.wm.eidos.utils.Timer
+
+class TestLoop extends Test {
+  
+  behavior of "Loop"
+  
+  ignore should "run faster in scala" in {
+    val left = new Array[Float](300)
+    left.indices.foreach(i => left(i) = 400 - i)
+    val right = new Array[Float](300)
+    right.indices.foreach(i => right(i) = -200 + i)
+    val limit = 1000000
+
+    val res1 = Timer.time("Using fold") {
+      0.until(limit).foreach { i =>
+        left.indices.foldRight(0.0f)((i, sum) => sum + left(i) * right(i))
+      }
+    }
+
+    val res2 = Timer.time("Using fold") {
+      0.until(limit).foreach { j =>
+        var sum = 0.0f
+        var i = 0
+        while (i < left.length) {
+          sum += left(i) * right(i)
+          i += 1
+        }
+        sum
+      }
+    }
+  }  
+}


### PR DESCRIPTION
Namely,
```
  protected def isContentTag(tag: String) =
      tag.startsWith("NN") ||
      tag.startsWith("VB")

  def isCanonical(lemma: String, tag: String, ner: String): Boolean =
    isContentTag(tag) &&
    !stopwordManaging.containsStopword(lemma) &&
    !StopwordManager.STOP_NER.contains(ner)
```

Also, not only do descriptions pass through this check, but so do examples and even node names.  Node names are now also added to the values against which the nodes are grounded.  _ characters are replaced with spaces in node names.

The vectors had been converted to Floats, but now so have the outputs of word2vec operations.  This is done to conserve memory, especially since incoming data is at less than float precision.