### PR TITLE
key not found: cause error after adding migration event

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/actions/CorefHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/actions/CorefHandler.scala
@@ -97,7 +97,12 @@ class CausalBasicCorefHandler(taxonomy: Taxonomy) extends CorefHandler {
   }
 
   def existsDeterminerCause(mention: Mention): Boolean = {
-    CorefHandler.startsWithCorefDeterminer(mention.arguments("cause").head)
+    if (isCauseEvent(mention)) CorefHandler.startsWithCorefDeterminer(mention.arguments("cause").head)
+    else false
+  }
+
+  def isCauseEvent(mention: Mention): Boolean = {
+    mention.arguments.get("cause").nonEmpty
   }
 
 


### PR DESCRIPTION
I tried to create a temporary solution for the `key not found: cause` error that happens in the branches with migration events (CorefHandler can only work with the cause events and broke when a different type of event---migration event---was introduced, I think). Locally, all tests pass, but the travis build doesn't pass. Any suggestions?

This was the error (and also what caused the errors @zupon mentioned here https://github.com/clulab/eidos/issues/594#issuecomment-499684549):

```
[info] org.clulab.wm.eidos.system.TestParallel *** ABORTED ***
[info]   java.util.NoSuchElementException: key not found: cause
[info]   at scala.collection.immutable.Map$Map1.apply(Map.scala:108)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.existsDeterminerCause(CorefHandler.scala:100)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.$anonfun$resolveCoref$5(CorefHandler.scala:51)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.$anonfun$resolveCoref$5$adapted(CorefHandler.scala:48)
[info]   at scala.collection.immutable.List.foreach(List.scala:389)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.$anonfun$resolveCoref$3(CorefHandler.scala:48)
[info]   at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:156)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.resolveCoref(CorefHandler.scala:47)
[info]   at org.clulab.wm.eidos.EidosActions.$anonfun$globalAction$4(EidosActions.scala:48)
[info]   at scala.Option.map(Option.scala:146)
[info]   ...
[info] org.clulab.wm.eidos.system.TestSerial *** ABORTED ***
[info]   java.util.NoSuchElementException: key not found: cause
[info]   at scala.collection.immutable.Map$Map1.apply(Map.scala:108)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.existsDeterminerCause(CorefHandler.scala:100)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.$anonfun$resolveCoref$5(CorefHandler.scala:51)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.$anonfun$resolveCoref$5$adapted(CorefHandler.scala:48)
[info]   at scala.collection.immutable.List.foreach(List.scala:389)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.$anonfun$resolveCoref$3(CorefHandler.scala:48)
[info]   at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:156)
[info]   at org.clulab.wm.eidos.actions.CausalBasicCorefHandler.resolveCoref(CorefHandler.scala:47)
[info]   at org.clulab.wm.eidos.EidosActions.$anonfun$globalAction$4(EidosActions.scala:48)
[info]   at scala.Option.map(Option.scala:146)
```