### PR TITLE
Converted hedging to a TriggeredAttachment

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractAndExport.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractAndExport.scala
@@ -5,10 +5,10 @@ import java.io.PrintWriter
 import ai.lum.common.StringUtils._
 import com.typesafe.config.{Config, ConfigFactory}
 import org.clulab.utils.Serializer
-import org.clulab.odin.{EventMention, Mention, State}
+import org.clulab.odin.{Attachment, EventMention, Mention, State}
 import org.clulab.serialization.json.stringify
 import org.clulab.utils.Configured
-import org.clulab.wm.eidos.attachments.{Decrease, Increase, Quantification}
+import org.clulab.wm.eidos.attachments.{Decrease, Hedging, Increase, Quantification}
 import org.clulab.wm.eidos.groundings.EidosOntologyGrounder
 import org.clulab.wm.eidos.mentions.{EidosEventMention, EidosMention}
 import org.clulab.wm.eidos.{AnnotatedDocument, EidosSystem}
@@ -18,8 +18,6 @@ import org.clulab.wm.eidos.utils.FileUtils.{findFiles, printWriterFromFile}
 import org.clulab.wm.eidos.utils.GroundingUtils.{getBaseGrounding, getGroundingsString}
 
 import scala.collection.mutable.ArrayBuffer
-
-
 
 
 /**
@@ -174,13 +172,16 @@ case class EntityInfo(m: EidosMention, topN: Int = 5) {
 
 object ExporterUtils {
   def getModifier(mention: EidosMention): String = {
-    val attachments = mention.odinMention.attachments
-    val quantTriggers = attachments
-      .filter(a => a.isInstanceOf[Quantification])
-      .map(quant => quant.asInstanceOf[Quantification].trigger)
-      .map(t => t.toLowerCase)
+    def quantHedgeString(a: Attachment): Option[String] = a match {
+      case q: Quantification => Some(f"Quant(${q.trigger.toLowerCase})")
+      case h: Hedging => Some(f"Hedged(${h.quantifiers.get.mkString(",")})")
+      case _ => None
+    }
 
-    if (quantTriggers.nonEmpty) s"${quantTriggers.mkString(", ")}".normalizeSpace else ""
+    val attachments = mention.odinMention.attachments.map(quantHedgeString).toSeq.filter(_.isDefined)
+
+    val modifierString = attachments.map(a => a.get).mkString(", ")
+    modifierString
   }
 
   //fixme: not working -- always ;

--- a/src/main/scala/org/clulab/wm/eidos/attachments/EidosAttachment.scala
+++ b/src/main/scala/org/clulab/wm/eidos/attachments/EidosAttachment.scala
@@ -315,21 +315,23 @@ object Time {
 }
 
 
-class Hedging(hedgingTerms: Seq[String]) extends ContextAttachment {
-  val text = hedgingTerms.mkString(", ")
-  val value = hedgingTerms
+class Hedging(trigger: String, quantifiers: Option[Seq[String]], triggerMention: Option[TextBoundMention] = None,
+  quantifierMentions: Option[Seq[Mention]] = None) extends TriggeredAttachment(trigger, quantifiers, triggerMention, quantifierMentions) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
-    newJLDContextAttachment(serializer, Hedging.kind)
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[Hedging]
 
-  override def toJson(): JValue = toJson(Hedging.label)
+  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment = newJLDTriggeredAttachment(serializer, Hedging.kind)
+
+  override def toJson(): JValue = toJson(trigger)
 }
+
 
 object Hedging {
   val label = "Hedging"
   val kind = "HEDGE"
 
-  def apply(hedgingTerms: Seq[String]): Hedging = new Hedging(hedgingTerms)
+  def apply(hedgingTerms: Seq[String]): Hedging = Hedging(hedgingTerms.length.toString, Some(hedgingTerms))
+  def apply(num: String, hts: Option[Seq[String]]) = new Hedging(num, hts)
 }
 
 case class Score(score: Double) extends EidosAttachment {

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEidosActions.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEidosActions.scala
@@ -120,7 +120,7 @@ class TestEidosActions extends Test {
 
   def hasHedging(m: Mention, term: String): Boolean= {
     val hedged = m.attachments.filter(_.isInstanceOf[Hedging])
-    hedged.exists(h => h.asInstanceOf[Hedging].text == term )
+    hedged.exists(h => h.asInstanceOf[Hedging].quantifiers.get.contains(term) )
   }
 //  {
 //    val reader = new EidosSystem()


### PR DESCRIPTION
... to help it go through to the jsonld.  Format is now trigger is the
num of hedging words (as a string) and the quantifiers holds the list of
the hedging terms

@kwalcock if there is a cleaner solution please feel free to modify however you want!

@bgyori I verified, and with this branch hedging gets through to the jsonld.  for example, for the sentence: `Rainfall might cause increased flooding.` we get:
```...
{
    "@type" : "Extraction",
    "@id" : "_:Extraction_1",
    "type" : "relation",
    "subtype" : "causation",
    "labels" : [ "Causal", "DirectedRelation", "EntityLinker", "Event" ],
    "text" : "Rainfall might cause increased flooding",
    "rule" : "ported_syntax_1_verb-Causal",
    "canonicalName" : "rainfall cause increase flooding",
    "provenance" : [ {
      "@type" : "Provenance",
      "document" : {
        "@id" : "_:Document_1"
      },
      "documentCharInterval" : [ {
        "@type" : "Interval",
        "start" : 1,
        "end" : 39
      } ],
      "sentence" : {
        "@id" : "_:Sentence_1"
      },
      "positions" : [ {
        "@type" : "Interval",
        "start" : 1,
        "end" : 5
      } ]
    } ],
    "states" : [ {
      "@type" : "State",
      "type" : "HEDGE",
      "text" : "1",
      "modifiers" : [ {
        "@type" : "Modifier",
        "text" : "might"
      } ]
    } ],
...
```