### PR TITLE
(long-awaited) Grounding to properties

### DIFF
--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -16,6 +16,7 @@ EidosSystem {
     wdiOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/wdi_ontology.yml
     faoOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/fao_variable_ontology.yml
    meshOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mesh_ontology.yml
+  propsOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_properties.yml
   timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
            cacheDir = ./cache/${EidosSystem.language}
              useW2V = false

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -20,8 +20,9 @@ EidosSystem {
     wdiOntologyPath = /org/clulab/wm/eidos/english/ontologies/wdi_ontology.yml
     faoOntologyPath = /org/clulab/wm/eidos/english/ontologies/fao_variable_ontology.yml
    meshOntologyPath = /org/clulab/wm/eidos/english/ontologies/mesh_ontology.yml
+  propsOntologyPath = /org/clulab/wm/eidos/english/ontologies/un_properties.yml
           cacheDir  = ./cache/english
-         ontologies = ["un", "wdi", "fao"] // , "mesh"]
+         ontologies = ["un", "wdi", "fao", "props"] // , "mesh"]
              useW2V = false
         useTimeNorm = false
            useCache = false

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -15,7 +15,7 @@ import org.clulab.wm.eidos.attachments.NegationHandler._
 import org.clulab.wm.eidos.entities.EidosEntityFinder
 import org.clulab.wm.eidos.groundings._
 import org.clulab.wm.eidos.groundings.Aliases.Groundings
-import org.clulab.wm.eidos.groundings.EidosOntologyGrounder.{FAO_NAMESPACE, MESH_NAMESPACE, UN_NAMESPACE, WDI_NAMESPACE}
+import org.clulab.wm.eidos.groundings.EidosOntologyGrounder.{FAO_NAMESPACE, MESH_NAMESPACE, PROPS_NAMESPACE, UN_NAMESPACE, WDI_NAMESPACE}
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils._
 import ai.lum.common.ConfigUtils._
@@ -95,6 +95,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Stop
     def     wdiOntologyPath: String = eidosConf[String]("wdiOntologyPath")
     def     faoOntologyPath: String = eidosConf[String]("faoOntologyPath")
     def    meshOntologyPath: String = eidosConf[String]("meshOntologyPath")
+    def   propsOntologyPath: String = eidosConf[String]("propsOntologyPath")
     def            cacheDir: String = eidosConf[String]("cacheDir")
 
     // These are needed to construct some of the loadable attributes even though it isn't a path itself.
@@ -114,10 +115,11 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) extends Stop
       val serializedPath: String = DomainOntologies.serializedPath(name, cacheDir)
 
       name match {
-        case   UN_NAMESPACE =>   UNOntology(  unOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
-        case  WDI_NAMESPACE =>  WDIOntology( wdiOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
-        case  FAO_NAMESPACE =>  FAOOntology( faoOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
-        case MESH_NAMESPACE => MeshOntology(meshOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
+        case    UN_NAMESPACE =>          UNOntology(  unOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
+        case   WDI_NAMESPACE =>         WDIOntology( wdiOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
+        case   FAO_NAMESPACE =>         FAOOntology( faoOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
+        case  MESH_NAMESPACE =>        MeshOntology(meshOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
+        case PROPS_NAMESPACE => PropertiesOntology(propsOntologyPath, serializedPath, proc, canonicalizer, useCache = useCache)
         case _ => throw new IllegalArgumentException("Ontology " + name + " is not recognized.")
       }
     }

--- a/src/main/scala/org/clulab/wm/eidos/apps/CacheOntologies.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/CacheOntologies.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
 import org.clulab.utils.Configured
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.groundings.CompactDomainOntology.CompactDomainOntologyBuilder
-import org.clulab.wm.eidos.groundings.EidosOntologyGrounder.{FAO_NAMESPACE, MESH_NAMESPACE, UN_NAMESPACE, WDI_NAMESPACE}
+import org.clulab.wm.eidos.groundings.EidosOntologyGrounder.{FAO_NAMESPACE, MESH_NAMESPACE, PROPS_NAMESPACE, UN_NAMESPACE, WDI_NAMESPACE}
 import org.clulab.wm.eidos.groundings._
 import org.clulab.wm.eidos.utils.Canonicalizer
 
@@ -21,6 +21,7 @@ object CacheOntologies extends App with Configured {
   new File(cacheDir).mkdirs()
 
   val ontologies: Seq[String] = loadableAttributes.ontologies
+
   if (ontologies.isEmpty)
     throw new RuntimeException("No ontologies were specified, please check the config file.")
   else {
@@ -32,10 +33,11 @@ object CacheOntologies extends App with Configured {
       val serializedPath = DomainOntologies.serializedPath(domainOntology, cacheDir)
 
       val ontology: DomainOntology = domainOntology match {
-        case   UN_NAMESPACE =>   UNOntology(loadableAttributes.unOntologyPath,   serializedPath, proc, canonicalizer, useCache = false)
-        case  WDI_NAMESPACE =>  WDIOntology(loadableAttributes.wdiOntologyPath,  serializedPath, proc, canonicalizer, useCache = false)
-        case  FAO_NAMESPACE =>  FAOOntology(loadableAttributes.faoOntologyPath,  serializedPath, proc, canonicalizer, useCache = false)
-        case MESH_NAMESPACE => MeshOntology(loadableAttributes.meshOntologyPath, serializedPath, proc, canonicalizer, useCache = false)
+        case   UN_NAMESPACE =>          UNOntology(loadableAttributes.unOntologyPath,    serializedPath, proc, canonicalizer, useCache = false)
+        case  WDI_NAMESPACE =>         WDIOntology(loadableAttributes.wdiOntologyPath,   serializedPath, proc, canonicalizer, useCache = false)
+        case  FAO_NAMESPACE =>         FAOOntology(loadableAttributes.faoOntologyPath,   serializedPath, proc, canonicalizer, useCache = false)
+        case MESH_NAMESPACE =>        MeshOntology(loadableAttributes.meshOntologyPath,  serializedPath, proc, canonicalizer, useCache = false)
+        case PROPS_NAMESPACE => PropertiesOntology(loadableAttributes.propsOntologyPath, serializedPath, proc, canonicalizer, useCache = false)
         case _ => throw new IllegalArgumentException("Ontology " + domainOntology + " is not recognized.")
       }
       val treeDomainOntology = ontology.asInstanceOf[TreeDomainOntology]

--- a/src/main/scala/org/clulab/wm/eidos/attachments/EidosAttachment.scala
+++ b/src/main/scala/org/clulab/wm/eidos/attachments/EidosAttachment.scala
@@ -75,6 +75,14 @@ object EidosAttachment {
       .arguments
       .get("quantifier")
       .map(qs => qs.map(_.text))
+
+  def getAttachmentWords(a: Attachment): Seq[String] = {
+    a match {
+      case triggered: TriggeredAttachment => Seq(triggered.trigger) ++ triggered.quantifiers.getOrElse(Seq())
+      case context: ContextAttachment => context.text.split(" ")
+      case _ => throw new RuntimeException(s"Unsupported class of attachment: ${a.getClass}")
+    }
+  }
 }
 
 case class AttachmentInfo(triggerText: String, quantifierTexts: Option[Seq[String]] = None,

--- a/src/main/scala/org/clulab/wm/eidos/groundings/DomainOntologies.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/DomainOntologies.scala
@@ -28,6 +28,11 @@ object UNOntology {
       DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
 }
 
+object PropertiesOntology {
+  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
+    DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
+}
+
 object WDIOntology {
   def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
       DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
@@ -47,3 +52,5 @@ object MeshOntology {
   def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
       DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
 }
+
+

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -1,5 +1,6 @@
 package org.clulab.wm.eidos.groundings
 
+import org.clulab.wm.eidos.attachments.{EidosAttachment, Property}
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.Namer
 import org.slf4j.LoggerFactory
@@ -45,15 +46,33 @@ class EidosOntologyGrounder(val name: String, domainOntology: DomainOntology, wo
   }
 }
 
+class PropertiesOntologyGrounder(name: String, domainOntology: DomainOntology, wordToVec: EidosWordToVec) extends EidosOntologyGrounder(name, domainOntology, wordToVec) {
+
+  override def groundOntology(mention: EidosMention): OntologyGrounding = {
+    if (mention.odinMention.matches("Entity")) { // TODO: Store this string somewhere
+      val propertyAttachments = mention.odinMention.attachments.filter(a => a.isInstanceOf[Property])
+      val propertyTokens = propertyAttachments.flatMap(EidosAttachment.getAttachmentWords).toArray
+
+      OntologyGrounding(wordToVec.calculateSimilarities(propertyTokens, conceptEmbeddings))
+    }
+    else
+      OntologyGrounding()
+  }
+}
+
 object EidosOntologyGrounder {
   // Namespace strings for the different in-house ontologies we typically use
   val   UN_NAMESPACE = "un"
   val  WDI_NAMESPACE = "wdi"
   val  FAO_NAMESPACE = "fao"
   val MESH_NAMESPACE = "mesh"
+  val PROPS_NAMESPACE = "props"
 
   protected val logger = LoggerFactory.getLogger(this.getClass())
 
-  def apply(name: String, domainOntology: DomainOntology, wordToVec: EidosWordToVec) =
-      new EidosOntologyGrounder(name, domainOntology, wordToVec)
+  def apply(name: String, domainOntology: DomainOntology, wordToVec: EidosWordToVec): EidosOntologyGrounder =
+    name match {
+      case PROPS_NAMESPACE => new PropertiesOntologyGrounder(name, domainOntology, wordToVec)
+      case _ => new EidosOntologyGrounder(name, domainOntology, wordToVec)
+    }
 }

--- a/src/main/scala/org/clulab/wm/eidos/mentions/EidosMention.scala
+++ b/src/main/scala/org/clulab/wm/eidos/mentions/EidosMention.scala
@@ -134,14 +134,6 @@ abstract class EidosMention(val odinMention: Mention, canonicalizer: Canonicaliz
   def tokenIntervals: Seq[Interval] = Seq(odinMention.tokenInterval)
   def negation: Boolean = ???
 
-  def getAttachmentWords(a: Attachment): Seq[String] = {
-    a match {
-      case triggered: TriggeredAttachment => Seq(triggered.trigger) ++ triggered.quantifiers.getOrElse(Seq())
-      case context: ContextAttachment => context.text.split(" ")
-      case _ => throw new RuntimeException(s"Unsupported class of attachment: ${a.getClass}")
-    }
-  }
-
   /* Methods for canonicalForms of Mentions */
   protected def canonicalFormSimple(m: Mention): String = {
     val words = m.words
@@ -149,7 +141,7 @@ abstract class EidosMention(val odinMention: Mention, canonicalizer: Canonicaliz
     val tags = m.tags.get
     val ners = m.entities.get
 
-    val attachmentWords = m.attachments.flatMap(a => getAttachmentWords(a)).toSet
+    val attachmentWords = m.attachments.flatMap(a => EidosAttachment.getAttachmentWords(a)).toSet
 
     val contentLemmas = for {
       i <- lemmas.indices


### PR DESCRIPTION
Only the text of the property attachments is being used at the moment,
subject to change.

example in the JSON-LD for "price of rainfall" (please ignore non-sensicalness):
```
{
    "@type" : "Extraction",
    "@id" : "_:Extraction_4",
    "type" : "concept",
    "subtype" : "entity",
    "labels" : [ "Concept", "Entity" ],
    "text" : "price of rainfall",
    "rule" : "simple-np++property-lexiconner",
    "canonicalName" : "rainfall",
    "groundings" : [ {
      "@type" : "Groundings",
      "name" : "un",
      "values" : [ {
        "@type" : "Grounding",
        "ontologyConcept" : "UN/events/weather/precipitation",
        "value" : 0.8835827708244324
      }, {
        "@type" : "Grounding",
        "ontologyConcept" : "UN/events/natural_disaster/storm",
        "value" : 0.6114242672920227
      }, {
        "@type" : "Grounding",
        "ontologyConcept" : "UN/events/natural_disaster/drought",
        "value" : 0.585636556148529
  ...
    }, {
      "@type" : "Groundings",
      "name" : "props",
      "values" : [ {
        "@type" : "Grounding",
        "ontologyConcept" : "UN_properties/properties/price",
        "value" : 0.638780415058136
      }, {
        "@type" : "Grounding",
        "ontologyConcept" : "UN_properties/properties/volume",
        "value" : 0.45264413952827454
      }, 
...
```

@bgyori I'd be very interested to know how readily you can use this information, also how good it seems to perform...

@bgyori also note, since I'm currently only using the previously found Property attachments, if a mention does not have a property attachment, if has a block for this grounding, but no values, e.g., with "seasonal rains":
```
"extractions" : [ {
    "@type" : "Extraction",
    "@id" : "_:Extraction_3",
    "type" : "concept",
    "subtype" : "entity",
    "labels" : [ "Concept", "Entity" ],
    "text" : "Seasonal rains",
    "rule" : "simple-np",
    "canonicalName" : "rain",
    "groundings" : [ {
      "@type" : "Groundings",
      "name" : "un",
      "values" : [ {
        "@type" : "Grounding",
        "ontologyConcept" : "UN/events/weather/precipitation",
        "value" : 0.8207645416259766
      }, {
 ...
, {
      "@type" : "Groundings",
      "name" : "props"
    } ],
```

closes #409 