### PR TITLE
Use timenorm file from jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,18 +30,15 @@ libraryDependencies ++= {
   )
 }
 
-val minorVersionRegex = "\\d+\\.(\\d+).*".r
 libraryDependencies ++= {
-  scalaVersion { sv =>
-    sv match {
-      case minorVersionRegex(minor) if minor.toInt == 11 => Seq("com.github.clulab" % "timenorm" % "timenorm-0.9.6.15_2.11.11" exclude("org.slf4j", "slf4j-log4j12"))
-      case _ => Seq("com.github.clulab" % "timenorm" % "timenorm-0.9.6.15" exclude("org.slf4j", "slf4j-log4j12"))
-    }
-  }
-}.value
+  val (major, minor) = CrossVersion.partialVersion(scalaVersion.value).get
+  val timenorm = "timenorm-0.9.6.15" + (if (minor == 11) "_2.11.11" else "")
+
+  Seq("com.github.clulab" % "timenorm" % timenorm exclude("org.slf4j", "slf4j-log4j12"))
+}
 
 // This is useful because timenorm loads a dll and only one dll is allowed per (Java) process.
-// If it isn't here, sbt test can only be run once before it will fail with
+// If it isn't here, sbt test can seemingly only be run once before it will fail with
 // java.lang.UnsatisfiedLinkError: no jnihdf5 in java.library.path
 // Caused by: java.lang.UnsatisfiedLinkError: Native Library jnihdf5.dll already loaded in another classloader
 fork := true

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,12 @@ libraryDependencies ++= {
   }
 }.value
 
+// This is useful because timenorm loads a dll and only one dll is allowed per (Java) process.
+// If it isn't here, sbt test can only be run once before it will fail with
+// java.lang.UnsatisfiedLinkError: no jnihdf5 in java.library.path
+// Caused by: java.lang.UnsatisfiedLinkError: Native Library jnihdf5.dll already loaded in another classloader
+fork := true
+
 //
 // publishing settings
 //

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,8 @@ libraryDependencies ++= {
 // If it isn't here, sbt test can seemingly only be run once before it will fail with
 // java.lang.UnsatisfiedLinkError: no jnihdf5 in java.library.path
 // Caused by: java.lang.UnsatisfiedLinkError: Native Library jnihdf5.dll already loaded in another classloader
-fork := true
+// However, this also doubles the testing time, so it is disabled here.  Enable it if the exception appears.
+// fork := true
 
 //
 // publishing settings

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -19,6 +19,6 @@ EidosSystem {
   timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
            cacheDir = ./cache/${EidosSystem.language}
              useW2V = false
-        useTimeNorm = false
+        useTimeNorm = true
            useCache = false
 }

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -19,6 +19,6 @@ EidosSystem {
   timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
            cacheDir = ./cache/${EidosSystem.language}
              useW2V = false
-        useTimeNorm = true
+        useTimeNorm = false
            useCache = false
 }

--- a/src/main/scala/org/clulab/wm/eidos/utils/FileUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/FileUtils.scala
@@ -1,6 +1,7 @@
 package org.clulab.wm.eidos.utils
 
-import java.io.{File, FileNotFoundException, FilenameFilter, PrintWriter}
+import java.io._
+import java.net.URL
 import java.util.Collection
 
 import org.clulab.serialization.json.stringify
@@ -85,5 +86,25 @@ object FileUtils {
     val mentionsJSONLD = corpus.serialize()
     // 5. Write to output file
     pw.println(stringify(mentionsJSONLD, pretty = true))
+  }
+
+  def copyResourceToFile(src: String, dest: String): Unit = {
+    val os: OutputStream = new FileOutputStream(new File(dest))
+    val is: InputStream = FileUtils.getClass().getResourceAsStream(src)
+
+    var buf = new Array[Byte](8192)
+    var continue = true
+
+    while (continue) {
+      val len = is.read(buf)
+
+      continue =
+        if (len > 0) {
+          os.write(buf, 0, len); true
+        }
+        else false
+    }
+    is.close()
+    os.close()
   }
 }

--- a/src/main/scala/org/clulab/wm/eidos/utils/FileUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/FileUtils.scala
@@ -88,9 +88,9 @@ object FileUtils {
     pw.println(stringify(mentionsJSONLD, pretty = true))
   }
 
-  def copyResourceToFile(src: String, dest: String): Unit = {
-    val os: OutputStream = new FileOutputStream(new File(dest))
-    val is: InputStream = FileUtils.getClass().getResourceAsStream(src)
+  def copyResourceToFile(src: String, dest: File): Unit = {
+    val os: OutputStream = new FileOutputStream(dest)
+    val is: InputStream = FileUtils.getClass.getResourceAsStream(src)
 
     var buf = new Array[Byte](8192)
     var continue = true

--- a/src/main/scala/org/clulab/wm/eidos/utils/StringUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/StringUtils.scala
@@ -1,0 +1,30 @@
+package org.clulab.wm.eidos.utils
+
+object StringUtils {
+
+  def before(string: String, index: Int, all: Boolean): String = {
+    if (index < 0)
+      if (all) string
+      else ""
+    else string.substring(0, index)
+  }
+
+  def beforeLast(string: String, char: Char, all: Boolean = true): String =
+      before(string, string.lastIndexOf(char), all)
+
+  def beforeFirst(string: String, char: Char, all: Boolean = true): String =
+      before(string, string.indexOf(char), all)
+
+  def after(string: String, index: Int, all: Boolean): String = {
+    if (index < 0)
+      if (all) string
+      else ""
+    else string.substring(index + 1)
+  }
+
+  def afterLast(string: String, char: Char, all: Boolean = true): String =
+      after(string, string.lastIndexOf(char), all)
+
+  def afterFirst(string: String, char: Char, all: Boolean = true): String =
+      after(string, string.indexOf(char), all)
+}

--- a/src/test/scala/org/clulab/wm/eidos/system/TestParallel.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestParallel.scala
@@ -44,7 +44,7 @@ class TestParallel extends Test {
 //    def innerToText = toText(new EidosSystem())
 
     val expected = innerToText
-    val threads = 8
+    val threads = 2 // 8 // Cut this down for Travis
 
     behavior of "parallel EidosSystem calling of annotate"
 


### PR DESCRIPTION
This also works on Travis with crossScalaVersions.  This makes it possible to run Eidos from sbt without changing the source code.  This way people don't have to branch.