### PR TITLE
To vanilla json

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractAndExport.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractAndExport.scala
@@ -163,14 +163,21 @@ case class VanillaOdinJsonExporter(file: File) extends Exporter {
   import org.clulab.odin.serialization.json._
   import org.clulab.serialization.json._
 
-  val causeRole = ""
-  val effectRole = ""
-  val causalRelation = ""
-  val INCREASE = ""
-  val DECREASE = ""
   val CAUSE = "cause"
   val EFFECT = "effect"
-  val NODE_LABEL = ""
+
+  val NODE_LABEL = "Node" // org.clulab.influencer.ie.OdinUtils.NODE_LABEL
+
+  // org.clulab.influencer.assembly.DeduplicationUtils
+  val causeRole = "controller"
+  val effectRole = "controlled"
+  val causalRelation = "CausalEvent"
+  val increaseEvent = "IncreaseEvent"
+  val decreaseEvent = "DecreaseEvent"
+
+  val INCREASE = "increases"
+  val DECREASE = "decreases"
+
 
 
   override def export(annotatedDocuments: Seq[AnnotatedDocument]): Unit = {

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractAndExport.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractAndExport.scala
@@ -5,7 +5,7 @@ import java.io.{File, PrintWriter}
 import ai.lum.common.StringUtils._
 import com.typesafe.config.{Config, ConfigFactory}
 import org.clulab.utils.Serializer
-import org.clulab.odin.{Attachment, EventMention, Mention, State}
+import org.clulab.odin._
 import org.clulab.serialization.json.stringify
 import org.clulab.utils.Configured
 import org.clulab.wm.eidos.attachments._
@@ -32,11 +32,13 @@ object ExtractAndExport extends App with Configured {
       case "jsonld" => JSONLDExporter(printWriterFromFile(filename + ".jsonld"), reader)
       case "mitre" => MitreExporter(printWriterFromFile(filename + ".mitre.tsv"), reader, filename, topN)
       case "serialized" => SerializedExporter(filename)
+      case "vanillajson" => VanillaOdinJsonExporter(new File(filename + ".json"))
       case _ => throw new NotImplementedError(s"Export mode $exporterString is not supported.")
     }
   }
 
   val config = ConfigFactory.load("eidos")
+
   override def getConf: Config = config
 
   val inputDir = getArgString("apps.inputDirectory", None)
@@ -69,7 +71,7 @@ trait Exporter {
 }
 
 // Helper classes for facilitating the different export formats
-case class JSONLDExporter (pw: PrintWriter, reader: EidosSystem) extends Exporter {
+case class JSONLDExporter(pw: PrintWriter, reader: EidosSystem) extends Exporter {
   override def export(annotatedDocuments: Seq[AnnotatedDocument]): Unit = {
     val corpus = new JLDCorpus(annotatedDocuments, reader)
     val mentionsJSONLD = corpus.serialize()
@@ -78,7 +80,7 @@ case class JSONLDExporter (pw: PrintWriter, reader: EidosSystem) extends Exporte
   }
 }
 
-case class MitreExporter (pw: PrintWriter, reader: EidosSystem, filename: String, topN: Int) extends Exporter {
+case class MitreExporter(pw: PrintWriter, reader: EidosSystem, filename: String, topN: Int) extends Exporter {
   override def export(annotatedDocuments: Seq[AnnotatedDocument]): Unit = {
     // Header
     pw.println(header())
@@ -92,9 +94,8 @@ case class MitreExporter (pw: PrintWriter, reader: EidosSystem, filename: String
       "Relation Modifiers\tFactor B Text\tFactor B Normalization\tFactor B Modifiers\t" +
       "Factor B Polarity\tLocation\tTime\tEvidence\t" +
       s"Factor A top${topN}_UNOntology\tFactor A top${topN}_FAOOntology\tFactor A top${topN}_WDIOntology" +
-        s"Factor B top${topN}_UNOntology\tFactor B top${topN}_FAOOntology\tFactor B top${topN}_WDIOntology"
+      s"Factor B top${topN}_UNOntology\tFactor B top${topN}_FAOOntology\tFactor B top${topN}_WDIOntology"
   }
-
 
 
   def printTableRows(annotatedDocument: AnnotatedDocument, pw: PrintWriter, filename: String, reader: EidosSystem): Unit = {
@@ -137,11 +138,10 @@ case class MitreExporter (pw: PrintWriter, reader: EidosSystem, filename: String
   }
 
 
-
 }
 
 
-case class SerializedExporter (filename: String) extends Exporter {
+case class SerializedExporter(filename: String) extends Exporter {
   override def export(annotatedDocuments: Seq[AnnotatedDocument]): Unit = {
     val odinMentions = annotatedDocuments.flatMap(ad => ad.odinMentions)
     Serializer.save[SerializedMentions](new SerializedMentions(odinMentions), filename + ".serialized")
@@ -151,10 +151,110 @@ case class SerializedExporter (filename: String) extends Exporter {
 // Helper Class to facilitate serializing the mentions
 @SerialVersionUID(1L)
 class SerializedMentions(val mentions: Seq[Mention]) extends Serializable {}
+
 object SerializedMentions {
-  def load(file: File): Seq[Mention] = Serializer.load[SerializedMentions](file).mentions 
+  def load(file: File): Seq[Mention] = Serializer.load[SerializedMentions](file).mentions
+
   def load(filename: String): Seq[Mention] = Serializer.load[SerializedMentions](filename).mentions
 }
+
+
+case class VanillaOdinJsonExporter(file: File) extends Exporter {
+  import org.clulab.odin.serialization.json._
+  import org.clulab.serialization.json._
+
+  val causeRole = ""
+  val effectRole = ""
+  val causalRelation = ""
+  val INCREASE = ""
+  val DECREASE = ""
+  val CAUSE = "cause"
+  val EFFECT = "effect"
+  val NODE_LABEL = ""
+
+
+  override def export(annotatedDocuments: Seq[AnnotatedDocument]): Unit = {
+    // convert eidos mentions of interest to odin mentions
+    val vanillaMentions = for {
+      event <- annotatedDocuments.flatMap(_.odinMentions).collect { case m: EventMention => m }
+      vanilla <- convertToPromoteInhibit(event)
+      //if Constraints.validEdge(hEdge)
+    } yield vanilla
+
+    // export the odin mentions
+    vanillaMentions.saveJSON(file, pretty = false)
+  }
+
+  /// ------------------------------------------------------------------------------------------
+  //                             Code brought in from lum.ai repo
+  /// ------------------------------------------------------------------------------------------
+
+
+  def convertToPromoteInhibit(m: Mention): Option[Mention] = {
+    if (m matches EidosSystem.CAUSAL_LABEL) {
+      val cause = m.arguments("cause").head
+      val effect = m.arguments("effect").head
+      val causePolarity = nodePolarity(cause)
+      val effectPolarity = nodePolarity(effect)
+      val eventPolarity = causePolarity * effectPolarity
+      eventPolarity match {
+        case 0 => None
+        case 1 => Some(convertMention(m, INCREASE)) //todo
+        case -1 => Some(convertMention(m, DECREASE)) //todo
+        case _ => ??? // this should never happen because nodePolarity only returns -1, 0, or 1
+      }
+    } else {
+      // FIXME: we are ignoring correlation and coreference
+      // Some(m)
+      None
+    }
+  }
+
+  def convertMention(m: Mention, label: String): Mention = {
+    // NOTE: we are ignoring time, geolocation, and quantifiers
+    // check if mention is negated or hedged
+    val negated = m.attachments.exists(_.isInstanceOf[Negation])
+    val hedged = m.attachments.exists(_.isInstanceOf[Hedging])
+    // generate new labels for mention
+    val labels = label +: causalRelation +: m.labels
+    val mentionId = m.id
+    // return new mention with new labels and no attachments
+    val mention = m match {
+      case em: EventMention =>
+        val causeOrig = m.arguments(CAUSE).head.asInstanceOf[TextBoundMention]
+        val cause = causeOrig.copy(labels = NODE_LABEL +: causeOrig.labels)
+        val effectOrig = m.arguments(EFFECT).head.asInstanceOf[TextBoundMention]
+        val effect = effectOrig.copy(labels = NODE_LABEL +: effectOrig.labels)
+        val arguments = Map(causeRole -> List(cause), effectRole -> List(effect))
+        em.copy(labels = labels, attachments = Set.empty, arguments = arguments)
+      case rm: RelationMention =>
+        val causeOrig = m.arguments(CAUSE).head.asInstanceOf[TextBoundMention]
+        val cause = causeOrig.copy(labels = NODE_LABEL +: causeOrig.labels)
+        val effectOrig = m.arguments(EFFECT).head.asInstanceOf[TextBoundMention]
+        val effect = effectOrig.copy(labels = NODE_LABEL +: effectOrig.labels)
+        val arguments = Map(causeRole -> List(cause), effectRole -> List(effect))
+        rm.copy(labels = labels, attachments = Set.empty, arguments = arguments)
+      case tbm: TextBoundMention =>
+        tbm.copy(labels = labels, attachments = Set.empty)
+    }
+
+    mention
+  }
+
+  def nodePolarity(m: Mention): Int = {
+    val increases = m.attachments.filter(_.isInstanceOf[Increase]).toSeq
+    val decreases = m.attachments.filter(_.isInstanceOf[Decrease]).toSeq
+    (increases, decreases) match {
+      case (Seq(), Seq()) => 1 // both empty
+      case (inc, Seq()) => 1 // empty decreases
+      case (Seq(), Seq(dec)) => -1 // one decrease and no increases
+      case _ => 0 // TODO there may be other situations we can handle
+    }
+  }
+
+
+}
+
 
 case class EntityInfo(m: EidosMention, topN: Int = 5) {
   val text = m.odinMention.text


### PR DESCRIPTION
Added an Exporter that uses the code from @marcovzla (from the lum.ai repo) to convert the eidos mentions with attachments to the vanillla promote/inhibit mentions needed for influence search.

NOTE: this isn't tested yet, so please try on a test document to make sure it loads fine and all...
FYI @myedibleenso @gcgbarbosa @MihaiSurdeanu 