### PR TITLE
Account for leafless ontology branches

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/TreeDomainOntology.scala
@@ -213,8 +213,14 @@ object TreeDomainOntology {
 
         if (key == TreeDomainOntology.FIELD)
           Seq(parseOntology(parent, map))
-        else
-          parseOntology(new OntologyBranchNode(key, parent), map(key).asScala.toSeq)
+        else {
+          // This is to account for leafless branches.
+          val yamlNodesOpt = Option(map(key).asScala)
+          if (yamlNodesOpt.nonEmpty) // foreach does not work well here.
+            parseOntology(new OntologyBranchNode(key, parent), yamlNodesOpt.get.toSeq)
+          else
+            Seq.empty
+        }
       }
     }
   }


### PR DESCRIPTION
Some Eidos taxonomies coming from Linnaeus can have empty branches, especially when a backward facing edge has been pruned.  This change prevents Eidos from crashing when such a taxonomy is used.