### PR TITLE
Keeping, Expanding, and Dumping of inc/dec/quant concepts not in causal events

### DIFF
--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -12,7 +12,7 @@ EidosSystem {
           useTimeNorm = false
            useGeoNorm = true
              useCache = false
- keepStatefulConcepts = false
+ keepStatefulConcepts = true
 }
 
 apps {

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -12,6 +12,7 @@ EidosSystem {
           useTimeNorm = false
            useGeoNorm = true
              useCache = false
+ keepStatefulConcepts = false
 }
 
 apps {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,6 +15,7 @@ EidosSystem {
           useTimeNorm = false
            useGeoNorm = false
              useCache = false
+ keepStatefulConcepts = false
 }
 
 apps {

--- a/src/main/scala/org/clulab/wm/eidos/utils/MentionUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/MentionUtils.scala
@@ -20,4 +20,13 @@ object MentionUtils {
 
   def withMoreAttachments(mention: Mention, attachments: Seq[Attachment]): Mention =
       withOnlyAttachments(mention, mention.attachments ++ attachments)
+
+  def withLabel(mention: Mention, lab: String): Mention = {
+    mention match {
+      case m: TextBoundMention => m.copy(labels = Seq(lab) ++ m.labels)
+      case m: RelationMention => m.copy(labels = Seq(lab) ++ m.labels)
+      case m: EventMention => m.copy(labels = Seq(lab) ++ m.labels)
+      case _ => ??? // not done for cross-sentence
+    }
+  }
 }


### PR DESCRIPTION
- this was done from master, so fyi when it comes to merge ordering (I can fix conflicts too)
- there is likely another way to do this, but this is what I came up with, please tweak as desired
- to activate this "flag" set `EidosSystem.keepStatefulConcepts = true` in the config

![Screen Shot 2019-04-01 at 4 53 21 AM](https://user-images.githubusercontent.com/5384073/55325633-83591300-543a-11e9-819a-713748c57205.png)
