### PR TITLE
refactor pt 2: Lexiconner and entityfinder optional

### DIFF
--- a/src/main/python/icasa_to_yaml.py
+++ b/src/main/python/icasa_to_yaml.py
@@ -1,0 +1,36 @@
+import sys, re
+from mk_yaml_ontology import ont_node, dump_yaml
+
+def replace_token(pattern, replacement, s):
+    replacement = f' {replacement} '
+    s = re.sub(f' ?{pattern} ', replacement, s)
+    s = re.sub(f' {pattern} ?', replacement, s)
+    return s
+
+def mk_ont_node(line_string):
+    fields = line_string.split("\t")
+    assert(len(fields) >= 4)
+    var_name = fields[0].strip()
+    description = fields[3].strip()
+    description = replace_token("C", "carbon", description)
+    description = replace_token("CO2", "carbon dioxide", description)
+    description = replace_token("CH2O", "formaldehyde", description)
+    description = replace_token("N", "nitrogen", description)
+    description = replace_token("NH3", "ammonia", description)
+    description = replace_token("NH4", "ammonium", description)
+    description = replace_token("NO3", "nitrate", description)
+    description = replace_token("P", "phosphorus", description)
+    return ont_node(var_name, [description], None, add_name = False)    # the name isn't in a format we can use
+
+
+def main():
+    flat_file = sys.argv[1]
+    ont_file = sys.argv[2]
+    ont_name = sys.argv[3]
+    with open(flat_file, "r") as f:
+        _ = f.readline()    # read header
+        lines = [line.rstrip() for line in f.readlines()]
+    nodes = [mk_ont_node(line) for line in lines]
+    dump_yaml(nodes, ont_file, ont_name)
+
+main()

--- a/src/main/python/mk_yaml_ontology.py
+++ b/src/main/python/mk_yaml_ontology.py
@@ -16,9 +16,10 @@ def represent_none(self, _):
 yaml.add_representer(type(None), represent_none)
 
 
