### PR TITLE
Sorted to expand closest args first

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/actions/ExpansionHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/actions/ExpansionHandler.scala
@@ -326,11 +326,6 @@ class ExpansionHandler(val language: String) extends LazyLogging {
       m
   }
 
-  def addOverlappingAttachmentsTextBounds(ms: Seq[Mention], state: State): Seq[Mention] = {
-    for {
-      m <- ms
-    } yield addOverlappingAttachmentsTextBounds(m, state)
-  }
   def addOverlappingAttachmentsTextBounds(m: Mention, state: State): Mention = {
     m match {
       case tb: TextBoundMention =>


### PR DESCRIPTION
... had to refactor to make it work...

should help with sentences where both args are on the same side of the trigger and the further away arg swallows the closer, as with the sentence:
```Areas of greatest concern include Wau , northwestern Jonglei , and central Unity , though given the severity of food insecurity across South Sudan and unpredictable nature of conflict , the possibility of Famine ( IPC Phase 5 ) should be considered in many states of the country .```