### PR TITLE
Eidos web app/web service Docker container

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,44 @@
+FROM ubuntu:16.04
+
+# Install base packages
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    software-properties-common \ 
+    dialog \
+    git \
+    graphviz \
+    libgraphviz-dev \
+    vim
+
+# Install Java
+RUN add-apt-repository -y ppa:webupd8team/java
+RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
+RUN apt-get update && apt-get install -y \
+    oracle-java8-installer 
+RUN export JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
+RUN export PATH="$JAVA_HOME/bin:$PATH"    
+
+# Install Scala
+WORKDIR /
+RUN apt-get remove scala-library scala
+RUN wget http://scala-lang.org/files/archive/scala-2.12.7.deb
+RUN dpkg -i scala-2.12.7.deb
+RUN apt-get update && apt-get install scala
+RUN apt-get install apt-transport-https -y
+RUN echo "deb https://dl.bintray.com/sbt/debian /" |  tee -a /etc/apt/sources.list.d/sbt.list
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+RUN apt-get update && apt-get install sbt -y
+
+# Clone the Eidos repo
+RUN git clone https://github.com/clulab/eidos.git
+WORKDIR /eidos
+RUN wget https://s3.amazonaws.com/world-modelers/data/vectors.txt
+RUN mv vectors.txt src/main/resources/org/clulab/wm/eidos/english/w2v/
+RUN sed -i 's/useW2V = false/useW2V = true/' src/main/resources/eidos.conf
+RUN sed -i 's/useW2V = false/useW2V = true/' src/main/resources/reference.conf
+RUN sed -i 's/glove.840B.300d.vectors.txt/vectors.txt/' src/main/resources/eidos.conf
+RUN sbt assembly
+
+# Run Web Service
+EXPOSE 9000
+ENTRYPOINT ["sbt", "webapp/run"]

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,17 @@
+# Eidos Docker
+This directory contains a Dockerfile which generates a container that runs the Eidos web application and web service. From this directory you can build the container with:
+
+```
+docker build -f Dockerfile . -t eidos-webservice
+```
+
+You can run the container with:
+
+```
+docker run -id -p 9000:9000 eidos-webservice
+```
+
+This launches the container and exposes port 9000. You can then navigate to `localhost:9000` to access the web application and may submit requests to `localhost:9000/process_text` as described [here](https://github.com/clulab/eidos#web-service).
+
+### Configuration
+Currently, this container is built with grounding activated (`useW2V = true`) and Google's pre-trained vectors are used, not GloVe.


### PR DESCRIPTION
### What's new

This PR adds a directory to the top level of the project called `Docker`. Within this directory is a `Dockerfile` which builds the Docker container. Instructions for building the container and running it are included in the readme (`Docker/README.md`).

### Configuration

This container automatically runs the Eidos web application on port 9000. It defaults to using word2vec and Google's pre-trained vectors. In the future this could be configured by a user at the time the container is run, but would require adding GloVe vectors to the container image (thereby increasing its size). 

### Testing this PR

After pulling this PR code you can try:

```
cd Docker
docker build -f Dockerfile . -t eidos-webservice
```

Building the container will take some time. Once it completes you can try:

```
docker run -id -p 9000:9000 eidos-webservice
```

Then, you should be able to navigate to the web application in your browser at `localhost:9000`.

### Outstanding Issues

1. When the container is first initialized via `docker run [etc]` the web application runs, but the vectors are not loaded until the first call to the application is made. Therefore, the first API request to the `process_text` endpoint  is slow. Subsequent requests run normally.
2. The container must be run in interactive mode (with the `-i` flag specified) at run time since the web application requires stdin, which is normally surpressed by Docker. See this [StackOverflow post](https://stackoverflow.com/questions/46637070/akka-http-shuts-down-prematurely-in-a-docker-container) for more detail.
3. A built container could be pushed to a registry (e.g. Dockerhub). This can be done automatically with [Travis CI](https://docs.travis-ci.com/user/docker/).