### PR TITLE
Refactor actions

### DIFF
--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -6,7 +6,7 @@ EidosSystem {
         stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
       transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
-    timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf
+    timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
           useTimeNorm = false
            useGeoNorm = true
  keepStatefulConcepts = true

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -3,6 +3,8 @@ EidosSystem {
              language = english
       masterRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/master.yml
          taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
+        stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
+      transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf
           useTimeNorm = false

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -7,6 +7,8 @@ EidosSystem {
         wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/glove.840B.300d.txt
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
+        stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
+      transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
              cacheDir = ./cache/${EidosSystem.language}
                useW2V = false
           useTimeNorm = false

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/reverse_direction_causal.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/reverse_direction_causal.yml
@@ -12,7 +12,7 @@ rules:
     pattern: |
       trigger = [word=/(?i)^(${ trigger })/] (in|to|into)
       cause: Entity  = nsubj /^nmod_/?
-      effect: Entity = (nmod_in | nmod_to){1,2} | ccomp (nsubj | dobj)?
+      effect: Entity = (nmod_in | nmod_to){1,2} (amod | compound)? | ccomp (nsubj | dobj)?
 
   - name: reverse_causal-noun-2
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
@@ -1,7 +1,7 @@
 increase_triggers: "acceler|aid|augment|boost|compound|doubl|deep|elev|enhanc|exacerbat|exorbitant|favorable|height|improv|increas|intens|prolong|promot|rais|reactivat|restor|sav(e|ed|es|ing)$|spike|spread|stimul|synerg|up-regul|upregul|uptick|widen"
 noncausal_increase_triggers: "above|above-average|better|good|greater|heav|(highs?$)|highe(r|s)|provid|rise|rising|widespread"
 
-decrease_triggers: "attenu|abolish|abrog|arrest|block|collaps|constrain|(cuts?$)|cutting|deactiv|decimat|decreas|degrad|deplet|depreciat|depress|destabili|deregul|deteriorat|diminish|disrupt|down-reg|downreg|drop|dysregul|elimin|^ends?$|eras|erod|exhaust|impair|imped|inhibit|limit|less|lower|negat|nullifi|prevent|reduc|reliev|repress|restrict|revers|sequester|short|shrink|shrunk|slow|starv|suppress|supress|undermin|worse"
+decrease_triggers: "attenu|abolish|abrog|arrest|block|collaps|constrain|(cuts?$)|cutting|deactiv|decimat|decreas|degrad|deplet|depreciat|depress|destabili|deregul|deteriorat|diminish|disrupt|down-reg|downreg|drop|dysregul|elimin|^ends?$|eras|erod|exhaust|impair|imped|inhibit|hamper|limit|less|lower|negat|nullifi|prevent|reduc|reliev|repress|restrict|revers|sequester|short|shrink|shrunk|slow|starv|suppress|supress|undermin|worse"
 noncausal_decrease_triggers: "absence|below-average|declin|defici|discontinu|downturn|(fall$)|fail|(fell$)|inactiv|inadequate|knockdown|lack|loss|(lows?$)|plummet|poor|scarce|scarcity|shortage|shutdown"
 #advers|perturb|resist|
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,6 +3,8 @@ EidosSystem {
              language = english
       masterRulesPath = /org/clulab/wm/eidos/english/grammars/master.yml
          taxonomyPath = /org/clulab/wm/eidos/english/grammars/taxonomy.yml
+        stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt
+      transparentPath = /org/clulab/wm/eidos/english/filtering/transparent.txt
           hedgingPath = /org/clulab/wm/eidos/english/confidence/hedging.txt
     timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
           useLexicons = true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,6 +15,12 @@ EidosSystem {
           useTimeNorm = false
            useGeoNorm = false
              useCache = false
+             useCoref = true
+            corefType = "causalBasic"
+         useExpansion = true
+        // Filtering
+        stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt
+      transparentPath = /org/clulab/wm/eidos/english/filtering/transparent.txt
 }
 
 apps {
@@ -57,10 +63,6 @@ entityFinder {
   maxHops = 15
 }
 
-filtering {
-  stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt
-  transparentPath = /org/clulab/wm/eidos/english/filtering/transparent.txt
-}
 
 geoparser {
   geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -60,11 +60,6 @@ entityFinder {
   maxHops = 15
 }
 
-filtering {
-  stopWordsPath = /org/clulab/wm/eidos/english/filtering/stops.txt
-  transparentPath = /org/clulab/wm/eidos/english/filtering/transparent.txt
-}
-
 geoparser {
   geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
   geoWord2IdxPath = /org/clulab/wm/eidos/english/context/word2idx_file.txt

--- a/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
@@ -1,21 +1,17 @@
 package org.clulab.wm.eidos
 
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
 import org.clulab.odin._
-import org.clulab.odin.impl.Taxonomy
-import org.clulab.processors.{Document, Sentence}
 import org.clulab.wm.eidos.attachments._
-import org.clulab.wm.eidos.utils.{DisplayUtils, FileUtils, MentionUtils}
+import org.clulab.wm.eidos.utils.MentionUtils
 import org.clulab.struct.Interval
-import org.yaml.snakeyaml.Yaml
-import org.yaml.snakeyaml.constructor.Constructor
-
 import utils.DisplayUtils.{displayMention, shortDisplay}
-import org.clulab.wm.eidos.actions.ExpansionHandler
+import org.clulab.wm.eidos.actions.{CorefHandler, ExpansionHandler}
 import org.clulab.wm.eidos.context.GeoPhraseID
 import org.clulab.wm.eidos.document.EidosDocument
 import org.clulab.wm.eidos.document.TimeInterval
-import org.clulab.wm.eidos.entities.{EntityConstraints, EntityHelper}
 
 import scala.collection.mutable.{ArrayBuffer, Set => MutableSet}
 
@@ -24,20 +20,18 @@ import scala.collection.mutable.{ArrayBuffer, Set => MutableSet}
 
 //TODO: need to add polarity flipping
 
-class EidosActions(val taxonomy: Taxonomy, val expansionHandler: ExpansionHandler) extends Actions with LazyLogging {
+class EidosActions(val expansionHandler: Option[ExpansionHandler], val coref: Option[CorefHandler]) extends Actions with LazyLogging {
 
   /*
       Global Action -- performed after each round in Odin
   */
   def globalAction(mentions: Seq[Mention], state: State): Seq[Mention] = {
-    // expand arguments
-    val (expandable, textBounds) = mentions.partition(m => EidosSystem.CAG_EDGES.contains(m.label))
-    val expanded = expansionHandler.expandArguments(expandable, state)
+    // Expand mentions, if enabled
+    val expanded = expansionHandler.map(_.expand(mentions, state)).getOrElse(mentions)
     val mostComplete = keepMostCompleteEvents(expanded, state.updated(expanded))
-    val result = mostComplete ++ textBounds
 
     // Merge attachments
-    val merged = mergeAttachments(result, state.updated(result))
+    val merged = mergeAttachments(mostComplete, state.updated(mostComplete))
 
     // If the cause of an event is itself another event, replace it with the nested event's effect
     // collect all effects from causal events
@@ -53,76 +47,16 @@ class EidosActions(val taxonomy: Taxonomy, val expansionHandler: ExpansionHandle
     // In Kenya , the shortened length of the main growing season , due in part to a delayed onset of seasonal rainfall , coupled with long dry spells and below-average rainfall is resulting in below-average production prospects in large parts of the eastern , central , and southern Rift Valley .
     val modifiedMentions = assemble2 ++ nonCausal
 
-    // Basic coreference
-    val afterResolving = basicDeterminerCoref(modifiedMentions, state)
+    // Basic coreference, if enabled
+    val afterResolving = coref.map(_.resolveCoref(modifiedMentions, state)).getOrElse(modifiedMentions)
 
     // I know I'm an unnecessary line of code, but I am useful for debugging and there are a couple of things left to debug...
     afterResolving
   }
 
-  def basicDeterminerCoref(mentions: Seq[Mention], state: State): Seq[Mention] = {
-    val (eventMentions, otherMentions) = mentions.partition(_.isInstanceOf[EventMention])
 
-    if (eventMentions.isEmpty) mentions
-    else {
-      val orderedBySentence = eventMentions.groupBy(_.sentence)
-      val numSentences = eventMentions.head.document.sentences.length
 
-      if (orderedBySentence.isEmpty) mentions
-      else {
-        val resolvedMentions = new ArrayBuffer[Mention]
 
-        for (i <- 1 until numSentences) {
-          for (mention <- orderedBySentence.getOrElse(i, Seq.empty[Mention])) {
-
-            // If there is an event with "this/that" as cause...
-            if (EidosActions.existsDeterminerCause(mention)) {
-
-              // Get Causal mentions from the previous sentence (if any)
-              val prevSentenceCausal = getPreviousSentenceCausal(orderedBySentence, i)
-              if (prevSentenceCausal.nonEmpty) {
-
-                // If there was also a causal event in the previous sentence
-                val lastOccurring = prevSentenceCausal.sortBy(-_.tokenInterval.end).head
-                // antecedant
-                val prevEffects = lastOccurring.arguments("effect")
-                // reference
-                val currCauses = mention.asInstanceOf[EventMention].arguments("cause")
-                if (prevEffects.nonEmpty && currCauses.nonEmpty) {
-                  // todo: cover if there is more than one effect?
-                  val antecedent = prevEffects.head
-                  val anaphor = currCauses.head
-                  // Make a new CrossSentence mention using the previous effect as the anchor
-                  // Note: Overly simplistic, this is a first pass
-                  // todo: expand approach
-                  val corefMention = new CrossSentenceMention(
-                    labels = taxonomy.hypernymsFor(EidosSystem.COREF_LABEL),
-                    anchor = antecedent,
-                    neighbor = anaphor,
-                    arguments = Map[String, Seq[Mention]]((EidosActions.ANTECEDENT, Seq(antecedent)), (EidosActions.ANAPHOR, Seq(anaphor))),
-                    document = mention.document,
-                    keep = true,
-                    foundBy = s"BasicCorefAction_ant:${lastOccurring.foundBy}_ana:${mention.foundBy}",
-                    attachments = Set.empty[Attachment]
-                  )
-                  resolvedMentions.append(corefMention)
-
-                } else throw new RuntimeException(s"Previous or current Causal mention doesn't have effects " +
-                  s"\tsent1: ${lastOccurring.sentenceObj.getSentenceText}\n" +
-                  s"\tsent2 ${mention.sentenceObj.getSentenceText}")
-              }
-            }
-          }
-        }
-        mentions ++ resolvedMentions
-      }
-    }
-  }
-
-  def getPreviousSentenceCausal(orderedBySentence: Map[Int, Seq[Mention]], i: Int): Seq[Mention] = {
-    val prevSentenceMentions = orderedBySentence.getOrElse(i - 1, Seq.empty[Mention])
-    prevSentenceMentions.filter(_ matches EidosSystem.CAUSAL_LABEL)
-  }
 
   def createEventChain(causal: Seq[Mention], arg1: String, arg2: String): Seq[Mention] = {
     val arg1Mentions = State(causal.flatMap(_.arguments.getOrElse(arg1, Nil)))
@@ -168,10 +102,6 @@ class EidosActions(val taxonomy: Taxonomy, val expansionHandler: ExpansionHandle
     newBest
   }
 
-  /**
-    * @author Gus Hahn-Powell
-    *         Copies the label of the lowest overlapping entity in the taxonomy
-    */
   def customAttachmentFilter(mentions: Seq[Mention]): Seq[Mention] = {
 
     // --- To distinguish between :
@@ -527,22 +457,17 @@ object EidosActions extends Actions {
   val ANTECEDENT: String = "antecedent"
   val ANAPHOR: String = "anaphor"
 
-  def apply(taxonomyPath: String, expansionHandler: ExpansionHandler) =
-      new EidosActions(readTaxonomy(taxonomyPath), expansionHandler)
+  def fromConfig(config: Config): EidosActions = {
+    val useCoref: Boolean = config[Boolean]("useCoref")
+    val corefHandler = if (useCoref) Some(CorefHandler.fromConfig(config)) else None
 
-  private def readTaxonomy(path: String): Taxonomy = {
-    val input = FileUtils.getTextFromResource(path)
-    val yaml = new Yaml(new Constructor(classOf[java.util.Collection[Any]]))
-    val data = yaml.load(input).asInstanceOf[java.util.Collection[Any]]
-    Taxonomy(data)
+    val useExpansion: Boolean = config[Boolean]("useExpansion")
+    val expansionHandler = if (useExpansion) Some(ExpansionHandler.fromConfig(config)) else None
+
+    new EidosActions(expansionHandler, corefHandler)
   }
 
-  def existsDeterminerCause(mention: Mention): Boolean = {
-    startsWithCorefDeterminer(mention.arguments("cause").head)
-  }
 
-  def startsWithCorefDeterminer(m: Mention): Boolean = {
-    val corefDeterminers = COREF_DETERMINERS
-    corefDeterminers.exists(det => m.text.toLowerCase.startsWith(det))
-  }
+
+
 }

--- a/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
@@ -28,14 +28,14 @@ class EidosActions(val expansionHandler: Option[ExpansionHandler], val coref: Op
   def globalAction(mentions: Seq[Mention], state: State): Seq[Mention] = {
     // Expand mentions, if enabled
     val expanded = expansionHandler.map(_.expand(mentions, state)).getOrElse(mentions)
-    val mostComplete = keepMostCompleteEvents(expanded, state.updated(expanded))
-
     // Merge attachments
-    val merged = mergeAttachments(mostComplete, state.updated(mostComplete))
+    val merged = mergeAttachments(expanded, state.updated(expanded))
+    // Keep only the most complete version of any given Mention
+    val mostComplete = keepMostCompleteEvents(merged, state.updated(merged))
 
     // If the cause of an event is itself another event, replace it with the nested event's effect
     // collect all effects from causal events
-    val (causal, nonCausal) = merged.partition(m => EidosSystem.CAG_EDGES.contains(m.label))
+    val (causal, nonCausal) = mostComplete.partition(m => EidosSystem.CAG_EDGES.contains(m.label))
 
     val assemble1 = createEventChain(causal, "effect", "cause")
     // FIXME please

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -51,7 +51,7 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
     )
   }
 
-  val stopwordManager = StopwordManager.fromConfig(config[Config]("filtering"))
+  val stopwordManager = StopwordManager.fromConfig(config)
   val canonicalizer = new Canonicalizer(stopwordManager)
   val ontologyHandler = new OntologyHandler(proc, wordToVec, canonicalizer)
 
@@ -108,7 +108,7 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
       // Odin rules and actions:
       // Reread these values from their files/resources each time based on paths in the config file.
       val masterRules = FileUtils.getTextFromResource(masterRulesPath)
-      val actions = EidosActions(taxonomyPath, expansionHandler)
+      val actions = EidosActions.fromConfig(config)
 
       // Entity Finders can be used to preload entities into the odin state, their use is optional.
       val entityFinder = if (useEntityFinder) {

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -51,7 +51,7 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
     )
   }
 
-  val stopwordManager = StopwordManager.fromConfig(config)
+  val stopwordManager = StopwordManager.fromConfig(eidosConf)
   val canonicalizer = new Canonicalizer(stopwordManager)
   val ontologyHandler = new OntologyHandler(proc, wordToVec, canonicalizer)
 
@@ -108,7 +108,7 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
       // Odin rules and actions:
       // Reread these values from their files/resources each time based on paths in the config file.
       val masterRules = FileUtils.getTextFromResource(masterRulesPath)
-      val actions = EidosActions.fromConfig(config)
+      val actions = EidosActions.fromConfig(eidosConf)
 
       // Entity Finders can be used to preload entities into the odin state, their use is optional.
       val entityFinder = if (useEntityFinder) {

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -39,7 +39,7 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
   // Prunes sentences form the Documents to reduce noise/allow reasonable processing time
   val documentFilter = FilterByLength(proc, cutoff = 150)
   val debug = true // Allow external control with var if needed
-  val stopwordManager: StopwordManager = StopwordManager.fromConfig(config[Config]("filtering"))
+  val stopwordManager: StopwordManager = StopwordManager.fromConfig(eidosConf)
   val ontologyHandler: OntologyHandler = OntologyHandler.load(config[Config]("ontologies"), proc, stopwordManager)
 
   /**

--- a/src/main/scala/org/clulab/wm/eidos/actions/CorefHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/actions/CorefHandler.scala
@@ -1,0 +1,129 @@
+package org.clulab.wm.eidos.actions
+
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.Config
+import org.clulab.odin._
+import org.clulab.odin.impl.Taxonomy
+import org.clulab.wm.eidos.{EidosActions, EidosSystem}
+import org.clulab.wm.eidos.EidosActions.{COREF_DETERMINERS}
+import org.clulab.wm.eidos.utils.FileUtils
+import org.yaml.snakeyaml.Yaml
+import org.yaml.snakeyaml.constructor.Constructor
+
+import scala.collection.mutable.ArrayBuffer
+
+trait CorefHandler {
+  def resolveCoref(mentions: Seq[Mention], state: State): Seq[Mention]
+  def hasCorefToResolve(m: Mention): Boolean
+}
+object CorefHandler {
+  def fromConfig(config: Config): CorefHandler = {
+    config[String]("corefType") match {
+      case "causalBasic" => CausalBasicCorefHandler.fromConfig(config)
+      case _ => ???
+    }
+  }
+
+  def startsWithCorefDeterminer(m: Mention): Boolean = {
+    val corefDeterminers = COREF_DETERMINERS
+    corefDeterminers.exists(det => m.text.toLowerCase.startsWith(det))
+  }
+}
+
+class CausalBasicCorefHandler(taxonomy: Taxonomy) extends CorefHandler {
+
+  def resolveCoref(mentions: Seq[Mention], state: State): Seq[Mention] = {
+    val (eventMentions, otherMentions) = mentions.partition(_.isInstanceOf[EventMention])
+
+    if (eventMentions.isEmpty) mentions
+    else {
+      val orderedBySentence = eventMentions.groupBy(_.sentence)
+      val numSentences = eventMentions.head.document.sentences.length
+
+      if (orderedBySentence.isEmpty) mentions
+      else {
+        val resolvedMentions = new ArrayBuffer[Mention]
+
+        for (i <- 1 until numSentences) {
+          for (mention <- orderedBySentence.getOrElse(i, Seq.empty[Mention])) {
+
+            // If there is an event with "this/that" as cause...
+            if (existsDeterminerCause(mention)) {
+
+              // Get Causal mentions from the previous sentence (if any)
+              val prevSentenceCausal = getPreviousSentenceCausal(orderedBySentence, i)
+              if (prevSentenceCausal.nonEmpty) {
+
+                // If there was also a causal event in the previous sentence
+                val lastOccurring = prevSentenceCausal.sortBy(-_.tokenInterval.end).head
+                // antecedent
+                val prevEffects = lastOccurring.arguments("effect")
+                // reference
+                val currCauses = mention.asInstanceOf[EventMention].arguments("cause")
+                if (prevEffects.nonEmpty && currCauses.nonEmpty) {
+                  // todo: cover if there is more than one effect?
+                  val antecedent = prevEffects.head
+                  val anaphor = currCauses.head
+                  // Make a new CrossSentence mention using the previous effect as the anchor
+                  // Note: Overly simplistic, this is a first pass
+                  // todo: expand approach
+                  val corefMention = new CrossSentenceMention(
+                    labels = taxonomy.hypernymsFor(EidosSystem.COREF_LABEL),
+                    anchor = antecedent,
+                    neighbor = anaphor,
+                    arguments = Map[String, Seq[Mention]]((EidosActions.ANTECEDENT, Seq(antecedent)), (EidosActions.ANAPHOR, Seq(anaphor))),
+                    document = mention.document,
+                    keep = true,
+                    foundBy = s"BasicCorefAction_ant:${lastOccurring.foundBy}_ana:${mention.foundBy}",
+                    attachments = Set.empty[Attachment]
+                  )
+                  resolvedMentions.append(corefMention)
+
+                } else throw new RuntimeException(s"Previous or current Causal mention doesn't have effects " +
+                  s"\tsent1: ${lastOccurring.sentenceObj.getSentenceText}\n" +
+                  s"\tsent2 ${mention.sentenceObj.getSentenceText}")
+              }
+            }
+          }
+        }
+        mentions ++ resolvedMentions
+      }
+    }
+  }
+
+  def getPreviousSentenceCausal(orderedBySentence: Map[Int, Seq[Mention]], i: Int): Seq[Mention] = {
+    val prevSentenceMentions = orderedBySentence.getOrElse(i - 1, Seq.empty[Mention])
+    prevSentenceMentions.filter(_ matches EidosSystem.CAUSAL_LABEL)
+  }
+
+  def existsDeterminerCause(mention: Mention): Boolean = {
+    CorefHandler.startsWithCorefDeterminer(mention.arguments("cause").head)
+  }
+
+
+  def hasCorefToResolve(m: Mention): Boolean = {
+    m match {
+      case tb: TextBoundMention => CorefHandler.startsWithCorefDeterminer(tb)
+      case rm: RelationMention => existsDeterminerCause(rm)
+      case em: EventMention => existsDeterminerCause(em)
+      case _ => false
+    }
+  }
+}
+
+object CausalBasicCorefHandler {
+  def fromConfig(config: Config): CausalBasicCorefHandler = {
+    val taxonomyPath = config[String]("taxonomyPath")
+    val taxonomy = readTaxonomy(taxonomyPath)
+    new CausalBasicCorefHandler(taxonomy)
+  }
+
+  def readTaxonomy(path: String): Taxonomy = {
+    val input = FileUtils.getTextFromResource(path)
+    val yaml = new Yaml(new Constructor(classOf[java.util.Collection[Any]]))
+    val data = yaml.load(input).asInstanceOf[java.util.Collection[Any]]
+    Taxonomy(data)
+  }
+
+
+}

--- a/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/entities/EidosEntityFinder.scala
@@ -7,6 +7,7 @@ import org.clulab.odin.{ExtractorEngine, Mention, State, TextBoundMention}
 import org.clulab.processors.Document
 import org.clulab.struct.Interval
 import org.clulab.wm.eidos.EidosActions
+import org.clulab.wm.eidos.actions.CorefHandler
 import org.clulab.wm.eidos.groundings.EidosOntologyGrounder
 import org.clulab.wm.eidos.utils.{FileUtils, StopwordManager}
 
@@ -88,7 +89,7 @@ class EidosEntityFinder(entityEngine: ExtractorEngine, avoidEngine: ExtractorEng
     // it's needed as a trigger downstream), it's valid (ex: 'economic declines')
     (entity.tags.get.last.startsWith("JJ") || entity.tags.get.last.startsWith("ADJ")) && nextTagNN(entity) ||
     // Otherwise, is it a determiner that may need to be resolved downstream?
-    EidosActions.startsWithCorefDeterminer(entity)
+    CorefHandler.startsWithCorefDeterminer(entity) // fixme
     // Otherwise, it's not valid
   }
 

--- a/src/test/resources/englishTest.conf
+++ b/src/test/resources/englishTest.conf
@@ -2,20 +2,14 @@ EidosSystem {
 // Override the default values here
            language = english
     masterRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/master.yml
-     quantifierPath =  org/clulab/wm/eidos/${EidosSystem.language}/lexicons/Quantifier.tsv
-    entityRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/entities/grammar/entities.yml
-     avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
        taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
       wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
       stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
     transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
         hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
-     unOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_ontology.yml
-    wdiOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/wdi_ontology.yml
-    faoOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/fao_variable_ontology.yml
-   meshOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mesh_ontology.yml
+      stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
+    transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
   timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
-   geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
            cacheDir = ./cache/${EidosSystem.language}
              useW2V = false
         useTimeNorm = false
@@ -26,8 +20,47 @@ EidosSystem {
        useExpansion = true
 }
 
-adjectiveGrounder {
-  domainParamKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/domain_parameters.kb
-   quantifierKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/gradable_adj_fullmodel.kb
+ontologies {
+  ontologies = ["un", "wdi", "fao", "mitre12", "who", "interventions"] // , "icasa", "mesh"]
+  cacheDir = ${EidosSystem.cacheDir}
+  useCache = ${EidosSystem.useCache}
+  // Paths to the ontologies
+  // Primary
+  un            = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_ontology.yml
+  // Plugins
+  interventions = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/interventions.yml
+  // Indicators
+  wdi           = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/wdi_ontology.yml
+  fao           = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/fao_variable_ontology.yml
+  mitre12       = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mitre12_indicators.yml
+  who           = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/who_ontology.yml
+  // Variables
+  icasa         = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/icasa.yml
+  // Other
+  mesh          = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mesh_ontology.yml
 }
 
+
+entityFinder {
+  finderType = "eidos"
+  entityRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/entities/grammar/entities.yml
+  avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
+  maxHops = 15
+}
+
+
+geoparser {
+  geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
+  geoWord2IdxPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
+  geoLoc2IdPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/geo_dict_with_population_SOUTH_SUDAN.txt
+}
+
+lexiconNER {
+  quantifierPath =  org/clulab/wm/eidos/${EidosSystem.language}/lexicons/Quantifier.tsv
+  lexicons = [${lexiconNER.quantifierPath}]
+}
+
+adjectiveGrounder {
+  domainParamKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/domain_parameters.kb
+  quantifierKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/gradable_adj_fullmodel.kb
+}

--- a/src/test/resources/englishTest.conf
+++ b/src/test/resources/englishTest.conf
@@ -21,6 +21,9 @@ EidosSystem {
         useTimeNorm = false
          useGeoNorm = true
            useCache = false
+           useCoref = true
+          corefType = "causalBasic"
+       useExpansion = true
 }
 
 adjectiveGrounder {

--- a/src/test/resources/englishTest.conf
+++ b/src/test/resources/englishTest.conf
@@ -57,7 +57,8 @@ geoparser {
 
 lexiconNER {
   quantifierPath =  org/clulab/wm/eidos/${EidosSystem.language}/lexicons/Quantifier.tsv
-  lexicons = [${lexiconNER.quantifierPath}]
+  propertiesPath =  org/clulab/wm/eidos/english/lexicons/Property.tsv
+  lexicons = [${lexiconNER.quantifierPath}, ${lexiconNER.propertiesPath}]
 }
 
 adjectiveGrounder {

--- a/src/test/resources/portugueseTest.conf
+++ b/src/test/resources/portugueseTest.conf
@@ -19,6 +19,9 @@ EidosSystem {
              useW2V = false
         useTimeNorm = false
            useCache = false
+           useCoref = true
+          corefType = "causalBasic"
+       useExpansion = true
 }
 
 adjectiveGrounder {

--- a/src/test/resources/portugueseTest.conf
+++ b/src/test/resources/portugueseTest.conf
@@ -2,18 +2,11 @@ EidosSystem {
 // Override the default values here
            language = portuguese
     masterRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/master.yml
-     quantifierPath =  org/clulab/wm/eidos/${EidosSystem.language}/lexicons/Quantifier.tsv
-    entityRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/entities/grammar/entities.yml
-     avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
        taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
       wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
       stopWordsPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/stops.txt
     transparentPath = /org/clulab/wm/eidos/${EidosSystem.language}/filtering/transparent.txt
         hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
-     unOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_ontology.yml
-    wdiOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/wdi_ontology.yml
-    faoOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/fao_variable_ontology.yml
-   meshOntologyPath = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/mesh_ontology.yml
   timeNormModelPath = /org/clulab/wm/eidos/models/timenorm_model.hdf5
            cacheDir = ./cache/${EidosSystem.language}
              useW2V = false
@@ -24,7 +17,33 @@ EidosSystem {
        useExpansion = true
 }
 
+ontologies {
+  ontologies = ["un", "wdi", "fao", "props", "mitre12", "who", "interventions"] // , "icasa", "mesh"]
+  cacheDir = ${EidosSystem.cacheDir}
+  useCache = ${EidosSystem.useCache}
+}
+
+
+entityFinder {
+  finderType = "eidos"
+  entityRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/entities/grammar/entities.yml
+  avoidRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/avoidLocal.yml
+  maxHops = 15
+}
+
+
+geoparser {
+  geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.dl4j.zip
+  geoWord2IdxPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
+  geoLoc2IdPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/geo_dict_with_population_SOUTH_SUDAN.txt
+}
+
+lexiconNER {
+  quantifierPath =  org/clulab/wm/eidos/${EidosSystem.language}/lexicons/Quantifier.tsv
+  lexicons = [${lexiconNER.quantifierPath}]
+}
+
 adjectiveGrounder {
   domainParamKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/domain_parameters.kb
-   quantifierKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/gradable_adj_fullmodel.kb
+  quantifierKBPath = /org/clulab/wm/eidos/${EidosSystem.language}/quantifierKB/gradable_adj_fullmodel.kb
 }

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEidosActions.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEidosActions.scala
@@ -145,7 +145,7 @@ class TestEidosActions extends ExtractionTest {
 //  }
 
   // fixme: do we want a default here for "english" ???
-  class TestEidosActions extends EidosActions(new Taxonomy(Map.empty), ExpansionHandler("english")) {
+  class TestEidosActions extends EidosActions(Some(ExpansionHandler("english")), None) {
     // Relax some protected functions for testing
 
     override def filterSubstringTriggers(attachments: Seq[TriggeredAttachment]): Seq[TriggeredAttachment] =

--- a/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc3.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc3.scala
@@ -601,10 +601,10 @@ class TestDoc3 extends EnglishTest {
     // Nodes here
     val rainfall = NodeSpec("seasonal rains", Inc("intensification"))
     val rainfallDeficit = NodeSpec("rainfall", Dec("deficits"), Dec("ease"))
-    val rainfall2 = NodeSpec("rains", Quant("heavy"))
-    val maize = NodeSpec("maize harvesting", Dec("hamper"))
+    val rainfall2 = NodeSpec("expected heavy rains", Quant("heavy"), Inc("heavy"))
+    val maize = NodeSpec("ongoing maize harvesting", Quant("ongoing"), Dec("hamper"))
     val drying = NodeSpec("drying activities", Dec("hamper"))
-    val losses = NodeSpec("post-harvest losses")
+    val losses = NodeSpec("post-harvest losses", Dec("losses"))
     val dry = NodeSpec("dry days", Quant("significant")) // todo: this is a part of the hyper edge, should handle one day
 
     behavior of "TestDoc3 Paragraph 15"
@@ -613,13 +613,13 @@ class TestDoc3 extends EnglishTest {
     failingTest should "have correct edges 1" taggedAs(Somebody) in {
       tester.test(EdgeSpec(rainfall, Causal, rainfallDeficit)) should be (successful) // Test edges connecting them
     }
-    failingTest should "have correct edges 2" taggedAs(Somebody) in {
+    passingTest should "have correct edges 2" taggedAs(Somebody) in {
       tester.test(EdgeSpec(rainfall2, Causal, maize)) should be (successful) // Test edges connecting them
     }
     failingTest should "have correct edges 3" taggedAs(Somebody) in {
       tester.test(EdgeSpec(rainfall2, Causal, drying)) should be (successful) // Test edges connecting them
     }
-    failingTest should "have correct edges 4" taggedAs(Somebody) in {
+    passingTest should "have correct edges 4" taggedAs(Somebody) in {
       tester.test(EdgeSpec(rainfall2, Causal, losses)) should be (successful) // Test edges connecting them
     }
     passingTest should "have correct singleton node 2" taggedAs(Somebody) in {


### PR DESCRIPTION
This is a start to refactoring the EidosActions (aimed at making eidos more modular and so domain and task independent). This is by no means "the solution" but just (I think) a step in the right direction.

**NOTE 1**: I think this _does_ allow for using eidos to extract *non-causal* events by disabling the coref (I think that corefHandler is the only place where explicit refs to "cause" and "effect" args are made)

**NOTE 2**: made from master, so after next round of PRs may need conflicts resolved

Highlights:
 - `fromConfig` constructor for EidosActions that makes expansion and coref not only optional but swappable (note the `useCoref` and `useExpansion` keys in config)
 - CorefHandler which should make coref approaches swappable (note the `corefType` key in config)
 - Slight changes to config again (sorry!) -- the placement of the `stopWordsPath` and `transparentPath` in `EidosSystem` block of config
- I _may_ have added some grammar tweaks to make 2 more tests pass, even though I completely agree that this was the wrong place to do it (i.e., I should have made it a separate PR...) :)