### PR TITLE
Use actual glove filename in default configs

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -36,7 +36,7 @@ RUN wget https://s3.amazonaws.com/world-modelers/data/vectors.txt
 RUN mv vectors.txt src/main/resources/org/clulab/wm/eidos/english/w2v/
 RUN sed -i 's/useW2V = false/useW2V = true/' src/main/resources/eidos.conf
 RUN sed -i 's/useW2V = false/useW2V = true/' src/main/resources/reference.conf
-RUN sed -i 's/glove.840B.300d.vectors.txt/vectors.txt/' src/main/resources/eidos.conf
+RUN sed -i 's/glove.840B.300d.txt/vectors.txt/' src/main/resources/eidos.conf
 RUN sbt assembly
 
 # Run Web Service

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -9,7 +9,7 @@ EidosSystem {
        avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
          taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
 //        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
-        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.vectors.txt
+        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.txt
         stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
       transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ EidosSystem {
        taxonomyPath = /org/clulab/wm/eidos/english/grammars/taxonomy.yml
             maxHops = 15
       wordToVecPath = /org/clulab/wm/eidos/english/w2v/vectors.txt
-//      wordToVecPath = /org/clulab/wm/eidos/english/w2v/glove.840B.300d.vectors.txt
+//      wordToVecPath = /org/clulab/wm/eidos/english/w2v/glove.840B.300d.txt
 
    topKNodeGroundings = 10
         stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt


### PR DESCRIPTION
This PR changes the default name of the glove w2v file in the default configs to match the actual filename that is obtained when extracting glove.840B.300d.txt.tgz from Google Drive.