### PR TITLE
Web service endpoint for web application

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ page.
 - Running Eidos
   - Using the Sample Apps
     - [Webapp](#webapp)
+    - [Web Service](#web-service)
     - [Interactive Shell](#interactive-shell)
     - [ExtractAndExport](#extractandexport)
     - [Other Apps](#other-apps)
@@ -94,6 +95,31 @@ will be processed much more quickly.
 To eventually escape from `sbt`, you can stop the web server with Control-D and then quit the
 program with `exit`.
 
+### Web Service
+When the web app is run, it exposes a web service at port `9000` via the `/process_text` endpoint. It accepts a `POST` request and requires JSON with the following parameter:
+
+* `text`: the text you wish to submit for parsing by Eidos.
+
+For example, we can use the Python `requests` library to interact with the web service with the following:
+
+```
+import requests
+
+text = """Drought increases regional insecurity."""
+
+webservice = 'http://localhost:9000'
+res = requests.post('%s/process_text' %webservice, headers={'Content-type': 'application/json'}, json={'text': text})
+
+json_dict = res.json()
+```
+
+Using `CURL` we can do the same with:
+
+curl \
+  --header "Content-type: application/json" \
+  --request POST \
+  --data '{"text": "Drought increases regional insecurity."}' \
+  http://localhost:9000/process_text
 
 ### Interactive Shell
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,13 @@ json_dict = res.json()
 
 Using `CURL` we can do the same with:
 
+```
 curl \
   --header "Content-type: application/json" \
   --request POST \
   --data '{"text": "Drought increases regional insecurity."}' \
   http://localhost:9000/process_text
+```
 
 ### Interactive Shell
 

--- a/src/main/scala/org/clulab/wm/eidos/utils/PlayUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/PlayUtils.scala
@@ -1,0 +1,29 @@
+package org.clulab.wm.eidos.utils
+
+import play.api.libs.{ json => pjson }
+import org.{ json4s => j4s }
+
+object PlayUtils {
+
+  implicit def toJson4s(json: play.api.libs.json.JsValue):org.json4s.JValue = json match {
+    case pjson.JsString(str) => j4s.JString(str)
+    case pjson.JsNull => j4s.JNull
+    case pjson.JsBoolean(value) => j4s.JBool(value)
+    case pjson.JsNumber(value) => j4s.JDecimal(value)
+    case pjson.JsArray(items) => j4s.JArray(items.map(toJson4s(_)).toList)
+    case pjson.JsObject(items) => j4s.JObject(items.map { case (k, v) => k -> toJson4s(v)}.toList)
+  }
+
+  implicit def toPlayJson(json: org.json4s.JValue): play.api.libs.json.JsValue = json match {
+    case j4s.JString(str) => pjson.JsString(str)
+    case j4s.JNothing => pjson.JsNull
+    case j4s.JNull => pjson.JsNull
+    case j4s.JDecimal(value) => pjson.JsNumber(value)
+    case j4s.JDouble(value) => pjson.JsNumber(value)
+    case j4s.JInt(value) => pjson.JsNumber(BigDecimal(value))
+    case j4s.JLong(value) => pjson.JsNumber(BigDecimal(value))
+    case j4s.JBool(value) => pjson.JsBoolean(value)
+    case j4s.JArray(fields) => pjson.JsArray(fields.map(toPlayJson(_)))
+    case j4s.JObject(fields) => pjson.JsObject(fields.map { case (k, v) => k -> toPlayJson(v)}.toMap)
+  }
+}

--- a/src/main/scala/org/clulab/wm/eidos/utils/PlayUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/PlayUtils.scala
@@ -25,5 +25,6 @@ object PlayUtils {
     case j4s.JBool(value) => pjson.JsBoolean(value)
     case j4s.JArray(fields) => pjson.JsArray(fields.map(toPlayJson(_)))
     case j4s.JObject(fields) => pjson.JsObject(fields.map { case (k, v) => k -> toPlayJson(v)}.toMap)
+    case j4s.JSet(fields) => pjson.JsArray(fields.toList.map(toPlayJson(_)))
   }
 }

--- a/webapp/conf/routes
+++ b/webapp/conf/routes
@@ -6,6 +6,7 @@
 # An example controller showing a sample home page
 GET     /                           controllers.HomeController.index
 GET     /parseText                  controllers.HomeController.parseText(text: String, cagRelevantOnly: Boolean)
+POST    /process_text               controllers.HomeController.process_text
 GET     /buildInfo                  controllers.HomeController.buildInfo
 GET     /config                     controllers.HomeController.config
 

--- a/webapp/test/controllers/HomeControllerSpec.scala
+++ b/webapp/test/controllers/HomeControllerSpec.scala
@@ -4,6 +4,7 @@ import org.scalatestplus.play._
 import org.scalatestplus.play.guice._
 import play.api.test._
 import play.api.test.Helpers._
+import play.api.libs.json._
 
 /**
  * Add your spec here.

--- a/webapp/test/controllers/HomeControllerSpec.scala
+++ b/webapp/test/controllers/HomeControllerSpec.scala
@@ -21,7 +21,7 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include ("World Modelers Visualizer")
     }
 
     "render the index page from the application" in {
@@ -30,7 +30,7 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include ("World Modelers Visualizer")
     }
 
     "render the index page from the router" in {
@@ -39,7 +39,7 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Welcome to Play")
+      contentAsString(home) must include ("World Modelers Visualizer")
     }
   }
 

--- a/webapp/test/controllers/HomeControllerSpec.scala
+++ b/webapp/test/controllers/HomeControllerSpec.scala
@@ -42,4 +42,19 @@ class HomeControllerSpec extends PlaySpec with GuiceOneAppPerTest with Injecting
       contentAsString(home) must include ("Welcome to Play")
     }
   }
+
+  "HomeController POST" should {
+    "accept request with text parameter and return JSON" in {
+
+      // Note that the request fails because the JSON does not have key 'text' but instead has key 'text123'
+      // This is because testing an actual run requires initialization which takes too long
+
+      val testJson = Json.parse("""{ "text123": "Drought causes regional instability." }""")
+      val request = FakeRequest(POST, "/process_text").withJsonBody(testJson)
+      val result = route(app, request).get
+
+      contentAsString(result) must include ("Missing parameter [text]")
+    }
+  }
+  
 }


### PR DESCRIPTION
This PR includes service enabling the web application with the creation of a `/process_text` endpoint. After the web application is run, a user may `POST` a request with JSON to the `/process_text` endpoint. The user will be returned an Eidos processed document in JSON-LD format.

I included additional docs/examples in the README as well as a test. I corrected the webapp tests so that they function when invoked with `sbt webapp/test`.

I attempted to follow your design paradigms as best as I could, and intend this mostly to open discussion around this capability and hopefully to see it included in Eidos if you think it is useful and valid. 

The use case for this is to be able to provide a ready made Docker container which initializes the web application upon start so that users (e.g. data scientists) who may only work in Python/R/etc. and are unfamiliar with Java/Scala could easily deploy Eidos. As INDRA and Delphi are Python this reduces friction for someone who wants to run INDRA + Delphi + Eidos.

To manually test this PR you should run (after cloning this fork) :
```
cd eidos
git checkout webservice
sbt webapp/run
```
Then you can submit a request with:
```
curl \
  --header "Content-type: application/json" \
  --request POST \
  --data '{"text": "Drought increases regional insecurity."}' \
  http://localhost:9000/process_text
```

To run the automated tests:
```
cd eidos
git checkout webservice
sbt webapp/test
```
