### PR TITLE
Install OpenJDK instead of OracleJDK in docker build to avoid oracle …

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -11,16 +11,17 @@ RUN apt-get update && apt-get install -y \
     vim
 
 # Install Java
-RUN add-apt-repository -y ppa:webupd8team/java
-RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
-RUN apt-get update && apt-get install -y \
-    oracle-java8-installer 
-RUN export JAVA_HOME="/usr/lib/jvm/java-8-oracle/"
-RUN export PATH="$JAVA_HOME/bin:$PATH"    
+RUN apt-get -y install software-properties-common
+RUN add-apt-repository -y ppa:openjdk-r/ppa
+RUN apt-get update
+RUN apt-get -y install openjdk-8-jdk
+RUN export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+RUN export PATH="$JAVA_HOME/bin:$PATH"
 
 # Install Scala
 WORKDIR /
 RUN apt-get remove scala-library scala
+RUN apt-get install wget
 RUN wget http://scala-lang.org/files/archive/scala-2.12.7.deb
 RUN dpkg -i scala-2.12.7.deb
 RUN apt-get update && apt-get install scala


### PR DESCRIPTION
### Changes
The consequential change in this PR is that instead of installing the OracleJDK the Docker container will now be installed with an OpenJDK package. This switch is necessitated by a change to Oracle JDK's license on April 16th, 2019 (See https://www.oracle.com/technetwork/java/javase/overview/oracle-jdk-faqs.html) that breaks the previously used webupd8 package (See http://www.webupd8.org/2014/03/how-to-install-oracle-java-8-in-debian.html)

### Testing this PR
After pulling this PR you can try:
```
cd Docker
docker build -f Dockerfile . -t eidos-webservice
```
Building the container will take some time. Once it completes you can try:
```
docker run -id -p 9000:9000 eidos-webservice
```
Then, you should be able to navigate to the web application in your browser at localhost:9000.

### Issue Reference

#611 

