### PR TITLE
Updates for newest geonorm model

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Eidos and declared in `built.sbt` as a library dependency.  Change the value of
 `useTimeNorm` from `false` to `true` to use the time functions.
 
 The newest model file used for geolocations is too large for GitHub and requires additional installation.
-Download [geonorm_model.hdf5](https://drive.google.com/file/d/16vIRhfEHjEMxnGTemnaUhkQT1eVbUm6j/view?usp=sharing)
+Download [geonorm_model.dl4j.zip](https://drive.google.com/open?id=10d8QSatXHQCfW5G-ON0kC698zo7q5BzT)
 and place it in the directory `src/main/resources/org/clulab/wm/eidos/models/`.  Then change the value of
 `useGeoNorm` from `false` to `true` to use the functions.
 

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -21,7 +21,7 @@ EidosSystem {
   mitre12OntologyPath = /org/clulab/wm/eidos/english/ontologies/mitre12_indicators.yml
       whoOntologyPath = /org/clulab/wm/eidos/english/ontologies/who_ontology.yml
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
-     geoNormModelPath = /org/clulab/wm/eidos/models/geonorm_model.hdf5
+     geoNormModelPath = /org/clulab/wm/eidos/models/geonorm_model.dl4j.zip
       geoWord2IdxPath = /org/clulab/wm/eidos/english/context/word2idx_file.txt
         geoLoc2IdPath = /org/clulab/wm/eidos/english/context/geo_dict_with_population_SOUTH_SUDAN.txt
 

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/geoLocationAttachment.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/geoLocationAttachment.yml
@@ -8,4 +8,4 @@ rules:
     action: ${ action }
     pattern: |
       trigger = [norm="LOC"] [norm="LOC"]*
-      theme: Entity = </^nmod/ >nmod_in?
+      theme: Entity = <compound? </^nmod/ >nmod_in?

--- a/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
@@ -468,18 +468,15 @@ class EidosActions(val taxonomy: Taxonomy, val expansionHandler: ExpansionHandle
       flattenedContextAttachments = entities.flatMap(_.attachments.filter(_.isInstanceOf[ContextAttachment]).map(_.asInstanceOf[ContextAttachment]))
       filteredAttachments = filterAttachments(flattenedTriggeredAttachments)
     } yield {
-      if (filteredAttachments.nonEmpty) {
-
+      val bestEntities = if (filteredAttachments.nonEmpty) {
         val bestAttachment = filteredAttachments.sorted.reverse.head
         // Since head was used above and there could have been a tie, == should be used below
         // The tie can be broken afterwards.
-        val bestEntities = entities.filter(_.attachments.exists(_ == bestAttachment))
-        val bestEntity = tieBreaker(bestEntities)
-
-        MentionUtils.withOnlyAttachments(bestEntity, filteredAttachments  ++ flattenedContextAttachments)
+        entities.filter(_.attachments.exists(_ == bestAttachment))
+      } else {
+        entities
       }
-      else
-        tieBreaker(entities)
+      MentionUtils.withOnlyAttachments(tieBreaker(bestEntities), filteredAttachments ++ flattenedContextAttachments)
     }
 
     val res = keepMostCompleteEvents(mergedEntities.toSeq ++ nonentities, state)

--- a/src/main/scala/org/clulab/wm/eidos/context/GeoDisambiguateParser.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/GeoDisambiguateParser.scala
@@ -1,5 +1,7 @@
 package org.clulab.wm.eidos.context
 
+import java.io.InputStream
+
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.Sourcer
 import org.deeplearning4j.nn.graph.ComputationGraph
@@ -36,8 +38,8 @@ object KerasToDL4J {
   }
 }
 
-class GeoDisambiguateParser(modelPath: String, word2IdxPath: String, loc2geonameIDPath: String) {
-  protected val network: ComputationGraph = ModelSerializer.restoreComputationGraph(modelPath)
+class GeoDisambiguateParser(modelStream: InputStream, word2IdxPath: String, loc2geonameIDPath: String) {
+  protected val network: ComputationGraph = ModelSerializer.restoreComputationGraph(modelStream)
   lazy protected val word2int: Map[String, Int] = readDict(word2IdxPath)
   // provide path of geoname dict file having geonameID with max population
   lazy protected val loc2geonameID: Map[String, Int] = readDict(loc2geonameIDPath)

--- a/src/test/resources/englishTest.conf
+++ b/src/test/resources/englishTest.conf
@@ -17,8 +17,10 @@ EidosSystem {
     faoOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/fao_variable_ontology.yml
    meshOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mesh_ontology.yml
   timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
+   geoNormModelPath = /org/clulab/wm/eidos/models/geonorm_model.dl4j.zip
            cacheDir = ./cache/${EidosSystem.language}
              useW2V = false
         useTimeNorm = false
+         useGeoNorm = false
            useCache = false
 }

--- a/src/test/scala/org/clulab/wm/eidos/graph/GraphTester.scala
+++ b/src/test/scala/org/clulab/wm/eidos/graph/GraphTester.scala
@@ -34,10 +34,9 @@ class GraphTester(ieSystem: EidosSystem, text: String) {
   }
 
   protected def toString(mentions: Seq[Mention]): String = {
-    val stringBuilder = new StringBuilder()
-
-    mentions.indices.foreach(index => stringBuilder.append(s"$index: ${mentions(index).text}\n"))
-    stringBuilder.toString()
+    mentions.zipWithIndex.map{case (mention, index) => {
+      s"$index: ${mention.text} ${mention.attachments.mkString(", ")}"
+    }}.mkString("\n")
   }
 
   protected def annotateTest(result: Seq[String]): Seq[String] =

--- a/src/test/scala/org/clulab/wm/eidos/text/english/cag/TestCagP2.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/cag/TestCagP2.scala
@@ -11,7 +11,7 @@ class TestCagP2 extends EnglishTest {
     val tester = new GraphTester(p2s1)
 
     val economicCrisis = NodeSpec("South Sudan's economic crisis", GeoLoc("South Sudan"))
-    val sudanesePound = NodeSpec("rapidly depreciating value of the South Sudanese Pound (SSP)", Dec("depreciating", "rapidly"))
+    val sudanesePound = NodeSpec("rapidly depreciating value of the South Sudanese Pound (SSP)", Dec("depreciating", "rapidly"), GeoLoc("South"), GeoLoc("Pound"))
     val hardCurrency = NodeSpec("shortages of hard currency", Dec("shortages"))
     val oilPrices = NodeSpec("global declines in oil prices", Dec("declines"))
     val dependenceOnImports = NodeSpec("significant dependence on imports", Quant("significant"))

--- a/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc3.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc3.scala
@@ -129,7 +129,7 @@ class TestDoc3 extends EnglishTest {
 
     val rainfall1 = NodeSpec("rainfall", Quant("average to above average"))
     val rainfall2 = NodeSpec("Widespread rains", Inc("Widespread"), Inc("favorable"), Quant("favorable"))
-    val cropDevelopment = NodeSpec("crop development in Greater Bahr el Ghazal and Greater Upper Nile states", Inc("favorable"))
+    val cropDevelopment = NodeSpec("crop development in Greater Bahr el Ghazal and Greater Upper Nile states", GeoLoc("Greater Bahr"), GeoLoc("Ghazal"), GeoLoc("Greater Upper Nile"), Inc("favorable"))
     val rainfall3 = NodeSpec("rainfall", Dec("reduction", "slight")) // todo (temporal?): really should capture the "compared to the previous month"...
     val rainfall4 = NodeSpec("rainfall", Dec("decline"))
     val moistureStress = NodeSpec("moisture stress on crops")
@@ -305,7 +305,7 @@ class TestDoc3 extends EnglishTest {
     behavior of "TestDoc3 Paragraph 9"
     val cropCond = NodeSpec("Cropping conditions", Inc("favorable"), Quant("favorable"))
     val rainfall = NodeSpec("good performance of seasonal rainfall", Quant("good"), Inc("good"))
-    val rainfall2 = NodeSpec("persistently well above-average rainfall over the western Ethiopia highlands", Inc("above-average","persistently", "well"), Quant("above-average", "persistently", "well"))
+    val rainfall2 = NodeSpec("persistently well above-average rainfall over the western Ethiopia highlands", Inc("above-average","persistently", "well"), Quant("above-average", "persistently", "well"), GeoLoc("Ethiopia"))
     val flood = NodeSpec("flooding", TimEx("weeks"))
     val rainfall3 = NodeSpec("continued rains")
     val worm = NodeSpec("impact of Fall Armyworm", Dec("reduce"))


### PR DESCRIPTION
Vikas updated the geonorm model recently, but since geonorm tests aren't run by default, no one noticed that some tests were failing with the new model (in all cases, the new model was finding locations that the old model wasn't). This pull request first fixes those tests, then updates the code to load a DeepLearning4J (.dl4j.zip) version of the model, instead of loading the Keras (.hdf5) model and converting it to DeepLearning4J every time the geonorm parser is loaded. This also gets rid of the need for extracting the .hdf5 to a temporary directory; we simply load the .dl4j.zip model as a resource stream.

A few other changes that were needed to get this all working:
* An update to the grammar for attaching locations
* A fix to a bug in EidosActions.mergeAttachments, which was discarding location attachments
* A fix to GraphTester.toString to display attachments so that it's possible to debug test failures due to attachments