### PR TITLE
Restricted negation to not match when found in args

### DIFF
--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/causal.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/causal.yml
@@ -149,6 +149,33 @@ rules:
       cause: Entity = /${agents}/
 
 
+  - name: becauseOfSyntax1-${addlabel}
+    priority: ${rulepriority}
+    label: ${label}
+    action: ${ action }
+    example: "Because of the increase in conflict, many families do not have food. "
+    pattern: |
+      trigger = [lemma="because"]
+      cause: Entity = <case /${preps}|${noun_modifiers}/{,2}
+      effect: Entity =
+        (<case <nmod_because_of (?! [outgoing=dobj]) /${agents}/ /${ preps }/{,2})
+          |
+        (<case <nmod_because_of)
+
+  - name: becauseSyntax2-${addlabel}
+    priority: ${rulepriority}
+    label: ${label}
+    action: ${ action }
+    example: "Many families do not have food because the conflict has worsened."
+              #There is increased migration because the conflict has worsened.
+    pattern: |
+      trigger = [lemma="because"]
+      cause: Entity = <mark /${agents}|${preps}|${noun_modifiers}/{,2}
+      effect: Entity =
+        (<mark <advcl_because (?! [outgoing=dobj]) /${agents}/ /${ preps }/{,2})
+          |
+        (<mark <advcl_because)
+
 # ------------------- Explicitly Causal REACH --------------------------
 
   #We may need a better verb than "mediated" and "activation" here

--- a/src/test/scala/org/clulab/wm/eidos/system/TestNegation.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestNegation.scala
@@ -32,4 +32,10 @@ class TestNegation extends Test {
     val mentions1 = extractMentions(text1)
     mentions1.filter(em => em.isInstanceOf[EventMention]).exists(hasNegation) should be (true)
   }
+
+  it should "not match negation contained in the event arguments" in {
+    val text1 = "Many families do not have food because of the increase in conflict."
+    val mentions1 = extractMentions(text1)
+    mentions1.filter(em => em.isInstanceOf[EventMention]).exists(hasNegation) should be (false)
+  }
 }


### PR DESCRIPTION
We should be handling argument negation with either decreases or grounding, not by marking the whole event as negation.


Added test for this and also a few rules while I was there...