-def ont_node(name, examples, keywords):
-    # Make sure the node name is added to the examples to be used for grounding
-    examples.append(name)
+def ont_node(name, examples, keywords, add_name = True):
+    # If selected, make sure the node name is added to the examples to be used for grounding
+    if add_name:
+        examples.append(name)
     d = {'OntologyNode': None, "name": name, 'examples': examples, 'polarity': 1.0}
     if keywords is not None:
         d['keywords'] = keywords

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -2,25 +2,18 @@ EidosSystem {
 // Override the default values here
              language = english
       masterRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/master.yml
+         taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
      quantifierKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/gradable_adj_fullmodel.kb
     domainParamKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/domain_parameters.kb
-       quantifierPath =  org/clulab/wm/eidos/${EidosSystem.language}/lexicons/Quantifier.tsv
-      entityRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/entities/grammar/entities.yml
-       avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
-         taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
 //        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
         wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
-     geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
-      geoWord2IdxPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
-        geoLoc2IdPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/geo_dict_with_population_SOUTH_SUDAN.txt
-
              cacheDir = ./cache/${EidosSystem.language}
-               useW2V = false
+               useW2V = true
           useTimeNorm = false
            useGeoNorm = true
-             useCache = false
+             useCache = true
 }
 
 apps {
@@ -56,7 +49,10 @@ ontologies {
 
 }
 
-filtering {
-  stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
-  transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
+geoparser {
+  geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
+  geoWord2IdxPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
+  geoLoc2IdPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/geo_dict_with_population_SOUTH_SUDAN.txt
 }
+
+

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -8,10 +8,8 @@ EidosSystem {
       entityRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/entities/grammar/entities.yml
        avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
          taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
-//        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
-        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.txt
-        stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
-      transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
+        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
+//        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
      geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
@@ -21,7 +19,7 @@ EidosSystem {
              cacheDir = ./cache/${EidosSystem.language}
                useW2V = true
           useTimeNorm = false
-           useGeoNorm = true
+           useGeoNorm = false
              useCache = true
 }
 
@@ -37,7 +35,7 @@ apps {
 }
 
 ontologies {
-  ontologies = ["un", "icasa"] // , "mesh"]
+  ontologies = ["un"] // , "mesh"]
   cacheDir = ${EidosSystem.cacheDir}
   useCache = false //${EidosSystem.useCache}
   // Paths to the ontologies
@@ -56,4 +54,9 @@ ontologies {
   // Other
   mesh          = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mesh_ontology.yml
 
+}
+
+filtering {
+  stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
+  transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
 }

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -8,8 +8,8 @@ EidosSystem {
       entityRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/entities/grammar/entities.yml
        avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
          taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
-        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
-//        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.txt
+//        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
+        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
      geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -17,15 +17,15 @@ EidosSystem {
         geoLoc2IdPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/geo_dict_with_population_SOUTH_SUDAN.txt
 
              cacheDir = ./cache/${EidosSystem.language}
-               useW2V = true
+               useW2V = false
           useTimeNorm = false
-           useGeoNorm = false
-             useCache = true
+           useGeoNorm = true
+             useCache = false
 }
 
 apps {
-  inputDirectory = "watermelon/"
-  outputDirectory = "canteloupe/"
+  inputDirectory = "."
+  outputDirectory = "."
   inputFileExtension = ".txt"
   exportAs = ["serialized", "jsonld", "mitre"] // valid modes: jsonld, mitre, serialized
   groundTopN = 5
@@ -35,10 +35,10 @@ apps {
 }
 
 ontologies {
-  ontologies = ["un"] // , "mesh"]
+  ontologies = ["un", "wdi", "fao", "props", "mitre12", "who", "interventions"] // , "icasa", "mesh"]
   cacheDir = ${EidosSystem.cacheDir}
-  useCache = false //${EidosSystem.useCache}
-  // Paths to the ontologies
+  useCache = ${EidosSystem.useCache}
+  // Paths to the ontologies:
   // Primary
   un            = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_ontology.yml
   props         = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_properties.yml

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -8,8 +8,8 @@ EidosSystem {
       entityRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/entities/grammar/entities.yml
        avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
          taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
-//        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
-        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.vectors.txt
+        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
+//        wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.vectors.txt
         stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
       transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
@@ -26,8 +26,8 @@ EidosSystem {
 }
 
 apps {
-  inputDirectory = "."
-  outputDirectory = "."
+  inputDirectory = "watermelon/"
+  outputDirectory = "canteloupe/"
   inputFileExtension = ".txt"
   exportAs = ["serialized", "jsonld", "mitre"] // valid modes: jsonld, mitre, serialized
   groundTopN = 5
@@ -37,7 +37,7 @@ apps {
 }
 
 ontologies {
-  ontologies = ["un", "wdi", "fao", "props", "mitre12", "who", "interventions", "icasa"] // , "mesh"]
+  ontologies = ["un", "icasa"] // , "mesh"]
   cacheDir = ${EidosSystem.cacheDir}
   useCache = false //${EidosSystem.useCache}
   // Paths to the ontologies

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -13,24 +13,16 @@ EidosSystem {
         stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
       transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
-       unOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_ontology.yml
-      wdiOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/wdi_ontology.yml
-      faoOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/fao_variable_ontology.yml
-     meshOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mesh_ontology.yml
-    propsOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_properties.yml
-  mitre12OntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mitre12_indicators.yml
-      whoOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/who_ontology.yml
-      intOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/interventions.yml
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
      geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
       geoWord2IdxPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
         geoLoc2IdPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/geo_dict_with_population_SOUTH_SUDAN.txt
 
              cacheDir = ./cache/${EidosSystem.language}
-               useW2V = false
+               useW2V = true
           useTimeNorm = false
            useGeoNorm = true
-             useCache = false
+             useCache = true
 }
 
 apps {
@@ -42,4 +34,26 @@ apps {
   ontologymapper {
     outfile = src/main/resources/org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_to_indicators.tsv
   }
+}
+
+ontologies {
+  ontologies = ["un", "wdi", "fao", "props", "mitre12", "who", "interventions", "icasa"] // , "mesh"]
+  cacheDir = ${EidosSystem.cacheDir}
+  useCache = false //${EidosSystem.useCache}
+  // Paths to the ontologies
+  // Primary
+  un            = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_ontology.yml
+  props         = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_properties.yml
+  // Plugins
+  interventions = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/interventions.yml
+  // Indicators
+  wdi           = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/wdi_ontology.yml
+  fao           = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/fao_variable_ontology.yml
+  mitre12       = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mitre12_indicators.yml
+  who           = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/who_ontology.yml
+  // Variables
+  icasa         = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/icasa.yml
+  // Other
+  mesh          = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mesh_ontology.yml
+
 }

--- a/src/main/resources/org/clulab/wm/eidos/english/ontologies/icasa.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/ontologies/icasa.yml
@@ -1,0 +1,2975 @@
+- icasa:
+  - OntologyNode:
+    examples:
+    - Active phosphorus - soil a soil layer .
+    name: active_P_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Anthesis date as day of year
+    name: anthesis_day_of_year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Assimilate production
+    name: assimilate_production
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Assimilate reduction, cumulative
+    name: assimilation_reduc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Average daily carbon O2 concentration, sowing to harvest
+    name: co2_concentration_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Basal dry weight
+    name: basal_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - By-product removed at harvest as dry wt
+    name: byprod_removed_at_harv
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - By-product weight at maturity
+    name: byprod_removed_at_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Cane fresh yield
+    name: cane_yield_fresh_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Cane fresh yield at harvest
+    name: cane_yield_harv
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy height
+    name: canopy_height
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy height at anthesis
+    name: canopy_height_anthesis
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy height at harvest
+    name: canopy_height_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy height at physiological maturity
+    name: canopy_height_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy height, max value
+    name: canopy_height_max
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy height, std dev of max value
+    name: canopy_ht_max_stdev
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy length (to extended leaf tip)
+    name: canopy_length
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy length as soil to tip of longest leaf
+    name: canopy_length
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Canopy width (for 1 row)
+    name: canopy_width
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Carbohydrate accumulation
+    name: carbohydr_accumulation
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Carbohydrate in stem
+    name: stem_carbohydrate_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Carbohydrate mobilization
+    name: carbohydr_mobilization
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Carbohydrate pool reduction
+    name: carbohydr_pool_reduction
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Carbohydrate, concentration in leaf
+    name: leaf_carbohydrate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Chaff dry weight, harvest
+    name: chaff_dry_weight_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Chaff nitrogen '
+    name: chaff_N_content
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Chaff nitrogen concentration
+    name: chaff_N_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Chaff phosphorus
+    name: chaff_P_content
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Chaff phosphorus concentration
+    name: chaff_P_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Chaff weight at a given date
+    name: chaff_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' carbon dioxide factor for photosynthesis (0 to 1 scale)'
+    name: CO2_factor_photosynth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - CO2, accumulated by soil surface
+    name: CO2_accumulated_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - CO2, accumulated soil
+    name: CO2_soil_accumulated
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Corm
+    name: corm_population
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Corm dry weight
+    name: corm_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Corm unit dry weight
+    name: corm_unit_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Corn earworms population (larvae)
+    name: corn_earworm
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Crop age
+    name: crop_age
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Crop age (vegetative days, e.g., thermal time)
+    name: crop_age_vegetative_days
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Crop component number
+    name: crop_component_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Crown dry weight
+    name: crown_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Cumulative phosphorus immobilization .
+    name: P_immobilized_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Cumulative phosphorus mineralization .
+    name: P_mineralized_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Daily air temperature, average, sowing to harvest
+    name: temperature_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Date of first square on plant
+    name: first_square_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Date of measurement
+    name: date_of_measurement
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Date of physiological maturity using alternate criteria
+    name: maturity_day_2
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Day of year, or if year = -99 then DA phosphorus or DAH
+    name: day
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Daylength factor (0 to 1 scale)
+    name: daylength_factor
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Days after planting
+    name: days_after_planting
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Days after start of simulation
+    name: days_after_sim_start
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Dead canopy dry weight
+    name: dead_canopy_dry_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Dead leaf dry weight
+    name: dead_leaf_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Dead material dry increase
+    name: dead_mater_dry_increase
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Dead material dry weight
+    name: dead_material_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Dead nitrogen increment
+    name: dead_N_increment
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Dead phosphorus increment
+    name: dead_P_increment
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Dead root dry weight
+    name: dead_root_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Dead stem dry weight
+    name: dead_stem_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Drainage, cumulative
+    name: drainage_cumulative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Drainage,season
+    name: drainage_over_season
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Ear (grain+chaff) dry weight
+    name: ear_grain_chaff_dry_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Ear area index
+    name: ear_area_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Ear height, max value
+    name: ear_height_max
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Ear height, std dev of max value
+    name: ear_ht_max_stdev
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Ear number
+    name: ear_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Ear plus grain dry weight
+    name: ear_plus_grain_dry_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Ear plus grain dry weight per shoot
+    name: ear_dry_wt_per_shoot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Ethanol yield of grain
+    name: grain_ethanol_yield
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evaporation, floodwater, cumulative
+    name: floodwater_evap_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evaporation, soil, daily
+    name: soil_evaporation_daily
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evaporation,soil, cumulative
+    name: soil_evap_cumulative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evaporation,soil, cumulative from planting to harvest
+    name: soil_evap_cumul_pl_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evaporation,soil, cumulative to end of season
+    name: soil_evap_cumul_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evaporation,soil, daily, averaged
+    name: soil_evap_daily_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evapotranspiration
+    name: evapotranspiration_daily
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evapotranspiration, averaged over season
+    name: evapotransp_average
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evapotranspiration, cumulative from planting to harvest
+    name: evapotrans_cumul_pl_harv
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evapotranspiration, cumulative over season
+    name: evapotransp_cumulative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evapotranspiration, cumulative to end of season
+    name: evapotrans_cumul_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evapotranspiration, potential
+    name: potential_evapotrans
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Evapotranspiration, potential, average over season
+    name: potential_evapotrans_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Eye number at maturity
+    name: eye_number_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Eye number at maturity (per harvested unit, e.g. fruit)
+    name: eye_no_per_unit_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Eye weight at harvest maturity
+    name: eye_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Fall armyworm population count
+    name: fall_armyworm
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Flag to identify time series observed data with specific problems or significance
+    name: flag_time_series_data
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Floodwater Ammoniacal nitrogen '
+    name: floodwater_Ammoniacal_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater Ammonium nitrogen (NH4) carbon onc.
+    name: floodwtr_ammonium_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater Aqueous nitrogen H3 nitrogen carbon onc.
+    name: floodwtr_aqu_NH3_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater denitrification date (N)
+    name: floodwater_denitrif_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater depth
+    name: floodwater_depth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater evaporation rate
+    name: floodwater_evap_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater light index (0 to 1 scale)
+    name: floodwater_light_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater nitrogen itrate nitrogen (NO3) carbon onc.
+    name: floodwtr_nitrate_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater nitrogen Index (0 to 1 scale)
+    name: floodwater_N_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater pH, maximum daytime
+    name: floodwater_pH_max_day
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater photosynth. activity index (0 to 1 scale)
+    name: floodwater_photosyn_ind
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater runoff over bund
+    name: floodwtr_runoff_ovr_bund
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Floodwater Temperature Index (0 to 1 scale)
+    name: floodwater_temper_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Floodwater Urea nitrogen '
+    name: floodwater_Urea_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Forcing date
+    name: forcing_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Fruit fresh weight
+    name: fruit_fresh_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Fruit fresh weight at harvest
+    name: fruit_fresh_wt_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Fruit nitrogen '
+    name: fruit_N_content
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain carbohydrate concentration
+    name: grain_carbohydrate_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain dry weight
+    name: grain_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain dry wt at maturity
+    name: grain_dry_wt_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain dry wt at maturity, per plant basis
+    name: grain_dry_wt_matur_plnt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain mass consumed
+    name: grain_mass_consumed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain mass consumed, cumulative
+    name: grain_mass_consum_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain moisture at maturity
+    name: grain_moisture_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Grain nitrogen '
+    name: grain_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain nitrogen at maturity
+    name: grain_N_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain nitrogen concentration at maturity
+    name: grain_N_conc_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain nitrogen concentration on sampling date
+    name: grain_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain number consumed
+    name: grain_number_consumed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain number consumed, cumulative
+    name: grain_numb_consum_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain number on sampling date
+    name: grain_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain number per plant
+    name: grain_number_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain number per shoot
+    name: grain_number_per_shoot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain oil concentration
+    name: grain_oil_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain oil concentration at maturity
+    name: grain_oil_conc_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain phosphorus
+    name: grain_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain phosphorus at maturity
+    name: grain_P_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain phosphorus concentration
+    name: grain_P_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain phosphorus concentration at maturity
+    name: grain_P_conc_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain protein concentration
+    name: grain_protein_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain protein concentration at maturity
+    name: grain_protein_conc_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain starch concentration at maturity
+    name: grain_starch_conc_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain unit dry weight
+    name: grain_unit_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Grain unit dry wt at maturity
+    name: grain_unit_dry_wt_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Green area index (any green material on plants)
+    name: green_area_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth rate, crop (=tops+storage)
+    name: crop_growth_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth rate, relative
+    name: growth_rate_relative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage
+    name: growth_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage according to Haun scale
+    name: growth_stage_Haun
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage according to Zadok's scale
+    name: growth_stage_Zadoks
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage as days after planting
+    name: harvest_dap
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage as days after planting, anthesis
+    name: anthesis_dap
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date for branch 1
+    name: growth_stage_branch_1
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, anthesis
+    name: anthesis_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, apex 1cm
+    name: growth_stage_apex_1_cm
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, beginning bloom
+    name: beginning_bloom_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, beginning maturity
+    name: beginning_maturity_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, beginning peg
+    name: beginning_peg_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, beginning pod
+    name: beginning_pod_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, beginning seed
+    name: beginning_seed_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, branch 2
+    name: growth_stage_branch_2
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, branch 3
+    name: growth_stage_branch_3
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, branch 4
+    name: growth_stage_branch_4
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, double ridges
+    name: double_ridge_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, ear emergence
+    name: ear_emergence_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, emergence
+    name: emergence_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, full seed
+    name: full_seed_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, full-sized pod
+    name: full_size_pod_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, harvest
+    name: harvest_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, harvest maturity
+    name: harvest_maturity_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, last leaf
+    name: last_leaf_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, leaf3 full expansion
+    name: leaf_3_full_expansion
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, leaf5 full expansion
+    name: leaf_5_full_expansion
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, pod over-mature
+    name: pod_over-mature_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, terminal spikelet
+    name: terminal_spikelet_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, tuber initiation
+    name: tuber_initiation_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, Zadoks 21
+    name: zadoks_21_growth_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, Zadoks 30
+    name: zadoks_30_growth_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, Zadoks 31
+    name: zadoks_31_growth_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, Zadoks 37
+    name: zadoks_37_growth_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage date, Zadoks 39
+    name: zadoks_39_growth_stage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage days>planting, harv mature
+    name: harvest_maturity_dap
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage days>planting, tuber init
+    name: tuber_initiation_dap
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of first pod, as date
+    name: first_pod_set_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of first pod, as days after planting
+    name: first_pod_set_days
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of full-sized pod, as date
+    name: full_size_pod_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of full-sized pod, as days after planting
+    name: full_pod_days
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of jointing (node detectable through sheath) in cereals
+    name: jointing_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of panicle initiation, as date
+    name: panicle_initiation_date
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of panicle initiation, as days after planting
+    name: panicle_initiation_dap
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of physiol. maturity, as date
+    name: physiologic_maturity_dat
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of physiol. maturity, as day of year
+    name: maturity_day_of_year
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage of physiol. maturity, as days after planting
+    name: physiologic_maturity_dap
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Growth stage when harvest occurs
+    name: growth_stage_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest index at maturity
+    name: harvest_index_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest index for nitrogen on sampling date
+    name: nitrogen_harvest_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest index for phosphorus on sampling date
+    name: phosphorus_harvest_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest index on sampling date
+    name: harvest_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest number per area at maturity (e.g., seed or tubers)
+    name: harvest_no_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest number per group at maturity
+    name: harvest_no_per_grp_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest number per unit at maturity (e.g., seed per spike or pod)
+    name: harv_no_per_unit
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest unit dry (e.g., seed) weight at harv. maturity
+    name: unit_dry_wt_harv_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest yield (fresh wt) at a given day
+    name: harvest_yield_fresh_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest yield (grain, fresh), maturity
+    name: harv_yld_grn_fresh_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest yield (grain, fresh), per plant at maturity
+    name: harv_yld_grn_fr_pl_mat
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest yield at harvest maturity (dry wt)
+    name: harvest_yld_matur_dry_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest yield at harvest maturity (fresh wt)
+    name: harv_yield_matur_f_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest yield at harvest, standard deviation
+    name: harvest_yld_stdev
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest yield corrected for various factors
+    name: yield_corrected
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvest yield, specified day (dry wt)
+    name: harvest_yield_at_day_dw
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvested yield at harvest (dry wt)
+    name: harvest_yield_harvest_dw
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Harvested yield at harvest (fresh wt)
+    name: harv_yield_harv_f_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - id
+    name: id
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Infiltration rate
+    name: infiltration_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Initial water content of entire profile
+    name: initial_profile_wtr_cont_sim
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Irrigation amount per day
+    name: irrigation
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Irrigation applications, cumulative
+    name: irrigation_applications
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Irrigation, cumulative
+    name: irrigation_cumulative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - K, inorganic, in soil at harvest maturity
+    name: K_inorganic_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Labile phosphorus - soil a soil layer (ppm) .
+    name: labile_P_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf appearance rate
+    name: leaf_appearance_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf appearance rate on a biological day basis
+    name: lf_appear_rate_bio_day_b
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area consumed or destroyed by pests or diseases, cumulative
+    name: leaf_area_consumed_cumu
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area consumed per day
+    name: leaf_area_consumption
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area index (live+dead)
+    name: leaf_ar_index_live_dead
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area index on a given day
+    name: leaf_area_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area index, maximum
+    name: leaf_area_index_maximum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area per leaf
+    name: leaf_area_per_leaf
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area per plant
+    name: leaf_area_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area, flag leaf
+    name: leaf_area_flag_leaf
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area, increase in diseased area
+    name: increase_disease_lf_area
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area, increase in diseased area fraction
+    name: incr_disease_lf_ar_pcent
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf area, new on leaves
+    name: leaf_area_new
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf critical nitrogen factor
+    name: leaf_critical_N_factor
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf dry weight
+    name: leaf_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf dry weight at harvest maturity
+    name: leaf_dry_wt_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf dry weight per plant
+    name: leaf_dry_wt_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf dry weight, green areas
+    name: leaf_dry_wt_green_areas
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf mass consumed per day
+    name: leaf_mass_consumed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf mass consumed, cumulative
+    name: leaf_mass_consumed_cumu
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Leaf nitrogen '
+    name: leaf_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf nitrogen concentration
+    name: leaf_N_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf nitrogen of dead (senesced) leaves
+    name: dead_leaf_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf nitrogen of green leaves
+    name: green_leaf_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf number increase rate
+    name: leaf_no_increase_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf number of cereals as Haun stage
+    name: leaf_number_as_haun_stg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf number per stem
+    name: leaf_number_per_stem
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf number per stem, at harvest maturity
+    name: leaf_no_per_stem_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf number per stem, maximum
+    name: leaf_number_per_stem_max
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf phosphorus
+    name: leaf_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf phosphorus concentration
+    name: leaf_P_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Leaf tip number per stem
+    name: leaf_tip_number_per_stem
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Lint weight at maturity
+    name: lint_weight_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Lint weight on sample date
+    name: lint_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter (trash) dry weight
+    name: litter_trash_dry_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon - soil a soil layer
+    name: litter_C_soil_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon on surface
+    name: litter_C_on_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon, metabolic
+    name: litter_C_metabolic
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon, metabolic a soil layer
+    name: litter_C_metabol_by_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon, metabolic surface
+    name: litter_C_metabol_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon, structural
+    name: litter_Cstructural
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon, structural a soil layer
+    name: litter_C_struct__by_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon, structural surface
+    name: litter_C_struct_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter carbon, total
+    name: litter_carbon_total
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen for a soil layer
+    name: litter_N_soil_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen on surface
+    name: litter_N_on_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen , metabolic
+    name: litter_N_metabolic
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen , metabolic a soil layer
+    name: litter_N_metabol_by_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen , metabolic surface
+    name: litter_N_metabol_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen , structural
+    name: litter_Nstructural
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen , structural a soil layer
+    name: litter_N_struct_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen , structural surface
+    name: litter_N_struct_surf
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter nitrogen ,total
+    name: litter_Nal
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter phosphorus - soil a soil layer
+    name: litter_P_soil_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter phosphorus in all soil layers and surface
+    name: litter_P_total
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter phosphorus in surface litter
+    name: litter_P_on_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter phosphorus , metabolic
+    name: litter_P_metabolic
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter phosphorus , metabolic a soil layer
+    name: litter_P_metabol_by_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Litter phosphorus , metabolic surface
+    name: litter_P_metabol_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Mass of shoot (leaf + stem) at a given day
+    name: shoot_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Maximum daily air temperature, average, sowing to harvest
+    name: temperature_max_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Minimum daily air temperature, average, sowing to harvest
+    name: temperature_min_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Minimum root phosphorus concentration calculated dynamically
+    name: minimum_root_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Minimum seed phosphorus concentration
+    name: minimum_seed_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Minimum shell phosphorus concentration
+    name: minimum_shell_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Minimum shoot phosphorus concentration
+    name: minimum_shoot_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Moisture content of fresh yield (e.g., grain, fruit, leaves) at harvest
+    name: harvest_moisture
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen applications'
+    name: N_applications
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen denitrification, cumulative'
+    name: N_denitrification_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen factor for leaf growth (0 to 1 scale)'
+    name: N_factor_for_leaf_growth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen factor for nitrogen uptake'
+    name: N_factor_for_N_uptake
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen factor for photosynthesis (0 to 1 scale)'
+    name: N_factor_photosynthesis
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen factor for senescence (0 to 1 scale)'
+    name: N_factor_for_senescence
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen factor for tillering (0 to 1 scale)'
+    name: N_factor_for_tillering
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen fixation rate'
+    name: N_fixation_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen fixed'
+    name: N_fixed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen fixed during season'
+    name: N_fixed_during_season
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen immobilization, cumulative'
+    name: N_immobilization_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen leached up to harvest maturity, from bottom of soil profile'
+    name: N_leached_during_season
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen leached, cumulative from bottom of profile'
+    name: N_leached
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen mineralization, cumulative from bottom of profile'
+    name: N_mineralization_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen nitrification, cumulative'
+    name: N_nitrification_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen to phosphorus ratio in vegetative tissue'
+    name: N_to_P_ratio
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen uptake'
+    name: N_uptake
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen uptake during season'
+    name: N_uptake_during_season
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen uptake rate'
+    name: N_uptake_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen uptake to demand ratio'
+    name: N_uptake_to_demand_ratio
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrogen uptake, cumulative'
+    name: N_uptake_cumulative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - N, inorganic, applied to date
+    name: N_inorganic_applied
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - N, inorganic, applied up to harvest maturity
+    name: N_inorganic_appl_tot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - N, inorganic, in soil at harvest maturity
+    name: N_inorganic_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' ammonia nitrogen volatilization rate'
+    name: NH3_volatilization_rate
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' ammonia nitrogen volatilization, cumulative'
+    name: NH3_volatilization_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' ammonium nitrogen ,soil total'
+    name: NH4_Nsoil_total
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - NH4[N], for a given soil layer
+    name: NH4_soil_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrificaton Rate (N), oxidized layer
+    name: nitrificat_rate_oxid_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrogen concentration in shaded leaves, noon
+    name: shaded_leaf_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrogen in above ground plant parts
+    name: tops_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrogen in above ground plant parts
+    name: tops_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrogen in above ground plant parts at anthesis
+    name: tops_N_at_anthesis
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrogen in above ground plant parts at maturity
+    name: tops_N_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrogen stress factor, photosynthesis (0 to 1 scale)
+    name: N_stress_photosyn_daily
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrogen stress factor, physiol average for life span of a single leaf (0 to
+      1 scale)
+    name: N_stress_photosyn_leaf
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nitrogen sunlit leaves, noon
+    name: sunlit_leaf_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' nitrate nitrogen ,soil total'
+    name: NO3_Nsoil_total
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - NO3[N], for a given soil layer
+    name: NO3_soil_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - NO3+ ammonium nitrogen ,soil total
+    name: NO3_NH4_Nsoil_total
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Nodule dry weight
+    name: nodule_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Optimum root phosphorus concentration
+    name: optimum_root_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Optimum seed phosphorus concentration
+    name: optimum_seed_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Optimum shell phosphorus concentration
+    name: optimum_shell_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Optimum shoot phosphorus concentration
+    name: optimum_shoot_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Option for crop in sequence
+    name: option_for_crop_in_seq
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon in soil a soil layer
+    name: organic_C_soil_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon in soil at maturity
+    name: organic_C_soil_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon , active - a soil layer
+    name: organic_C_active_by_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon , active on surface
+    name: organic_C_active_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon , active,soil total
+    name: organic_C_active_tot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon , intermediate - a soil layer
+    name: organic_C_intermed_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon , intermediate, soil total
+    name: organic_C_intermed_tot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon , passive - a soil layer
+    name: org_C_passive_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon , passive, soil total
+    name: soil_org_C_passive_tot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon , stable at user defined depth
+    name: org_C_stable_user_depth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic carbon, soil total
+    name: organic_carbon_soil_tot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic matter added, cumulative
+    name: org_matter_added_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic matter appl (dry), cumulative
+    name: org_matter_appl_dry_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic matter nitrogen added, cumulative
+    name: org_matter_N_added_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic matter phosphorus added, cumulative
+    name: org_matter_P_added_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen in soil
+    name: organic_N_in_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen in soil a soil layer
+    name: organic_N_soil_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen in soil at maturity
+    name: soil_organic_N_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen , active - a soil layer
+    name: org_N_active_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen , active on surface
+    name: organic_N_active_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen , active,soil total
+    name: org_N_active_soil_total
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen , intermediate - a soil layer
+    name: organic_N_intermed_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen , intermediate, soil total
+    name: organic_N_intermed_tot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen , passive a soil layer
+    name: organic_N_passive_by_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen , passive, soil total
+    name: org_N_passive_soil_tot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen , stable @ user depth
+    name: org_N_stable_user_depth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic nitrogen, soil total
+    name: org_nitrogen_soil_total
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic phosphorus , active - a soil layer
+    name: org_P_active_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic phosphorus , active on surface
+    name: organic_P_active_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Organic phosphorus , active,soil total
+    name: org_P_active_soil_total
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus available for plant uptake .'
+    name: available_P_kg/ha
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus concentration in leaf and stem'
+    name: shoot_P_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus content in leaf and stem (kg[P]/ha)'
+    name: shoot_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus content in plant'
+    name: plant_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus content in roots on sampling day'
+    name: root_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus content in seed'
+    name: seed_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus content in shell (kg[P]/ha)'
+    name: shell_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus senesced to soil'
+    name: P_senesce_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus senesced to surface'
+    name: P_senesce_surf
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus stress factor for reducing photosynthate (0-1)'
+    name: P_stress_photo
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus stress which affects vegetative partitioning (0-1)'
+    name: P_stress_veg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - ' phosphorus uptake'
+    name: P_uptake_day
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - P, inorganic, in soil at harvest maturity
+    name: P_inorganic_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Panicle number
+    name: panicle_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Panicle number per area at maturity
+    name: panicle_number_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Panicle weight (grain+structural)
+    name: panicle_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - PAR (light) interception
+    name: PAR_interception-daily
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - PAR (light) noon interception
+    name: PAR_intercepted_noon
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - PAR absorbed
+    name: PAR_absorbed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - PAR interception
+    name: PAR_interception
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - PAR utilization efficiency
+    name: PAR_utiliz_efficiency
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Partitioning of weight to shoot
+    name: partitioning_of_wt_shoot
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Percent lodging
+    name: lodging_percent
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Phosphorus amount in roots at harvest
+    name: root_P_at_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Phosphorus amount in stems at maturity
+    name: stem_P_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Phosphorus applications (cumulative no.)
+    name: phosphorus_applic_no
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Phosphorus applied (cumulative)
+    name: phosphorus_applied_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Phosphorus in above ground plant parts at anthesis
+    name: tops_P_at_anthesis
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Phosphorus in above ground plant parts at maturity
+    name: tops_P_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Phosphorus leached, cumulative from bottom of profile
+    name: P_leached
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Photosynthesis, gross (as carbon H2O)
+    name: photosynth_gross_CH2O
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Photosynthesis, gross (CO2), noon
+    name: photosyn_gross_CO2_noon
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Photosynthesis, phosphorus max for shaded leaves at noon
+    name: leaf_phot_shaded_lf_noon
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Photosynthesis, phosphorus max for sunlit leaves at noon
+    name: leaf_phot_sunlit_lf_noon
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant density (population or stand) at fulle emergence, equivalent to initial
+      stand count
+    name: plant_density_emergence
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant density (population or stand) at harvest
+    name: plant_density_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant density (population or stand) at maturity
+    name: plant_density_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant density on sampling date
+    name: plant_density
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant height (e.g., including spikes above canopy per se) at anthesis
+    name: plant_height_anthesis
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant height (e.g., including spikes above canopy per se) at maturity
+    name: plant_height_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant height (e.g., including spikes above canopy per se), maximum value in
+      season
+    name: plant_height_max
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant population
+    name: plant_population
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant population reduction
+    name: plant_pop_reduction_day
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant population reduction, cumulative
+    name: plant_pop_reduct_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Plant_height (e.g., including spikes above canopy per se)
+    name: plant_height
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Planting material dry weight
+    name: planting_material_dry_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Pod dry weight
+    name: pod_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Pod dry weight at maturity
+    name: pod_dry_weight_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Pod number
+    name: pod_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Pod number per area at maturity
+    name: pod_number_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Pod, detached, dry weight
+    name: pod_detached_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Pod, panicle, ear or head harvest index
+    name: pod_harvest_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Pod, panicle, head or ear harvest index at maturity
+    name: pod_harv_index_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Pods, portion that are mature
+    name: pods_mature
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Purity of sugar, e.g. extract from cane
+    name: purity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Rainfall, cumulative
+    name: rainfall_cumulative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Rainfall, planting to harvest
+    name: rainfall_plant_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Rainfall, season (may differ from planting to harvest)
+    name: rainfall_in_season
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Replicate number
+    name: replicate_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Reserve nitrogen '
+    name: reserve_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Reserve nitrogen '
+    name: reserve_N_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Reserve phosphorus
+    name: reserve_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Reserve phosphorus on per plant basis
+    name: reserve_P_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Reserves factor for photosynthesis (0 to 1 scale)
+    name: reserves_factor_photosyn
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Reserves weight
+    name: reserves_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Reserves, concentration of carbon H2O
+    name: reserves_CH2O_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Residue nitrogen remaining
+    name: residue_N_remaining
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Respiration associated with translocation
+    name: respiration_translocat
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Respiration, growth component (as carbon H2O)
+    name: growth_respiration_daily
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Respiration, maintenance (CH2O)
+    name: maintenance_respir_CH2O
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root depth, maximum extent at date
+    name: root_depth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root dry weight
+    name: root_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root length
+    name: root_length
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root length consumed
+    name: root_length_consumed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root length consumed, cumulative
+    name: root_length_consum_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root length density consumed
+    name: root_length_dens_consum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root length to root weight
+    name: root_length/weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root length_density in a soil layer
+    name: root_length_dens_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root ln density consumed, cumulative
+    name: root_lngth_dens_cons_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root mass consumed
+    name: root_mass_consumed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root mass consumed, cumulative
+    name: root_mass_consum_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root mass density in a soil layer
+    name: root_mass_dens_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root nitrogen concentration on sampling day
+    name: root_N_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root nitrogen on sampling day
+    name: root_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root nitrogen amount at harvest
+    name: root_N_at_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root phosphorus concentration
+    name: root_P_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root senesced dry weight
+    name: root_senesced_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root weight/length
+    name: root_weight/length
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Root worm population count
+    name: root_worm
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Roots critical [N] factor
+    name: roots_critical_N_factor
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Runoff, cumulative
+    name: runoff_cumulative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Runoff, season total
+    name: runoff_season
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Runoff, surface
+    name: runoff_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Seasonal cumulative phosphorus uptake
+    name: P_uptake_cum
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Sediment loss
+    name: sediment_loss
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Seed (i.e., what is sown) nitrogen concentration
+    name: seed_N_conc_planting
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Seed (i.e., what sown) nitrogen
+    name: seed_or_what_sown_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Seed (i.e., what sown) weight
+    name: weight_of_sown_seed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Seed phosphorus concentration
+    name: seed_P_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Seed weight per plant
+    name: seed_wt_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced carbon added to litter
+    name: senesced_C_added_litter
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced carbon added to soil
+    name: senesced_C_added_to_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced dry matter to soil
+    name: senesced_dry_mat_to_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced dry matter to surface
+    name: senesced_dry_mat_to_surf
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced lignin added to litter
+    name: senesced_lignin_to_lit
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced lignin added to soil
+    name: senesced_lignin_to_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced nitrogen added to litter
+    name: senesced_N_added_litter
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced nitrogen added to litter+soil
+    name: senesced_N_add_lit_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced nitrogen added to soil
+    name: senesced_N_added_to_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced nitrogen to soil
+    name: senesced_N_to_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced nitrogen to surface
+    name: senesced_N_to_surface
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senesced wt added to litter+soil
+    name: senesced_wt_to_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Senescence rate,tops (dry weight)
+    name: senescence_rate_tops
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Sequence number
+    name: sequence_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shell dry weight
+    name: shell_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shell mass consumed
+    name: shell_mass_consumed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shell mass consumed, cumulative
+    name: shell_mass_consum_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shell nitrogen concentration
+    name: shell_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shell number consumed
+    name: shell_number_consumed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shell number consumed, cumulative
+    name: shell_numb_consum_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shell phosphorus concentration
+    name: shell_P_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shelling (seed wt/pod wt*100)
+    name: shelling_percentage
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shoot (apex) number
+    name: shoot_(apex)_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Shoot (apex) number per plant
+    name: shoot_apex_num_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil bulk density, puddled surface lyer
+    name: bulk_dens_puddl_surf_lyr
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil carbon in a soil layer
+    name: soil_carbon_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil carbon O2 (as carbon ) emission on a given day
+    name: soil_CO2_emission
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil layer depth to lower boundary of sample (bottom)
+    name: soil_layer_bot_depth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil layer depth to upper boundary of sample (top)
+    name: soil_layer_top_depth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil nitrogen in a soil layer
+    name: soil_nitrogen_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil organic carbon, total in profile
+    name: soil_organic_carbon
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil phosphorus at maturity
+    name: soil_P_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil water measured at a specified depth
+    name: soil_water_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soil water, extractable at maturity
+    name: extractable_soil_wtr_mat
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Solar radiation, average, sowing to harvest
+    name: solar_radiation_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Southern green stinkbug population count
+    name: southern_green_stinkbug
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Soybean looper population count
+    name: soybean_looper
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Specific leaf area
+    name: specific_leaf_area
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Specific leaf nitrogen '
+    name: specific_leaf_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Specific leaf wt, shaded leaves, noon
+    name: specif_lf_wt_shaded_noon
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Specific leaf wt, sunlit leaves, noon
+    name: specif_lf_wt_sunlit_noon
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Spikelet number
+    name: spikelet_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stable phosphorus - soil a soil layer .
+    name: stabile_P_by_layer
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Standard deviation of anthesis DAP
+    name: anthesis_dap_stdev
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Standard deviation of harvest maturity DAP
+    name: harvest_mat_dap_stdev
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Standard deviation of harvest moisture fraction
+    name: harvest_moisture_stdev
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Standard deviation of harvested yield at harvest (fresh wt)
+    name: harv_yield_harv_f_wt_sd
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Standard deviation of physiological maturity DAP
+    name: phys_mat_dap_stdev
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Standard deviation of tops weight, maturity
+    name: tops_dw_mat_stdev
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem area index
+    name: stem_area_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem critical nitrogen factor
+    name: stem_critical_N_factor
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem dry weight
+    name: stem_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem dry weight per plant
+    name: stem_dry_wt_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem mass consumed
+    name: stem_mass_consumed
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem mass consumed, cumulative
+    name: stem_mass_consum_cumul
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Stem nitrogen '
+    name: stem_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem nitrogen at maturity
+    name: stem_N_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem nitrogen concentration
+    name: stem_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem phosphorus
+    name: stem_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem phosphorus concentration
+    name: stem_P_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem plus chaff
+    name: stem_plus_chaff
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem reserves weight
+    name: stem_reserves_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Stem structural weight
+    name: stem_structural_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Sucker dry weight
+    name: sucker_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Sucrose dry weight
+    name: sucrose_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Sucrose harvest index
+    name: sucrose_harvest_index
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Sucrose, commercial, dry weight
+    name: sucrose_commercial_d_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Temperature factor for leaf growth (0 to 1 scale)
+    name: temp_fact_leaf_growth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Temperature factor for photosynthesis (0 to 1 scale)
+    name: temp_fact_photosyn
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Temperature for plant death (dynamic)
+    name: plant_death_temperature
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Temperature, daily canopy average
+    name: canopy_temp_daily_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Temperature, noon canopy
+    name: temperature_noon_canopy
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Test weight (fresh) at maturity
+    name: test_wt_fresh_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Threshing % at maturity
+    name: threshing_%_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tillage operations number
+    name: tillage_operations_no
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tiller number
+    name: tiller_number
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tiller number per area at maturity
+    name: tiller_number_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tiller number per plant
+    name: tiller_number_per_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops (i.e., canopy) nitrogen concentration
+    name: tops_N_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops (i.e., canopy) phosphorus concentration
+    name: tops_P_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops (i.e., canopy) protein concentration
+    name: tops_protein_concentration
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Tops (ie canopy) nitrogen '
+    name: tops_(ie_canopy)_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops (ie canopy) phosphorus
+    name: tops_(ie_canopy)_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops dry weight
+    name: tops_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops dry weight
+    name: tops_dry_weight_plant
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops dry weight at anthesis
+    name: tops_dry_weight_anthesis
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops dry weight at harvest
+    name: tops_dry_weight_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops dry weight at maturity
+    name: tops_dry_weight_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops+dead dry wt at anthesis
+    name: tops_dead_dry_wt_anthes
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops+roots+storage dry weight
+    name: tops_roots_storage_d_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tops+roots+storage+senesced tissue (dry weight)
+    name: tot_crop_wt_w_senesced
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total active soil phosphorus .
+    name: total_active_P_kg/ha
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total biomass without senesced material (dry weight)
+    name: total_biomass_dry_wt
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total dry weight at harvest
+    name: tot_dry_wt_at_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total dry weight at maturity
+    name: tot_dry_weight_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total inorganic soil phosphorus .
+    name: total_inorganic_P_in_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total labile soil phosphorus .
+    name: total_labile_P_in_soil
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total nitrogen at maturity
+    name: total_N_at_maturity
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total phosphorus in soil
+    name: total_soil_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Total stable soil phosphorus .
+    name: stable_P_kg/ha
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Transpiration (evaporation from plant), daily
+    name: transpiration_daily
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Transpiration, cumulative from planting to harvest
+    name: transpirat_cumul_pl_harv
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Transpiration, cumulative over season
+    name: transpiration_cumulative
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Transpiration, cumulative to end of season
+    name: transpirat_cumul_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Transpiration, daily, averaged
+    name: transpiration_daily_avg
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Treatment id for observed data, unique internal ID
+    name: observ_treat_ID
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber dry weight
+    name: tuber_dry_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber dry weight at harvest
+    name: tuber_dry_wt_at_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber fresh weight
+    name: tuber_fresh_weight
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber fresh weight at harvest
+    name: tuber_fresh_wt_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Tuber nitrogen '
+    name: tuber_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber nitrogen at harvest
+    name: tuber_N_at_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber nitrogen concentration
+    name: tuber_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber nitrogen concentration at harvest
+    name: tuber_N_conc_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber phosphorus
+    name: tuber_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber phosphorus at harvest
+    name: tuber_P_at_harvest
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber phosphorus concentration
+    name: tuber_P_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Tuber+stem+leaf nitrogen '
+    name: tuber_stem_leaf_N
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber+stem+leaf nitrogen at harvest
+    name: tuber_stem_leaf_N_harv
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Tuber+stem+leaf phosphorus
+    name: tuber_stem_leaf_P
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Urea nitrogen Hydrolysis Rate in Floodwater
+    name: urea_N_hydrol_rt_flood
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Veg (leaf+stemt) dry wt, maturity
+    name: vegetative_dry_wt_matur
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - 'Veg (stem+leaf) nitrogen '
+    name: vegetative_N_content
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Veg (stem+leaf) nitrogen concentration
+    name: veg_stem_leaf_N_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Veg (stem+leaf) phosphorus
+    name: vegetative_P_content
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Veg (stem+leaf) phosphorus concentration
+    name: veg_stem_leaf_P_conc
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Velvetbean caterpillar 5 instar count
+    name: velvetbn_catrpllar_5inst
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Velvetbean caterpillar 6 instar count
+    name: velvetbn_catrpllar_6inst
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Vernalization factor (0 to 1 scale)
+    name: vernalization_factor
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water available in root zone
+    name: water_avail_root_zone
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water available to demand ratio
+    name: water_avail_demand_ratio
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress - excess (0 to 1 scale)
+    name: water_stress_excess
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress - growth (0 to 1 scale)
+    name: water_stress_growth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress - photosynthesis (0 to 1 scale)
+    name: water_stress_photosynth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress factor accelerating senescence (0 to 1 scale)
+    name: water_factor_senescence
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress factor affecting photosynthesis, average for life span of a single
+      leaf (0 to 1 scale)
+    name: water_stress_photosyn_lf
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress factor reducing growth (0 to 1 scale)
+    name: water_factor_for_growth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress factor reducing photosynthesis (0 to 1 scale)
+    name: water_factor_photosynth
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress factor reducing tillering (0 to 1 scale)
+    name: water_factor_tillering
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water stress factor reducing transpiration (0 to 1 scale)
+    name: water_factor_transpir
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water table depth
+    name: water_table_depth_daily
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Water uptake to demand ratio
+    name: water_uptake_demand_rat
+    polarity: 1.0
+  - OntologyNode:
+    examples:
+    - Whole plant phosphorus concentration
+    name: plant_P_conc
+    polarity: 1.0

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,7 +12,6 @@ EidosSystem {
             maxHops = 15
       wordToVecPath = /org/clulab/wm/eidos/english/w2v/vectors.txt
 //      wordToVecPath = /org/clulab/wm/eidos/english/w2v/glove.840B.300d.vectors.txt
-
    topKNodeGroundings = 10
         stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt
       transparentPath = /org/clulab/wm/eidos/english/filtering/transparent.txt
@@ -21,17 +20,8 @@ EidosSystem {
      geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
       geoWord2IdxPath = /org/clulab/wm/eidos/english/context/word2idx_file.txt
         geoLoc2IdPath = /org/clulab/wm/eidos/english/context/geo_dict_with_population_SOUTH_SUDAN.txt
-
-       unOntologyPath = /org/clulab/wm/eidos/english/ontologies/un_ontology.yml
-      wdiOntologyPath = /org/clulab/wm/eidos/english/ontologies/wdi_ontology.yml
-      faoOntologyPath = /org/clulab/wm/eidos/english/ontologies/fao_variable_ontology.yml
-     meshOntologyPath = /org/clulab/wm/eidos/english/ontologies/mesh_ontology.yml
-    propsOntologyPath = /org/clulab/wm/eidos/english/ontologies/un_properties.yml
-  mitre12OntologyPath = /org/clulab/wm/eidos/english/ontologies/mitre12_indicators.yml
-      whoOntologyPath = /org/clulab/wm/eidos/english/ontologies/who_ontology.yml
-      intOntologyPath = /org/clulab/wm/eidos/english/ontologies/interventions.yml
             cacheDir  = ./cache/english
-           ontologies = ["un", "wdi", "fao", "props", "mitre12", "who", "interventions"] // , "mesh"]
+
                useW2V = false
           useTimeNorm = false
            useGeoNorm = false
@@ -47,4 +37,26 @@ apps {
   ontologymapper {
     outfile = src/main/resources/org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_to_indicators.tsv
   }
+}
+
+ontologies {
+  ontologies = ["un", "wdi", "fao", "props", "mitre12", "who", "interventions"] // , "icasa", "mesh"]
+  cacheDir = ${EidosSystem.cacheDir}
+  useCache = ${EidosSystem.useCache}
+  // Paths to the ontologies
+  // Primary
+  un            = /org/clulab/wm/eidos/english/ontologies/un_ontology.yml
+  props         = /org/clulab/wm/eidos/english/ontologies/un_properties.yml
+  // Plugins
+  interventions = /org/clulab/wm/eidos/english/ontologies/interventions.yml
+  // Indicators
+  wdi           = /org/clulab/wm/eidos/english/ontologies/wdi_ontology.yml
+  fao           = /org/clulab/wm/eidos/english/ontologies/fao_variable_ontology.yml
+  mitre12       = /org/clulab/wm/eidos/english/ontologies/mitre12_indicators.yml
+  who           = /org/clulab/wm/eidos/english/ontologies/who_ontology.yml
+  // Variables
+  icasa         = /org/clulab/wm/eidos/english/ontologies/icasa.yml
+  // Other
+  mesh          = /org/clulab/wm/eidos/english/ontologies/mesh_ontology.yml
+
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -13,8 +13,6 @@ EidosSystem {
       wordToVecPath = /org/clulab/wm/eidos/english/w2v/vectors.txt
 //      wordToVecPath = /org/clulab/wm/eidos/english/w2v/glove.840B.300d.txt
    topKNodeGroundings = 10
-        stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt
-      transparentPath = /org/clulab/wm/eidos/english/filtering/transparent.txt
           hedgingPath = /org/clulab/wm/eidos/english/confidence/hedging.txt
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
      geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
@@ -58,5 +56,9 @@ ontologies {
   icasa         = /org/clulab/wm/eidos/english/ontologies/icasa.yml
   // Other
   mesh          = /org/clulab/wm/eidos/english/ontologies/mesh_ontology.yml
+}
 
+filtering {
+  stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt
+  transparentPath = /org/clulab/wm/eidos/english/filtering/transparent.txt
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -2,24 +2,17 @@ EidosSystem {
 // Override the default values here
            language = english
     masterRulesPath = /org/clulab/wm/eidos/english/grammars/master.yml
+       taxonomyPath = /org/clulab/wm/eidos/english/grammars/taxonomy.yml
    quantifierKBPath = /org/clulab/wm/eidos/english/quantifierKB/gradable_adj_fullmodel.kb
   domainParamKBPath = /org/clulab/wm/eidos/english/quantifierKB/domain_parameters.kb
-     quantifierPath =  org/clulab/wm/eidos/english/lexicons/Quantifier.tsv
-     propertiesPath =  org/clulab/wm/eidos/english/lexicons/Property.tsv
-    entityRulesPath = /org/clulab/wm/eidos/english/grammars/entities/grammar/entities.yml
-     avoidRulesPath = /org/clulab/wm/eidos/english/grammars/avoidLocal.yml
-       taxonomyPath = /org/clulab/wm/eidos/english/grammars/taxonomy.yml
-            maxHops = 15
       wordToVecPath = /org/clulab/wm/eidos/english/w2v/vectors.txt
 //      wordToVecPath = /org/clulab/wm/eidos/english/w2v/glove.840B.300d.txt
    topKNodeGroundings = 10
           hedgingPath = /org/clulab/wm/eidos/english/confidence/hedging.txt
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
-     geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
-      geoWord2IdxPath = /org/clulab/wm/eidos/english/context/word2idx_file.txt
-        geoLoc2IdPath = /org/clulab/wm/eidos/english/context/geo_dict_with_population_SOUTH_SUDAN.txt
             cacheDir  = ./cache/english
-
+          useLexicons = true
+      useEntityFinder = true
                useW2V = false
           useTimeNorm = false
            useGeoNorm = false
@@ -58,7 +51,28 @@ ontologies {
   mesh          = /org/clulab/wm/eidos/english/ontologies/mesh_ontology.yml
 }
 
+
+entityFinder {
+  finderType = "eidos"
+  entityRulesPath = /org/clulab/wm/eidos/english/grammars/entities/grammar/entities.yml
+  avoidRulesPath = /org/clulab/wm/eidos/english/grammars/avoidLocal.yml
+  maxHops = 15
+}
+
 filtering {
   stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt
   transparentPath = /org/clulab/wm/eidos/english/filtering/transparent.txt
 }
+
+geoparser {
+  geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
+  geoWord2IdxPath = /org/clulab/wm/eidos/english/context/word2idx_file.txt
+  geoLoc2IdPath = /org/clulab/wm/eidos/english/context/geo_dict_with_population_SOUTH_SUDAN.txt
+}
+
+lexiconNER {
+  quantifierPath =  org/clulab/wm/eidos/english/lexicons/Quantifier.tsv
+  propertiesPath =  org/clulab/wm/eidos/english/lexicons/Property.tsv
+  lexicons = [${lexiconNER.quantifierPath}, ${lexiconNER.propertiesPath}]
+}
+

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -1,9 +1,7 @@
 package org.clulab.wm.eidos
 
 import ai.lum.common.ConfigUtils._
-
 import com.typesafe.config.{Config, ConfigFactory}
-
 import org.clulab.odin._
 import org.clulab.processors.clu._
 import org.clulab.processors.fastnlp.FastNLPProcessor
@@ -14,12 +12,10 @@ import org.clulab.wm.eidos.actions.ExpansionHandler
 import org.clulab.wm.eidos.attachments.{HypothesisHandler, NegationHandler}
 import org.clulab.wm.eidos.context.GeoDisambiguateParser
 import org.clulab.wm.eidos.document.{AnnotatedDocument, EidosDocument}
-import org.clulab.wm.eidos.entities.EidosEntityFinder
+import org.clulab.wm.eidos.entities.{EidosEntityFinder, EntityFinder}
 import org.clulab.wm.eidos.groundings._
-import org.clulab.wm.eidos.groundings.EidosOntologyGrounder._
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils._
-
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
@@ -70,12 +66,12 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
     */
   class LoadableAttributes(
     // These are the values which can be reloaded.  Query them for current assignments.
-    val entityFinder: EidosEntityFinder,
-    val domainParams: DomainParams,
-    val adjectiveGrounder: AdjectiveGrounder,
+    val entityFinder: Option[EntityFinder],
+    val domainParams: DomainParams, // todo: move out
+    val adjectiveGrounder: AdjectiveGrounder, // todo: move out
     val actions: EidosActions,
     val engine: ExtractorEngine,
-    val ner: LexiconNER,
+    val ner: Option[LexiconNER],
     val hedgingHandler: HypothesisHandler,
     val negationHandler: NegationHandler,
     val expansionHandler: ExpansionHandler,
@@ -90,24 +86,16 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
     val       masterRulesPath: String = eidosConf[String]("masterRulesPath")
     val      quantifierKBPath: String = eidosConf[String]("quantifierKBPath")
     val     domainParamKBPath: String = eidosConf[String]("domainParamKBPath")
-    val        quantifierPath: String = eidosConf[String]("quantifierPath")
-    val        propertiesPath: String = eidosConf[String]("propertiesPath")
-    val       entityRulesPath: String = eidosConf[String]("entityRulesPath")
-    val        avoidRulesPath: String = eidosConf[String]("avoidRulesPath")
     val          taxonomyPath: String = eidosConf[String]("taxonomyPath")
     // Filtering
     val       topKNodeGroundings: Int = eidosConf[Int]("topKNodeGroundings")
     // Hedging
     val           hedgingPath: String = eidosConf[String]("hedgingPath")
     val              cacheDir: String = eidosConf[String]("cacheDir")
-    // These are needed to construct some of the loadable attributes even though it isn't a path itself.
-    val               maxHops: Int = eidosConf[Int]("maxHops")
     val      wordToVecPath: String = eidosConf[String]("wordToVecPath")
-    val  timeNormModelPath: String = eidosConf[String]("timeNormModelPath")
-    val   geoNormModelPath: String = eidosConf[String]("geoNormModelPath")
-    val    geoWord2IdxPath: String = eidosConf[String]("geoWord2IdxPath")
-    val      geoLoc2IdPath: String = eidosConf[String]("geoLoc2IdPath")
-
+    val  timeNormModelPath: String = eidosConf[String]("timeNormModelPath") // todo push to companion obj too
+    val       useLexicons: Boolean = eidosConf[Boolean]("useLexicons")
+    val   useEntityFinder: Boolean = eidosConf[Boolean]("useEntityFinder")
     val            useW2V: Boolean = eidosConf[Boolean]("useW2V")
     val       useTimeNorm: Boolean = eidosConf[Boolean]("useTimeNorm")
     val        useGeoNorm: Boolean = eidosConf[Boolean]("useGeoNorm")
@@ -116,7 +104,7 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
 
     val hypothesisHandler = HypothesisHandler(hedgingPath)
     val negationHandler = NegationHandler(language)
-    val expansionHandler = ExpansionHandler(language)
+    val expansionHandler = ExpansionHandler(language) // todo - make more optional
     // For use in creating the ontologies
 
 
@@ -125,13 +113,32 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
       // Reread these values from their files/resources each time based on paths in the config file.
       val masterRules = FileUtils.getTextFromResource(masterRulesPath)
       val actions = EidosActions(taxonomyPath, expansionHandler)
-      // Domain Ontologies:
+
+      // Entity Finders can be used to preload entities into the odin state, their use is optional.
+      val entityFinder = if (useEntityFinder) {
+        val entityFinderConfig = config[Config]("entityFinder")
+        entityFinderConfig[String]("finderType") match {
+          case "eidos" => Some(EidosEntityFinder.fromConfig(entityFinderConfig))
+          case _ => throw new RuntimeException(s"Unexpected entity finder type")
+        }
+      } else None
+
+      // LexiconNER files
+      val lexiconNER = if(useLexicons) {
+        val lexiconNERConfig = config[Config]("lexiconNER")
+        val lexicons = lexiconNERConfig[List[String]]("lexicons")
+        Some(LexiconNER(lexicons, caseInsensitiveMatching = true))
+      } else None
+
+      // Ontologies
       val ontologyGrounders =
           if (useW2V)
             ontologyHandler.ontologyGroundersFromConfig(config[Config]("ontologies"))
           else
             Seq.empty
       val multiOntologyGrounder = new MultiOntologyGrounder(ontologyGrounders)
+
+      // Temporal Parsing
       val timenorm: Option[TemporalCharbasedParser] =
           if (useTimeNorm)
             FileUtils.withResourceAsFile(timeNormModelPath) { file =>
@@ -140,25 +147,27 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
             }
           else
             None
+
+      // Geospatial Parsing
       val geonorm: Option[GeoDisambiguateParser] =
           if (useGeoNorm)
             // Be sure to use fork := true in build.sbt when doing this so that the dll is not loaded twice.
-            Some(new GeoDisambiguateParser(geoNormModelPath, geoWord2IdxPath, geoLoc2IdPath))
+            Some(GeoDisambiguateParser.fromConfig(config[Config]("geoparser")))
           else
             None
 
       new LoadableAttributes(
-        EidosEntityFinder(entityRulesPath, avoidRulesPath, maxHops = maxHops),
+        entityFinder,
         DomainParams(domainParamKBPath),
         EidosAdjectiveGrounder(quantifierKBPath),
         actions,
         ExtractorEngine(masterRules, actions, actions.globalAction), // ODIN component
-        LexiconNER(Seq(quantifierPath, propertiesPath), caseInsensitiveMatching = true), //TODO: keep Quantifier...
+        lexiconNER,
         hypothesisHandler,
         negationHandler,
         expansionHandler,
         ontologyGrounders,
-        multiOntologyGrounder,
+        multiOntologyGrounder,  // todo: do we need this and ontologyGrounders?
         timenorm,
         geonorm
       )
@@ -171,6 +180,10 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
   }
 
   def reload(): Unit = loadableAttributes = LoadableAttributes()
+
+  // ---------------------------------------------------------------------------------------------
+  //                                 Annotation Methods
+  // ---------------------------------------------------------------------------------------------
 
   def annotateDoc(document: Document, keepText: Boolean = true, documentCreationTime: Option[String] = None, filename: Option[String]= None): EidosDocument = {
     val doc = EidosDocument(document, keepText)
@@ -199,20 +212,36 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
     * This will use any non-O tags that are found to overwrite anything that proc has previously found.
     */
   protected def addLexiconNER(s: Sentence): Unit = {
-    val eidosEntities = loadableAttributes.ner.find(s)
-    // The Portuguese parser does not currently generate entities, so we want to create an empty list here for
-    // further processing and filtering operations that expect to be able to query the entities
-    if (s.entities.isEmpty)
-      s.entities = Some(eidosEntities)
-    else {
-      val procEntities = s.entities.get
+    // LexiconNER is an option
+    for (ner <- loadableAttributes.ner) {
+      val eidosEntities = ner.find(s)
 
-      eidosEntities.indices.foreach { index =>
-        if (eidosEntities(index) != EidosSystem.NER_OUTSIDE)
+      // The Portuguese parser does not currently generate entities, so we want to create an empty list here for
+      // further processing and filtering operations that expect to be able to query the entities
+      if (s.entities.isEmpty)
+        s.entities = Some(eidosEntities)
+      else {
+        val procEntities = s.entities.get
+
+        eidosEntities.indices.foreach { index =>
+          if (eidosEntities(index) != EidosSystem.NER_OUTSIDE)
           // Overwrite only if eidosEntities contains something interesting.
-          procEntities(index) = eidosEntities(index)
+            procEntities(index) = eidosEntities(index)
+        }
       }
     }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  //                                 Extraction Methods
+  // ---------------------------------------------------------------------------------------------
+
+  // MAIN PIPELINE METHOD if given text
+  def extractFromText(text: String, keepText: Boolean = true, cagRelevantOnly: Boolean = true,
+                      documentCreationTime: Option[String] = None, filename: Option[String] = None): AnnotatedDocument = {
+    val eidosDoc = annotate(text, keepText, documentCreationTime, filename)
+
+    extractFromDoc(eidosDoc, keepText, cagRelevantOnly, documentCreationTime, filename)
   }
 
   // MAIN PIPELINE METHOD if given doc
@@ -244,24 +273,15 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
     AnnotatedDocument(doc, afterNegation, eidosMentions)
   }
 
-  // MAIN PIPELINE METHOD if given text
-  def extractFromText(text: String, keepText: Boolean = true, cagRelevantOnly: Boolean = true,
-      documentCreationTime: Option[String] = None, filename: Option[String] = None): AnnotatedDocument = {
-    val eidosDoc = annotate(text, keepText, documentCreationTime, filename)
-
-    extractFromDoc(eidosDoc, keepText, cagRelevantOnly, documentCreationTime, filename)
-  }
-
-  def extractEventsFrom(doc: Document, state: State): Vector[Mention] = {
-    val res = loadableAttributes.engine.extractFrom(doc, state).toVector
-    loadableAttributes.actions.keepMostCompleteEvents(res, State(res)).toVector
-  }
-
   def extractFrom(doc: Document): Vector[Mention] = {
-    // get entities
-    val entities: Seq[Mention] = loadableAttributes.entityFinder.extractAndFilter(doc).toVector
-
-    val events = extractEventsFrom(doc, State(entities)).distinct
+    // Prepare the initial state -- if you are using the entity finder then it contains the found entities,
+    // else it is empty
+    val initalState = loadableAttributes.entityFinder match {
+      case None => new State()
+      case Some(ef) => State(ef.extract(doc))
+    }
+    // Run the main extraction engine, pre-populated with the initial state
+    val events = extractEventsFrom(doc, initalState).distinct
     // Note -- in main pipeline we filter to only CAG relevant after this method.  Since the filtering happens at the
     // next stage, currently all mentions make it to the webapp, even ones that we filter out for the CAG exports
     //val cagRelevant = keepCAGRelevant(events)
@@ -269,7 +289,14 @@ class EidosSystem(val config: Config = ConfigFactory.load("eidos")) {
     events
   }
 
+  def extractEventsFrom(doc: Document, state: State): Vector[Mention] = {
+    val res = loadableAttributes.engine.extractFrom(doc, state).toVector
+    loadableAttributes.actions.keepMostCompleteEvents(res, State(res)).toVector
+  }
 
+  // ---------------------------------------------------------------------------------------------
+  //                                 Helper Methods
+  // ---------------------------------------------------------------------------------------------
 
   /**
     * Wrapper for using w2v on some strings

--- a/src/main/scala/org/clulab/wm/eidos/apps/AnnotationTSV.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/AnnotationTSV.scala
@@ -27,7 +27,7 @@ object AnnotationTSV extends App with Configured {
 
   def mkTableRows(annotatedDocument: AnnotatedDocument, filename: String, reader: EidosSystem): (Seq[String], Counter[String]) = {
     val allMentions = annotatedDocument.odinMentions
-    val mentionsToPrint = annotatedDocument.eidosMentions.filter(m => reader.releventEdge(m.odinMention, State(allMentions)))
+    val mentionsToPrint = annotatedDocument.eidosMentions.filter(m => reader.stopwordManager.releventEdge(m.odinMention, State(allMentions)))
 
     val ruleCounter = new Counter[String]
 

--- a/src/main/scala/org/clulab/wm/eidos/apps/CacheOntologies.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/CacheOntologies.scala
@@ -2,58 +2,54 @@ package org.clulab.wm.eidos.apps
 
 import java.io.File
 
-import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
-import org.clulab.utils.Configured
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.ConfigFactory
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.groundings.CompactDomainOntology.CompactDomainOntologyBuilder
 import org.clulab.wm.eidos.groundings._
 import org.clulab.wm.eidos.utils.Canonicalizer
 
-object CacheOntologies extends App with Configured {
+object CacheOntologies extends App {
 
   val config = ConfigFactory.load("eidos")
-      .withValue("EidosSystem.useW2V", ConfigValueFactory.fromAnyRef(false, "Don't use vectors when caching ontologies."))
   val reader = new EidosSystem(config)
-  val loadableAttributes = reader.LoadableAttributes
-  val cacheDir: String = loadableAttributes.cacheDir
-
+  val cacheDir: String = reader.LoadableAttributes.cacheDir
+  // Since here we want to cache the current, we can't load from cached:
+  assert(config[Boolean]("ontologies.useCache") == false, "To use CacheOntologies, you must set ontologies.useCache = false")
+  assert(reader.LoadableAttributes.useW2V == true, "To use CacheOntologies, you must set useW2V = true")
   new File(cacheDir).mkdirs()
 
-  val ontologies: Seq[String] = loadableAttributes.ontologies
+  val ontologyGrounders: Seq[EidosOntologyGrounder] = reader.loadableAttributes.ontologyGrounders
 
-  if (ontologies.isEmpty)
+  if (ontologyGrounders.isEmpty)
     throw new RuntimeException("No ontologies were specified, please check the config file.")
   else {
     val proc = reader.proc
     val canonicalizer = new Canonicalizer(reader)
 
     println(s"Saving ontologies to $cacheDir...")
-    ontologies.foreach { domainOntology =>
-      // make
-      val ontology: DomainOntology = reader.LoadableAttributes.mkDomainOntology(domainOntology, useCached = false)
+    ontologyGrounders.foreach { grounder =>
+      val ontologyName = grounder.name
+      val ontology: DomainOntology = grounder.domainOntology
       // convert
       val treeDomainOntology = ontology.asInstanceOf[TreeDomainOntology]
       val compactDomainOntology = new CompactDomainOntologyBuilder(treeDomainOntology).build()
       // save
-      val serializedPath = DomainOntologies.serializedPath(domainOntology, cacheDir)
+      val serializedPath = OntologyHandler.serializedPath(ontologyName, cacheDir)
       compactDomainOntology.save(serializedPath)
     }
-    println(s"Finished serializing ${ontologies.length} ontologies.")
+    println(s"Finished serializing ${ontologyGrounders.length} ontologies.")
   }
 
-  val filenameIn = loadableAttributes.wordToVecPath
-  val filenameOut = EidosWordToVec.makeCachedFilename(cacheDir, loadableAttributes.wordToVecPath)
+  val filenameIn = reader.LoadableAttributes.wordToVecPath
+  val filenameOut = EidosWordToVec.makeCachedFilename(cacheDir, filenameIn)
   println(s"Saving vectors to $filenameOut...")
   val word2Vec = CompactWord2Vec(filenameIn, resource = true, cached = false)
   word2Vec.save(filenameOut)
   println(s"Finished serializing vectors.")
 
   // Update the indicator mapping file
-  val config2 = ConfigFactory.load("eidos")
-    .withValue("EidosSystem.useW2V", ConfigValueFactory.fromAnyRef(true, "DO use vectors when mapping ontologies."))
-  override def getConf: Config = config2
-  val reader2 = new EidosSystem(config2)
-  val outputFile = getArgString("apps.ontologymapper.outfile", None)
-  val topN = getArgInt("apps.groundTopN", Some(5))
-  OntologyMapper.mapIndicators(reader2, outputFile, topN)
+  val outputFile = config[String]("apps.ontologymapper.outfile")
+  val topN = config[Int]("apps.groundTopN")
+  OntologyMapper.mapIndicators(reader, outputFile, topN)
 }

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExampleGenerator.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExampleGenerator.scala
@@ -21,7 +21,7 @@ object ExampleGenerator extends App {
 
   // extract mentions from annotated document
   val mentions = ieSystem.extractFrom(doc).sortBy(m => (m.sentence, m.getClass.getSimpleName))
-  val eidosMentions = EidosMention.asEidosMentions(mentions, new Canonicalizer(ieSystem.loadableAttributes.stopwordManager), ieSystem.loadableAttributes.multiOntologyGrounder)
+  val eidosMentions = EidosMention.asEidosMentions(mentions, new Canonicalizer(ieSystem.stopwordManager), ieSystem.loadableAttributes.multiOntologyGrounder)
 
   // Display the groundings for all entities
   for (e <- eidosMentions.filter(_.odinMention matches "Entity")) {

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractAndExport.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractAndExport.scala
@@ -100,7 +100,7 @@ case class MitreExporter(pw: PrintWriter, reader: EidosSystem, filename: String,
 
   def printTableRows(annotatedDocument: AnnotatedDocument, pw: PrintWriter, filename: String, reader: EidosSystem): Unit = {
     val allOdinMentions = annotatedDocument.eidosMentions.map(_.odinMention)
-    val mentionsToPrint = annotatedDocument.eidosMentions.filter(m => reader.releventEdge(m.odinMention, State(allOdinMentions)))
+    val mentionsToPrint = annotatedDocument.eidosMentions.filter(m => reader.stopwordManager.releventEdge(m.odinMention, State(allOdinMentions)))
 
     for {
       mention <- mentionsToPrint

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractFromFile.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractFromFile.scala
@@ -29,7 +29,7 @@ object ExtractFromFile extends App {
       // keep the EidosMentions that are relevant to the CAG
       val cagEdgeMentions = annotatedDoc.odinMentions.filter(m => EidosSystem.CAG_EDGES.contains(m.label))
       val cagEdgeArguments = cagEdgeMentions.flatMap(mention => mention.arguments.values.flatten.toSeq)
-      val eidosMentions = annotatedDoc.eidosMentions.filter(em => ieSystem.isCAGRelevant(em.odinMention, cagEdgeMentions, cagEdgeArguments))
+      val eidosMentions = annotatedDoc.eidosMentions.filter(em => ieSystem.stopwordManager.isCAGRelevant(em.odinMention, cagEdgeMentions, cagEdgeArguments))
 
       val mentionsBySentence = eidosMentions.groupBy(_.odinMention.sentence).toSeq.sortBy(_._1)
       for ((sentence, sentenceMentions) <- mentionsBySentence) {

--- a/src/main/scala/org/clulab/wm/eidos/apps/MakeRuleTSVs.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/MakeRuleTSVs.scala
@@ -30,7 +30,7 @@ object MakeRuleTSVs extends App {
 
   // Organize
   val mentions = annotatedDocuments.seq.flatMap(ad => ad.odinMentions)
-  val keptMentions = reader.keepCAGRelevant(mentions)
+  val keptMentions = reader.stopwordManager.keepCAGRelevant(mentions)
   // create a map where the key is the Set of rule/rule components and the values are the Mentions
   val byRules = keptMentions.groupBy(_.foundBy)
     .map(grouping => (grouping._1.split("\\+\\+").toSet, grouping._2))

--- a/src/main/scala/org/clulab/wm/eidos/context/GeoDisambiguateParser.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/GeoDisambiguateParser.scala
@@ -1,5 +1,7 @@
 package org.clulab.wm.eidos.context
 
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.Config
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.Sourcer
 import org.deeplearning4j.nn.graph.ComputationGraph
@@ -13,6 +15,13 @@ object GeoDisambiguateParser {
   val O_LOC = 2
   val UNKNOWN_TOKEN = "UNKNOWN_TOKEN"
   val TIME_DISTRIBUTED_1 = "time_distributed_1"
+
+  def fromConfig(config: Config): GeoDisambiguateParser = {
+    val   geoNormModelPath: String = config[String]("geoNormModelPath")
+    val    geoWord2IdxPath: String = config[String]("geoWord2IdxPath")
+    val      geoLoc2IdPath: String = config[String]("geoLoc2IdPath")
+    new GeoDisambiguateParser(geoNormModelPath, geoWord2IdxPath, geoLoc2IdPath)
+  }
 }
 
 /**

--- a/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
@@ -1,5 +1,7 @@
 package org.clulab.wm.eidos.entities
 
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import org.clulab.odin.{ExtractorEngine, Mention, State, TextBoundMention}
 import org.clulab.processors.Document
@@ -153,5 +155,12 @@ object EidosEntityFinder extends LazyLogging {
     val avoidEngine = ExtractorEngine(avoidRules)
 
     new EidosEntityFinder(entityEngine = entityEngine, avoidEngine = avoidEngine, maxHops = maxHops)
+  }
+
+  def fromConfig(config: Config): EidosEntityFinder = {
+    val entityRulesPath = config[String]("entityRulesPath")
+    val avoidRulesPath = config[String]("avoidRulesPath")
+    val maxHops = config[Int]("maxHops")
+    EidosEntityFinder(entityRulesPath, avoidRulesPath, maxHops = maxHops)
   }
 }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/DomainOntologies.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/DomainOntologies.scala
@@ -8,8 +8,6 @@ import org.slf4j.LoggerFactory
 object DomainOntologies {
   protected lazy val logger = LoggerFactory.getLogger(this.getClass())
 
-  def serializedPath(name: String, dir: String): String = s"$dir/$name.serialized"
-
   def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false): DomainOntology = {
     if (useCache) {
       logger.info(s"Processing cached yml ontology ${serializedPath}...")
@@ -20,51 +18,5 @@ object DomainOntologies {
       new TreeDomainOntologyBuilder(ontologyPath, proc, canonicalizer, filter).build()
     }
   }
-}
 
-// These are just here for when behavior might have to start differing.
-object UNOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
-}
-
-object PropertiesOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-    DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
-}
-
-object WDIOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
-}
-
-object FAOOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
-}
-
-object TopoFlowOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
-}
-
-object MeshOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-      DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
-}
-
-object MITRE12Ontology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-    DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
-}
-
-object WHOOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-    DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
-}
-
-// Intervention Ontology
-object IntOntology {
-  def apply(ontologyPath: String, serializedPath: String, proc: Processor, canonicalizer: Canonicalizer, filter: Boolean = true, useCache: Boolean = false) =
-    DomainOntologies(ontologyPath, serializedPath, proc, canonicalizer: Canonicalizer, filter, useCache)
 }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
@@ -75,7 +75,7 @@ class RealWordToVec(val w2v: CompactWord2Vec, topKNodeGroundings: Int) extends E
   }
 
   def makeCompositeVector(t: Iterable[String]): Array[Float] = w2v.makeCompositeVector(t)
-  
+
 }
 
 object EidosWordToVec {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
@@ -8,6 +8,8 @@ import org.slf4j.{Logger, LoggerFactory}
 trait EidosWordToVec {
   type Similarities = Seq[(Namer, Float)]
 
+  def name: String
+
   def stringSimilarity(string1: String, string2: String): Float
   def calculateSimilarity(mention1: Mention, mention2: Mention): Float
   def calculateSimilarities(canonicalNameParts: Array[String], conceptEmbeddings: Seq[ConceptEmbedding]): Similarities
@@ -15,6 +17,9 @@ trait EidosWordToVec {
 }
 
 class FakeWordToVec extends EidosWordToVec {
+  println("Loaded a FAKE w2v")
+
+  def name = "Fake"
 
   override def stringSimilarity(string1: String, string2: String): Float =
     throw new RuntimeException("Word2Vec wasn't loaded, please check configurations.")
@@ -28,7 +33,8 @@ class FakeWordToVec extends EidosWordToVec {
 }
 
 class RealWordToVec(val w2v: CompactWord2Vec, topKNodeGroundings: Int) extends EidosWordToVec {
-
+  println("Loaded a REAL w2v!")
+  def name = "Real"
   protected def split(string: String): Array[String] = string.split(" +")
 
   def stringSimilarity(string1: String, string2: String): Float =
@@ -74,7 +80,10 @@ class RealWordToVec(val w2v: CompactWord2Vec, topKNodeGroundings: Int) extends E
     }
   }
 
-  def makeCompositeVector(t: Iterable[String]): Array[Float] = w2v.makeCompositeVector(t)
+  def makeCompositeVector(t: Iterable[String]): Array[Float] = {
+    println("******** Made it to w2v makeCompositeVector")
+    w2v.makeCompositeVector(t)
+  }
 }
 
 object EidosWordToVec {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/EidosWordToVec.scala
@@ -8,8 +8,6 @@ import org.slf4j.{Logger, LoggerFactory}
 trait EidosWordToVec {
   type Similarities = Seq[(Namer, Float)]
 
-  def name: String
-
   def stringSimilarity(string1: String, string2: String): Float
   def calculateSimilarity(mention1: Mention, mention2: Mention): Float
   def calculateSimilarities(canonicalNameParts: Array[String], conceptEmbeddings: Seq[ConceptEmbedding]): Similarities
@@ -17,9 +15,6 @@ trait EidosWordToVec {
 }
 
 class FakeWordToVec extends EidosWordToVec {
-  println("Loaded a FAKE w2v")
-
-  def name = "Fake"
 
   override def stringSimilarity(string1: String, string2: String): Float =
     throw new RuntimeException("Word2Vec wasn't loaded, please check configurations.")
@@ -33,8 +28,7 @@ class FakeWordToVec extends EidosWordToVec {
 }
 
 class RealWordToVec(val w2v: CompactWord2Vec, topKNodeGroundings: Int) extends EidosWordToVec {
-  println("Loaded a REAL w2v!")
-  def name = "Real"
+
   protected def split(string: String): Array[String] = string.split(" +")
 
   def stringSimilarity(string1: String, string2: String): Float =
@@ -80,13 +74,12 @@ class RealWordToVec(val w2v: CompactWord2Vec, topKNodeGroundings: Int) extends E
     }
   }
 
-  def makeCompositeVector(t: Iterable[String]): Array[Float] = {
-    println("******** Made it to w2v makeCompositeVector")
-    w2v.makeCompositeVector(t)
-  }
+  def makeCompositeVector(t: Iterable[String]): Array[Float] = w2v.makeCompositeVector(t)
+  
 }
 
 object EidosWordToVec {
+
   protected lazy val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   def makeCachedFilename(path: String, file: String): String =

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -39,14 +39,14 @@ trait MultiOntologyGrounder {
 }
 
 
-class EidosOntologyGrounder(val name: String, domainOntology: DomainOntology, wordToVec: EidosWordToVec) extends OntologyGrounder {
+class EidosOntologyGrounder(val name: String, val domainOntology: DomainOntology, wordToVec: EidosWordToVec) extends OntologyGrounder {
   // Is not dependent on the output of other grounders
   val isPrimary = true
 
   val conceptEmbeddings: Seq[ConceptEmbedding] =
     0.until(domainOntology.size).map { n =>
       new ConceptEmbedding(domainOntology.getNamer(n),
-          wordToVec.makeCompositeVector(domainOntology.getValues(n)))
+           wordToVec.makeCompositeVector(domainOntology.getValues(n)))
     }
 
   val conceptPatterns: Seq[ConceptPatterns] =
@@ -152,10 +152,11 @@ object EidosOntologyGrounder {
   val MITRE12_NAMESPACE = "mitre12"
   val     WHO_NAMESPACE = "who"
   val     INT_NAMESPACE = "interventions"
+  val   ICASA_NAMESPACE = "icasa"
   // Used for plugin ontologies
   val INTERVENTION_PLUGIN_TRIGGER = "UN/interventions"
 
-  val indicatorNamespaces = Set(WDI_NAMESPACE, FAO_NAMESPACE, MITRE12_NAMESPACE, WHO_NAMESPACE)
+  val indicatorNamespaces = Set(WDI_NAMESPACE, FAO_NAMESPACE, MITRE12_NAMESPACE, WHO_NAMESPACE, ICASA_NAMESPACE)
 
   protected lazy val logger = LoggerFactory.getLogger(this.getClass())
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -46,6 +46,7 @@ class EidosOntologyGrounder(val name: String, val domainOntology: DomainOntology
 
   val conceptEmbeddings: Seq[ConceptEmbedding] =
     0.until(domainOntology.size).map { n =>
+      println(s"working on concept $n: name: ${domainOntology.getNamer(n)}")
       new ConceptEmbedding(domainOntology.getNamer(n),
            wordToVec.makeCompositeVector(domainOntology.getValues(n)))
     }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -44,11 +44,17 @@ class EidosOntologyGrounder(val name: String, val domainOntology: DomainOntology
   // Is not dependent on the output of other grounders
   val isPrimary = true
 
+  // fixme -- the w2v is Null for some reason!
+  println(s"W2V name: ${wordToVec.name}")
+
   val conceptEmbeddings: Seq[ConceptEmbedding] =
     0.until(domainOntology.size).map { n =>
-      println(s"working on concept $n: name: ${domainOntology.getNamer(n)}")
+      println(s"working on concept $n: name: ${domainOntology.getNamer(n).name} <EOL>")
+      println(s"$name\t${domainOntology.size}")
+      val values = domainOntology.getValues(n)
+      values.foreach(v => println(s"\t$v"))
       new ConceptEmbedding(domainOntology.getNamer(n),
-           wordToVec.makeCompositeVector(domainOntology.getValues(n)))
+           wordToVec.makeCompositeVector(values))
     }
 
   val conceptPatterns: Seq[ConceptPatterns] =

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -44,17 +44,10 @@ class EidosOntologyGrounder(val name: String, val domainOntology: DomainOntology
   // Is not dependent on the output of other grounders
   val isPrimary = true
 
-  // fixme -- the w2v is Null for some reason!
-  println(s"W2V name: ${wordToVec.name}")
-
   val conceptEmbeddings: Seq[ConceptEmbedding] =
     0.until(domainOntology.size).map { n =>
-      println(s"working on concept $n: name: ${domainOntology.getNamer(n).name} <EOL>")
-      println(s"$name\t${domainOntology.size}")
-      val values = domainOntology.getValues(n)
-      values.foreach(v => println(s"\t$v"))
       new ConceptEmbedding(domainOntology.getNamer(n),
-           wordToVec.makeCompositeVector(values))
+           wordToVec.makeCompositeVector(domainOntology.getValues(n)))
     }
 
   val conceptPatterns: Seq[ConceptPatterns] =

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
@@ -10,11 +10,7 @@ class OntologyHandler(val proc: Processor, val wordToVec: EidosWordToVec, val ca
 
   import OntologyHandler.serializedPath
 
-  println(s"In OntologyHandler, w2v name: ${wordToVec.name}")
-
   def ontologyGroundersFromConfig(config: Config): Seq[EidosOntologyGrounder] = {
-    println("*********************")
-    println(config.entrySet())
 
     val cacheDir: String = config[String]("cacheDir")
     val useCached: Boolean = config[Boolean]("useCache")
@@ -23,7 +19,6 @@ class OntologyHandler(val proc: Processor, val wordToVec: EidosWordToVec, val ca
       ontologyName <- selected
       path = config[String](ontologyName)
       domainOntology = mkDomainOntology(ontologyName, path, cacheDir, useCached)
-      _ = println(s"Making $ontologyName ontology from $path")
     } yield EidosOntologyGrounder(ontologyName, domainOntology, wordToVec)
   }
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
@@ -1,0 +1,40 @@
+package org.clulab.wm.eidos.groundings
+
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.Config
+import org.clulab.processors.Processor
+import org.clulab.wm.eidos.utils.Canonicalizer
+
+
+class OntologyHandler(val proc: Processor, val wordToVec: EidosWordToVec, val canonicalizer: Canonicalizer) {
+
+  import OntologyHandler.serializedPath
+
+  def ontologyGroundersFromConfig(config: Config): Seq[EidosOntologyGrounder] = {
+    println("*********************")
+    println(config.entrySet())
+
+    val cacheDir: String = config[String]("cacheDir")
+    val useCached: Boolean = config[Boolean]("useCache")
+    val selected = config[List[String]]("ontologies")
+    for {
+      ontologyName <- selected
+      path = config[String](ontologyName)
+      domainOntology = mkDomainOntology(ontologyName, path, cacheDir, useCached)
+    } yield EidosOntologyGrounder(ontologyName, domainOntology, wordToVec)
+  }
+
+  // todo: I removed all the variants bc we don't currently need specialization, but we can specialize as needed later
+  def mkDomainOntology(name: String, ontologyPath: String, cacheDir: String, useCached: Boolean): DomainOntology = {
+    val ontSerializedPath: String = serializedPath(name, cacheDir)
+    DomainOntologies(ontologyPath, ontSerializedPath, proc, canonicalizer: Canonicalizer, filter = true, useCache = useCached)
+  }
+
+}
+
+object OntologyHandler {
+
+  def serializedPath(name: String, dir: String): String = s"$dir/$name.serialized"
+
+}
+

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
@@ -10,6 +10,8 @@ class OntologyHandler(val proc: Processor, val wordToVec: EidosWordToVec, val ca
 
   import OntologyHandler.serializedPath
 
+  println(s"In OntologyHandler, w2v name: ${wordToVec.name}")
+
   def ontologyGroundersFromConfig(config: Config): Seq[EidosOntologyGrounder] = {
     println("*********************")
     println(config.entrySet())
@@ -21,6 +23,7 @@ class OntologyHandler(val proc: Processor, val wordToVec: EidosWordToVec, val ca
       ontologyName <- selected
       path = config[String](ontologyName)
       domainOntology = mkDomainOntology(ontologyName, path, cacheDir, useCached)
+      _ = println(s"Making $ontologyName ontology from $path")
     } yield EidosOntologyGrounder(ontologyName, domainOntology, wordToVec)
   }
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
@@ -84,11 +84,7 @@ class TreeDomainOntology(val ontologyNodes: Array[OntologyLeafNode]) extends Dom
 
   def getNamer(n: Integer): Namer = ontologyNodes(n)
 
-  def getValues(n: Integer): Array[String] = {
-    println("!!!!!!!!!!!!!!!!\n\t Made it to TreeDomainOntology")
-    println(s"\t returning ${ontologyNodes(n).values}")
-    ontologyNodes(n).values
-  }
+  def getValues(n: Integer): Array[String] = ontologyNodes(n).values
 
   def getPatterns(n: Integer): Option[Array[Regex]] = ontologyNodes(n).patterns
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
@@ -84,7 +84,11 @@ class TreeDomainOntology(val ontologyNodes: Array[OntologyLeafNode]) extends Dom
 
   def getNamer(n: Integer): Namer = ontologyNodes(n)
 
-  def getValues(n: Integer): Array[String] = ontologyNodes(n).values
+  def getValues(n: Integer): Array[String] = {
+    println("!!!!!!!!!!!!!!!!\n\t Made it to TreeDomainOntology")
+    println(s"\t returning ${ontologyNodes(n).values}")
+    ontologyNodes(n).values
+  }
 
   def getPatterns(n: Integer): Option[Array[Regex]] = ontologyNodes(n).patterns
 

--- a/src/main/scala/org/clulab/wm/eidos/utils/StopwordManager.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/StopwordManager.scala
@@ -1,5 +1,7 @@
 package org.clulab.wm.eidos.utils
 
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.Config
 import org.clulab.odin._
 import org.clulab.wm.eidos.{EidosActions, EidosSystem}
 
@@ -59,6 +61,48 @@ class StopwordManager(stopwordsPath: String, transparentPath: String) extends St
 
   override def containsStopwordStrict(stopword: String): Boolean = stopwords.contains(stopword)
 
+  def keepCAGRelevant(mentions: Seq[Mention]): Seq[Mention] = {
+
+    // 1) These will be "Causal" and "Correlation" which fall under "Event" if they have content
+    val allMentions = State(mentions)
+    val cagEdgeMentions = mentions.filter(m => releventEdge(m, allMentions))
+
+    // Should these be included as well?
+
+    // 3) These last ones may overlap with the above or include mentions not in the original list.
+    val cagEdgeArguments = cagEdgeMentions.flatMap(mention => mention.arguments.values.flatten.toSeq)
+    // Put them all together.
+    // val releventEdgesAndTheirArgs = cagEdgeMentions ++ cagEdgeArguments
+    // To preserve order, avoid repeats, and not allow anything new in the list, filter the original.
+    mentions.filter(mention => isCAGRelevant(mention, cagEdgeMentions, cagEdgeArguments))
+  }
+
+  def isCAGRelevant(mention: Mention, cagEdgeMentions: Seq[Mention], cagEdgeArguments: Seq[Mention]): Boolean =
+  // We're no longer keeping all modified entities
+  //(mention.matches("Entity") && mention.attachments.nonEmpty) ||
+    cagEdgeMentions.contains(mention) ||
+      cagEdgeArguments.contains(mention)
+
+  def releventEdge(m: Mention, state: State): Boolean = {
+    m match {
+      case tb: TextBoundMention => EidosSystem.CAG_EDGES.contains(tb.label)
+      case rm: RelationMention => EidosSystem.CAG_EDGES.contains(rm.label)
+      case em: EventMention => EidosSystem.CAG_EDGES.contains(em.label) && argumentsHaveContent(em, state)
+      case cs: CrossSentenceMention => EidosSystem.CAG_EDGES.contains(cs.label)
+      case _ => throw new UnsupportedClassVersionError()
+    }
+  }
+
+  def argumentsHaveContent(mention: EventMention, state: State): Boolean = {
+    val causes: Seq[Mention] = mention.arguments.getOrElse("cause", Seq.empty)
+    val effects: Seq[Mention] = mention.arguments.getOrElse("effect", Seq.empty)
+
+    if (causes.nonEmpty && effects.nonEmpty) // If it's something interesting,
+    // then both causes and effects should have some content
+      causes.exists(hasContent(_, state)) && effects.exists(hasContent(_, state))
+    else
+      true
+  }
 }
 
 object StopwordManager {
@@ -67,4 +111,10 @@ object StopwordManager {
   val STOP_NER: Set[String] = Set("DATE", "DURATION", "LOCATION", "MONEY", "NUMBER", "ORDINAL", "ORGANIZATION", "PERCENT", "PERSON", "PLACE", "SET", "TIME")
 
   def apply(stopwordsPath: String, transparentPath: String) = new StopwordManager(stopwordsPath, transparentPath)
+
+  def fromConfig(config: Config) = {
+    val stopwordsPath: String = config[String]("stopWordsPath")
+    val transparentPath: String = config[String]("transparentPath")
+    apply(stopwordsPath, transparentPath)
+  }
 }

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDSerializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDSerializer.scala
@@ -129,7 +129,7 @@ class TestJLDSerializer extends ExtractionTest {
         Set.empty
       )
       val nextOdinMentions = crossSentenceMention +: prevOdinMentions
-      val nextEidosMentions = EidosMention.asEidosMentions(nextOdinMentions, new Canonicalizer(ieSystem.loadableAttributes.stopwordManager), ieSystem.loadableAttributes.multiOntologyGrounder)
+      val nextEidosMentions = EidosMention.asEidosMentions(nextOdinMentions, new Canonicalizer(ieSystem.stopwordManager), ieSystem.loadableAttributes.multiOntologyGrounder)
       val nextAnnotatedDocument = AnnotatedDocument(firstMention.document, nextOdinMentions, nextEidosMentions)
 
       nextAnnotatedDocument

--- a/src/test/scala/org/clulab/wm/eidos/system/TestDomainOntology.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestDomainOntology.scala
@@ -34,7 +34,7 @@ class TestDomainOntology extends Test {
       .withValue("EidosSystem.useW2V", ConfigValueFactory.fromAnyRef(false, "Don't use vectors when caching ontologies."))
   val reader = new EidosSystem(config)
   val proc = reader.proc
-  val canonicalizer = new Canonicalizer(reader.loadableAttributes.stopwordManager)
+  val canonicalizer = new Canonicalizer(reader.stopwordManager)
   val convert = true
   val filter = true
 

--- a/src/test/scala/org/clulab/wm/eidos/system/TestDomainOntology.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestDomainOntology.scala
@@ -60,7 +60,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/un_ontology.yml"
 
     val newOntology = Timer.time("Load UN without cache") {
-      UNOntology(path, "", proc, canonicalizer, filter, useCache = false)
+      DomainOntologies(path, "", proc, canonicalizer, filter, useCache = false)
     }
     val newerOntology =
       if (convert)
@@ -69,7 +69,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load UN from cache") {
-          UNOntology(path, "", proc, canonicalizer, filter, useCache = true)
+          DomainOntologies(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 //    val newestOntology = Timer.time("Load UN from cache") {
@@ -87,7 +87,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/fao_variable_ontology.yml"
 
     val newOntology = Timer.time("Load FAO without cache") {
-      FAOOntology(path, "", proc, canonicalizer, filter, useCache =false)
+      DomainOntologies(path, "", proc, canonicalizer, filter, useCache =false)
     }
     val newerOntology =
       if (convert)
@@ -96,7 +96,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load FAO from cache") {
-          FAOOntology(path, "", proc, canonicalizer, filter, useCache = true)
+          DomainOntologies(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 
@@ -115,7 +115,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/wdi_ontology.yml"
 
     val newOntology = Timer.time("Load WDI without cache") {
-      WDIOntology(path, "", proc, canonicalizer, filter, useCache = false)
+      DomainOntologies(path, "", proc, canonicalizer, filter, useCache = false)
     }
     val newerOntology =
       if (convert)
@@ -124,7 +124,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load WDI from cache") {
-          WDIOntology(path, "", proc, canonicalizer, filter, useCache = true)
+          DomainOntologies(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 //    val newestOntology = Timer.time("Load WDI with cache") {
@@ -143,7 +143,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/topoflow_ontology.yml"
 
     val newOntology = Timer.time("Load TOPO without cache") {
-      TopoFlowOntology(path, "", proc, canonicalizer, filter, useCache = false)
+      DomainOntologies(path, "", proc, canonicalizer, filter, useCache = false)
     }
 
     hasDuplicates("topo", newOntology) should be (false)
@@ -154,7 +154,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/mesh_ontology.yml"
 
     val newOntology = Timer.time("Load MeSH without cache") {
-      MeshOntology(path, "", proc, canonicalizer, filter, useCache = false)
+      DomainOntologies(path, "", proc, canonicalizer, filter, useCache = false)
     }
     val newerOntology =
       if (convert)
@@ -163,7 +163,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load MeSH from cache") {
-          MeshOntology(path, "", proc, canonicalizer, filter, useCache = true)
+          DomainOntologies(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 //    val newestOntology = Timer.time("Load MeSH with cache") {
@@ -181,7 +181,7 @@ class TestDomainOntology extends Test {
     val path = baseDir + "/un_properties.yml"
 
     val newOntology = Timer.time("Load UN properties without cache") {
-      PropertiesOntology(path, "", proc, canonicalizer, filter, useCache = false)
+      DomainOntologies(path, "", proc, canonicalizer, filter, useCache = false)
     }
     val newerOntology =
       if (convert)
@@ -190,7 +190,7 @@ class TestDomainOntology extends Test {
         }
       else
         Timer.time("Load UN properties from cache") {
-          PropertiesOntology(path, "", proc, canonicalizer, filter, useCache = true)
+          DomainOntologies(path, "", proc, canonicalizer, filter, useCache = true)
         }
 
 //    val newestOntology = Timer.time("Load UN properties from cache") {


### PR DESCRIPTION
This would ideally be PRd after the dssat_vars branch (i made it from that branch, so the "diffs" will greatly reduce once that is merged....!)

I made the LexiconNER and EntityFinder optional (toggled in the config) and moved the params of those and the geonorm model to the companion objects in a `fromConfig` method

Updates to the configs accordingly

fyi @MihaiSurdeanu