### PR TITLE
Add program to process serialized documents

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractDocumentFromDirectory.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractDocumentFromDirectory.scala
@@ -1,0 +1,67 @@
+package org.clulab.wm.eidos.apps
+
+import org.clulab.processors.Document
+import org.clulab.serialization.DocumentSerializer
+import org.clulab.serialization.json.{JSONSerializer, stringify}
+import org.clulab.wm.eidos.AnnotatedDocument
+import org.clulab.wm.eidos.EidosSystem
+import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.utils.Closer.AutoCloser
+import org.clulab.wm.eidos.utils.FileUtils
+import org.clulab.wm.eidos.utils.FileUtils.findFiles
+import org.json4s.jackson.JsonMethods
+
+object ExtractDocumentFromDirectory extends App {
+
+  def annotateTxt(reader: EidosSystem, text: String): AnnotatedDocument = {
+    reader.extractFromText(text)
+  }
+
+  protected def annotateDocument(reader: EidosSystem, document: Document): AnnotatedDocument = {
+    val eidosDoc = reader.annotateDoc(document)
+
+    reader.extractFromDoc(eidosDoc)
+  }
+
+  def annotateJson(reader: EidosSystem, text: String): AnnotatedDocument = {
+    val doc: Document = JSONSerializer.toDocument(JsonMethods.parse(text))
+
+    annotateDocument(reader, doc)
+  }
+
+  def annotateDoc(reader: EidosSystem, text: String): AnnotatedDocument = {
+    val doc: Document = (new DocumentSerializer).load(text)
+
+    annotateDocument(reader, doc)
+  }
+
+  val inputDir = args(0)
+  val outputDir = args(1)
+  val format = if (args.length >= 2) args(2) else "1"
+  val extension = if (args.length >= 3) args(3) else "txt"
+  val annotator = format match {
+    case "1" => annotateTxt _
+    case "2" => annotateJson _
+    case "3" => annotateDoc _
+    case _ => throw new Exception(s"Unknown format '$format'")
+  }
+  val files = findFiles(inputDir, extension)
+  val reader = new EidosSystem()
+
+  // For each file in the input directory:
+  files.par.foreach { file =>
+    // 1. Open corresponding output file
+    println(s"Extracting from ${file.getName}")
+    FileUtils.printWriterFromFile(s"$outputDir/${file.getName}.jsonld").autoClose { pw =>
+      // 2. Get the input file contents
+      val text = FileUtils.getTextFromFile(file)
+      // 3. Extract causal mentions from the text
+      val annotatedDocuments = Seq(annotator(reader, text))
+      // 4. Convert to JSON
+      val corpus = new JLDCorpus(annotatedDocuments, reader)
+      val mentionsJSONLD = corpus.serialize()
+      // 5. Write to output file
+      pw.println(stringify(mentionsJSONLD, pretty = true))
+    }
+  }
+}

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractDocumentFromDirectory.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractDocumentFromDirectory.scala
@@ -37,8 +37,8 @@ object ExtractDocumentFromDirectory extends App {
 
   val inputDir = args(0)
   val outputDir = args(1)
-  val format = if (args.length >= 2) args(2) else "1"
-  val extension = if (args.length >= 3) args(3) else "txt"
+  val format = if (args.length > 2) args(2) else "1"
+  val extension = if (args.length > 3) args(3) else "txt"
   val annotator = format match {
     case "1" => annotateTxt _
     case "2" => annotateJson _

--- a/src/test/scala/org/clulab/wm/eidos/serialization/TestDocSerialization.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/TestDocSerialization.scala
@@ -12,29 +12,29 @@ import org.clulab.serialization.json.{DocOps, JSONSerializer}
 import org.json4s.jackson.JsonMethods.{parse, pretty, render}
 
 class TestDocSerialization extends Test {
-  val reader = new EidosSystem()
   val text = "Water trucking has decreased due to the cost of fuel last week." // "last week" added for time
-  val annotatedDocument = reader.extractFromText(text)
+  val reader = new EidosSystem()
+  val document = reader.extractFromText(text).document
 
   behavior of "Java serializer"
 
   it should "serialize and deserialize documents" in {
 
-    def serialize(original: Any): Unit = {
-      val copy = (new ByteArrayOutputStream()).autoClose { streamOut =>
+    def serialize(original: Document): Unit = {
+      val serial = (new ByteArrayOutputStream()).autoClose { streamOut =>
         (new ObjectOutputStream(streamOut)).autoClose { encoder =>
           encoder.writeObject(original)
         }
-
-        val bytes = streamOut.toByteArray
-
-        FileUtils.load[Any](bytes, this)
+        streamOut.toByteArray
       }
+      val copy = FileUtils.load[Document](serial, this)
 
       copy should not be (None)
+//      copy should be (original)
+//      document.hashCode should be (copy.hashCode)
     }
 
-    serialize(annotatedDocument.document)
+    serialize(document)
   }
 
   behavior of "JSON serializer"
@@ -48,7 +48,7 @@ class TestDocSerialization extends Test {
       copy should not be (None)
     }
 
-    serialize(annotatedDocument.document)
+    serialize(document)
   }
 
   behavior of "Custom serializer"
@@ -63,6 +63,6 @@ class TestDocSerialization extends Test {
       copy should not be (None)
     }
 
-    serialize(annotatedDocument.document)
+    serialize(document)
   }
 }

--- a/src/test/scala/org/clulab/wm/eidos/serialization/TestDocSerialization.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/TestDocSerialization.scala
@@ -1,0 +1,68 @@
+package org.clulab.wm.eidos.serialization
+
+import java.io.{ByteArrayOutputStream, ObjectOutputStream}
+
+import org.clulab.processors.Document
+import org.clulab.serialization.DocumentSerializer
+import org.clulab.wm.eidos.EidosSystem
+import org.clulab.wm.eidos.test.TestUtils.Test
+import org.clulab.wm.eidos.utils.Closer.AutoCloser
+import org.clulab.wm.eidos.utils.FileUtils
+import org.clulab.serialization.json.{DocOps, JSONSerializer}
+import org.json4s.jackson.JsonMethods.{parse, pretty, render}
+
+class TestDocSerialization extends Test {
+  val reader = new EidosSystem()
+  val text = "Water trucking has decreased due to the cost of fuel last week." // "last week" added for time
+  val annotatedDocument = reader.extractFromText(text)
+
+  behavior of "Java serializer"
+
+  it should "serialize and deserialize documents" in {
+
+    def serialize(original: Any): Unit = {
+      val copy = (new ByteArrayOutputStream()).autoClose { streamOut =>
+        (new ObjectOutputStream(streamOut)).autoClose { encoder =>
+          encoder.writeObject(original)
+        }
+
+        val bytes = streamOut.toByteArray
+
+        FileUtils.load[Any](bytes, this)
+      }
+
+      copy should not be (None)
+    }
+
+    serialize(annotatedDocument.document)
+  }
+
+  behavior of "JSON serializer"
+
+  it should "serialize and deserialize documents" in {
+
+    def serialize(original: Document): Unit = {
+      val serial = pretty(render(original.jsonAST))
+      val copy = JSONSerializer.toDocument(parse(serial))
+
+      copy should not be (None)
+    }
+
+    serialize(annotatedDocument.document)
+  }
+
+  behavior of "Custom serializer"
+
+  it should "serialize and deserialize documents" in {
+
+    def serialize(original: Document): Unit = {
+      val serializer = new DocumentSerializer
+      val serial = serializer.save(original, "UTF-8", true)
+      val copy = serializer.load(serial)
+
+      copy should not be (None)
+    }
+
+    serialize(annotatedDocument.document)
+  }
+}


### PR DESCRIPTION
This includes is a simple program to address this request:

I’d like to add some new functionality to Eidos. In particular, it should have the ability to parse documents that have been preprocessed by processors (that is, POS tagging and parsing). This output is a JSON format that serializes the document with this information. So, Eidos may see a directory of .txt files (as it does today) or a directory of pre-processed files produced by processors.