### PR TITLE
More corr

### DIFF
--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/explicitLinkers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/explicitLinkers.yml
@@ -49,12 +49,13 @@ rules:
   - name: syntax_verb-Correlation_with
     priority: ${ rulepriority }
     example: "moderate to heavy seasonal rainfall is expected to continue, with heightened risk of flooding in these regions"
+    # Significant decline in poverty will be associated with a decrease in family size and increase in non-farm income .
     label: Correlation
     action: ${ action }
     pattern: |
       trigger = [word=/(?i)^(${ correlation_trigger })/ & tag=/^VB/]
-      cause: Entity = nmod_with
-      effect: Entity  = nsubj
+      cause: Entity = nmod_with /${preps}/{,2}
+      effect: Entity  = /${agents}/ /${preps}/{,2}
 
 
   - name: syntax_5_verb-Correlation

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
@@ -13,4 +13,4 @@ reverse_direction_cause_triggers: "result|effect|consequence"
 affect_triggers: "affect|alter|(displaces?$)|chang|influenc|modifi|modify"
 nonavoid_affect_triggers: "impact"
 
-correlation_triggers: "coincid|link"
+correlation_triggers: "associat|coincid|link"


### PR DESCRIPTION
per convo with @bgyori , we weren't capturing "associated with" patterns:


> So I just noticed that there are a lot of occurrences of “associated with” phrases that could be extracted as Correlations but “association” doesn’t appear as a trigger word. There are even some test sentences like
> ```Significant decline in poverty will be associated with a decrease in family size and increase in non-farm income .```
> but currently I’m not getting a correlation from these
> I was wondering if adding this as a trigger and writing some extraction rules would be a good idea or if you avoided this on purpose

not on purpose, so here it is! :)

![image](https://user-images.githubusercontent.com/5384073/51641553-a986a200-1f23-11e9-8a72-715ea23907bf.png)

thanks @bgyori !

Also -- @MihaiSurdeanu -- fun fact: when we only show "CAG Relevant" extractions we lose the `Dec(family size)` Mention bc both `family` and `size` are transparent/filtered (I think we likely added these individually on purpose, but as an FYI in case we want to rethink any of those decisions)