### PR TITLE
turns timenorm into an Eidos finder

### DIFF
--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -4,9 +4,7 @@ EidosSystem {
       masterRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/master.yml
          taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
-        timeRegexPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/timenorm-regexes.txt
-        entityFinders = ["gazetteer", "rulebased", "geonorm"]
-          useTimeNorm = true
+        entityFinders = ["gazetteer", "rulebased", "geonorm", "timenorm"]
  keepStatefulConcepts = true
 }
 
@@ -64,6 +62,10 @@ geonorm {
   geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.pb
    geoWord2IdxPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
      geoLoc2IdPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/geo_dict_with_population_SOUTH_SUDAN.txt
+}
+
+timenorm {
+  timeRegexPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/timenorm-regexes.txt
 }
 
 adjectiveGrounder {

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/master.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/master.yml
@@ -16,7 +16,7 @@ rules:
   - import: org/clulab/wm/eidos/english/grammars/temporalAttachment.yml
     vars:
       rulepriority: "2"
-      action: applyTimeAttachment #Should add quantifier to state of entity
+      action: applyTimeAttachment #Should add time to state of entity
       label: Time
 
   #Step 2: Find other entity-modifying events (e.g. "Increase in rainfall")

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/temporalAttachment.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/temporalAttachment.yml
@@ -8,8 +8,8 @@ rules:
     label: ${ label }
     action: ${ action }
     pattern: |
-      trigger = [norm="B-Time"] [norm="I-Time"]*
-      theme: Entity = </^nmod/ >nmod_in?
+      time: Time
+      entity: Entity = </^nmod/ >nmod_in?
 
 
 
@@ -19,6 +19,6 @@ rules:
     label: ${ label }
     action: ${ action }
     pattern: |
-      trigger = [norm="B-Time"] [norm="I-Time"]*
-      theme: Entity = </^nmod/ >/^nsubj/
+      time: Time
+      entity: Entity = </^nmod/ >/^nsubj/
 

--- a/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
@@ -8,9 +8,6 @@ import org.clulab.wm.eidos.attachments._
 import org.clulab.wm.eidos.utils.MentionUtils
 import org.clulab.struct.Interval
 import org.clulab.wm.eidos.actions.CorefHandler
-import org.clulab.wm.eidos.context.GeoPhraseID
-import org.clulab.wm.eidos.document.EidosDocument
-import org.clulab.wm.eidos.document.TimEx
 import org.clulab.wm.eidos.expansion.Expander
 
 import scala.collection.mutable.{Set => MutableSet}
@@ -324,15 +321,8 @@ class EidosActions(val expansionHandler: Option[Expander], val coref: Option[Cor
   }
 
   def applyTimeAttachment(ms: Seq[Mention], state: State): Seq[Mention] = {
-    for {
-      m <- ms
-      trigger = m.asInstanceOf[EventMention].trigger
-      theme = tieBreaker(m.arguments("theme")).asInstanceOf[TextBoundMention]
-      times = m.document.asInstanceOf[EidosDocument].times
-      time: Option[TimEx] = if (times.isDefined) times.get(m.sentence).find(_.span.start == trigger.startOffset) else None
-    } yield time match {
-      case None => theme
-      case Some(t) => theme.withAttachment(new Time(t))
+    for (m <- ms; entity <- m.arguments("entity"); time <- m.arguments("time")) yield {
+      MentionUtils.withMoreAttachments(entity, time.attachments.toSeq)
     }
   }
 

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -14,7 +14,7 @@ import org.clulab.wm.eidos.groundings._
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils._
 import org.clulab.timenorm.neural.TemporalNeuralParser
-import org.clulab.wm.eidos.context.GeoNormFinder
+import org.clulab.wm.eidos.context.{GeoNormFinder, TimeNormFinder}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
@@ -62,8 +62,6 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
     val negationHandler: NegationHandler,
 
     val multiOntologyGrounder: MultiOntologyGrounding,
-    val timenorm: Option[TemporalNeuralParser],
-    val timeregexs: Option[List[Regex]],
     val expander: Option[Expander],
     val keepStatefulConcepts: Boolean
   )
@@ -97,18 +95,6 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
       val expander = eidosConf.get[Config]("conceptExpander").map(Expander.fromConfig)
       if (keepStatefulConcepts && expander.isEmpty) println("NOTICE: You're keeping stateful Concepts but didn't load an expander.")
 
-      // Temporal Parsing
-      val (timenorm: Option[TemporalNeuralParser], timeregexs: Option[List[Regex]]) = {
-        if (!useTimeNorm) (None, None)
-        else {
-          // Be sure to use fork := true in build.sbt when doing this so that the dll is not loaded twice.
-          val timeNorm = new TemporalNeuralParser()
-          val timeRegexPath: String = eidosConf[String]("timeRegexPath")
-          val regexs = Source.fromInputStream(getClass.getResourceAsStream(timeRegexPath)).getLines.map(_.r).toList
-          (Some(timeNorm), Some(regexs))
-        }
-      }
-
       new LoadableAttributes(
         entityFinders,
         actions,
@@ -116,8 +102,6 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
         hypothesisHandler,
         negationHandler,
         multiOntologyGrounder,  // todo: do we need this and ontologyGrounders?
-        timenorm,
-        timeregexs,
         expander,
         keepStatefulConcepts
       )
@@ -130,7 +114,7 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
   }
 
   def useGeoNorm: Boolean = loadableAttributes.entityFinders.collectFirst{ case f: GeoNormFinder => f }.isDefined
-  def useTimeNorm: Boolean = loadableAttributes.timenorm.isDefined
+  def useTimeNorm: Boolean = loadableAttributes.entityFinders.collectFirst{ case f: TimeNormFinder => f }.isDefined
 
   def reload(): Unit = loadableAttributes = LoadableAttributes()
 

--- a/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosSystem.scala
@@ -141,7 +141,7 @@ class EidosSystem(val config: Config = EidosSystem.defaultConfig) {
   def annotateDoc(document: Document, keepText: Boolean = true, documentCreationTime: Option[String] = None, filename: Option[String]= None): EidosDocument = {
     val doc = EidosDocument(document, keepText)
     // Time and Location
-    doc.parseTime(loadableAttributes.timenorm, loadableAttributes.timeregexs, documentCreationTime)
+    doc.dctString = documentCreationTime
     // Document ID
     doc.id = filename
     doc

--- a/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
@@ -1,0 +1,141 @@
+package org.clulab.wm.eidos.context
+
+import ai.lum.common.ConfigUtils._
+import com.typesafe.config.Config
+import org.clulab.odin.{Mention, State, TextBoundMention}
+import org.clulab.processors.Document
+import org.clulab.struct.Interval
+import org.clulab.timenorm.neural.{TemporalNeuralParser, TimeExpression}
+import org.clulab.wm.eidos.attachments.Time
+import org.clulab.wm.eidos.document.{DCT, EidosDocument, TimEx, TimeStep}
+import org.clulab.wm.eidos.extraction.Finder
+import org.clulab.wm.eidos.utils.Sourcer
+
+import scala.collection.mutable
+import scala.util.matching.Regex
+
+object TimeNormFinder {
+  def fromConfig(config: Config): TimeNormFinder = {
+    val timeRegexPath: String = config[String]("timeRegexPath")
+    val regexes = Sourcer.sourceFromResource(timeRegexPath).getLines.map(_.r).toSeq
+    new TimeNormFinder(new TemporalNeuralParser, regexes)
+  }
+}
+
+class TimeNormFinder(parser: TemporalNeuralParser, timeRegexes: Seq[Regex]) extends Finder {
+
+  private val CONTEXT_WINDOW_SIZE = 20
+  private val BATCH_SIZE = 40
+
+  override def extract(doc: Document, initialState: State): Seq[Mention] = doc match {
+    case eidosDocument: EidosDocument =>
+      val Some(text) = eidosDocument.text
+
+      // TODO: remove EidosDocument.times and just use the Mention objects instead of this
+      // pre-initialize the buffers where each sentence's time expressions will be saved
+      val sentenceBuffers = eidosDocument.sentences.map(_ => mutable.Buffer.empty[TimEx])
+      eidosDocument.times = Some(sentenceBuffers.map(_.toSeq))
+
+      // extract the pieces of each sentence where we should look for times
+      val sentenceContexts = for ((sentence, sentenceIndex) <- eidosDocument.sentences.zipWithIndex) yield {
+        val sentenceStart = sentence.startOffsets.head
+        val sentenceText = text.substring(sentenceStart, sentence.endOffsets.last)
+
+        // find all the places where a regular expression matches
+        val matches = timeRegexes.flatMap(_.findAllMatchIn(sentenceText))
+
+        // add some context around each match
+        val singleIntervals = for (m <- matches) yield {
+
+          // expand to the specified context window size
+          var start = math.max(0, m.start - CONTEXT_WINDOW_SIZE)
+          var end = math.min(sentenceText.length, m.end + CONTEXT_WINDOW_SIZE)
+
+          // do not include context beyond 2 consecutive newline characters
+          val separator = "\n\n"
+          start = sentenceText.slice(start, m.start).lastIndexOf(separator) match {
+            case -1 => start
+            case i => m.start - i
+          }
+          end = sentenceText.slice(m.end, end).indexOf(separator) match {
+            case -1 => end
+            case i => m.end + i
+          }
+
+          // expand to word boundaries
+          start = sentence.startOffsets.map(_ - sentenceStart).iterator.dropWhile(_ < start).next
+          end = sentence.endOffsets.map(_ - sentenceStart).iterator.dropWhile(_ < end).next
+
+          // yield the context interval
+          Interval(start, end)
+        }
+
+        // merge overlapping contexts
+        val mergedIntervals = singleIntervals.sorted.foldLeft(Seq.empty[Interval]) {
+          case (Seq(), context) => Seq(context)
+          case (init :+ last, context) if last.end > context.start => init :+ Interval(last.start, context.end)
+          case (contexts, context) => contexts :+ context
+        }
+
+        // get the text for each context
+        for (interval <- mergedIntervals) yield {
+          ((sentenceIndex, interval.start), sentenceText.substring(interval.start, interval.end))
+        }
+      }
+
+      // TODO: TemporalNeuralParser should take Array arguments, not List arguments, so the .toList here can be removed
+      val (contextLocations: List[(Int, Int)], contextTexts: List[String]) = sentenceContexts.flatten.toList.unzip
+
+      // run the timenorm parser over batches of contexts to find and normalize time expressions
+      val contextTimeExpressions: Seq[List[TimeExpression]] = eidosDocument.dctString match {
+        case Some(dctString) =>
+          val parsed = (dctString :: contextTexts).sliding(BATCH_SIZE, BATCH_SIZE).flatMap(parser.parse).toList
+          eidosDocument.dct = Some(DCT(parser.dct(parsed.head), dctString)) // Note the side effect!
+          parser.intervals(parsed.tail, eidosDocument.dct.map(_.interval))
+        case None =>
+          val parsed = contextTexts.sliding(BATCH_SIZE, BATCH_SIZE).flatMap(parser.parse).toList
+          parser.intervals(parsed)
+      }
+
+      // create mentions for each of the time expressions that were found
+      for {
+        ((sentenceIndex, contextSentenceStart), timeExpressions) <- contextLocations zip contextTimeExpressions
+        timeExpression <- timeExpressions
+      } yield {
+        // reconstruct full-text character offsets from sentence-level character offsets
+        val sentence = eidosDocument.sentences(sentenceIndex)
+        val contextStart = sentence.startOffsets.head + contextSentenceStart
+        val timeTextStart = contextStart + timeExpression.span.start
+        val timeTextEnd = contextStart + timeExpression.span.end
+        val timeTextInterval = Interval(timeTextStart, timeTextEnd)
+        val timeText = text.substring(timeTextStart, timeTextEnd)
+
+        // find the words covered by the time expression (only needed because TextBoundMention requires is)
+        val wordIndices = for {
+          i <- sentence.words.indices
+          if sentence.startOffsets(i) < timeTextEnd && timeTextStart < sentence.endOffsets(i)
+        } yield i
+        val wordInterval = Interval(wordIndices.head, wordIndices.last + 1)
+
+        // construct the attachment with the detailed time information
+        val timeSteps = for (timeInterval <- timeExpression.intervals) yield {
+          TimeStep(Option(timeInterval.start), Option(timeInterval.end), timeInterval.duration)
+        }
+        val attachment = TimEx(timeTextInterval, timeSteps, timeText)
+
+        // add the attachment directly to the document, since that's currently required as well
+        sentenceBuffers(sentenceIndex) += attachment
+
+        // create the Mention for this time expression
+        new TextBoundMention(
+          Seq("Time"),
+          wordInterval,
+          sentenceIndex,
+          eidosDocument,
+          true,
+          getClass.getSimpleName,
+          Set(Time(attachment))
+        )
+      }
+  }
+}

--- a/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
@@ -63,8 +63,9 @@ class TimeNormFinder(parser: TemporalNeuralParser, timeRegexes: Seq[Regex]) exte
           }
 
           // expand to word boundaries
-          start = sentence.startOffsets.map(_ - sentenceStart).iterator.dropWhile(_ < start).next
-          end = sentence.endOffsets.map(_ - sentenceStart).iterator.dropWhile(_ < end).next
+          def nextOrElse(iterator: Iterator[Int], x: =>Int): Int = if (iterator.hasNext) iterator.next else x
+          start = nextOrElse(sentence.startOffsets.reverseIterator.map(_ - sentenceStart).dropWhile(_ > start), 0)
+          end = nextOrElse(sentence.endOffsets.iterator.map(_ - sentenceStart).dropWhile(_ < end), sentenceText.length)
 
           // yield the context interval
           Interval(start, end)

--- a/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
@@ -55,7 +55,7 @@ class TimeNormFinder(parser: TemporalNeuralParser, timeRegexes: Seq[Regex]) exte
           val separator = "\n\n"
           start = sentenceText.slice(start, m.start).lastIndexOf(separator) match {
             case -1 => start
-            case i => m.start - i
+            case i => start + i + separator.length
           }
           end = sentenceText.slice(m.end, end).indexOf(separator) match {
             case -1 => end

--- a/src/main/scala/org/clulab/wm/eidos/document/EidosDocument.scala
+++ b/src/main/scala/org/clulab/wm/eidos/document/EidosDocument.scala
@@ -2,15 +2,12 @@ package org.clulab.wm.eidos.document
 
 import java.time.LocalDateTime
 
-import scala.util.matching.Regex
 import org.clulab.processors.Document
 import org.clulab.processors.Sentence
 import org.clulab.processors.corenlp.CoreNLPDocument
-import org.clulab.timenorm.neural.{TemporalNeuralParser, TimeInterval}
+import org.clulab.timenorm.neural.TimeInterval
 import org.clulab.timenorm.formal.{Interval => TimExInterval}
 import org.clulab.struct.{Interval => TextInterval}
-import org.clulab.timenorm.neural.TimeExpression
-import org.clulab.wm.eidos.context.GeoNorm
 import org.clulab.wm.eidos.context.GeoPhraseID
 
 class EidosDocument(sentences: Array[Sentence], text: Option[String]) extends CoreNLPDocument(sentences) {
@@ -19,163 +16,10 @@ class EidosDocument(sentences: Array[Sentence], text: Option[String]) extends Co
   var times: Option[Array[Seq[TimEx]]] = None
   var geolocs: Option[Array[Seq[GeoPhraseID]]] = None
   var dct: Option[DCT] = None
-
-  protected def mkNearContext(sentenceText: String, matchStart: Int, matchEnd: Int): TextInterval = {
-    // Do not include in the context text beyond 2 consecutive newline characters.
-    val separator = "\n\n"
-    val contextStart = {
-      val start = math.max(0, matchStart - EidosDocument.CONTEXT_WINDOW_SIZE)
-      sentenceText.slice(start, matchStart).reverse.indexOf(separator) match {
-        case -1 => start
-        case i => matchStart - i
-      }
-    }
-    val contextEnd = {
-      val end = math.min(matchEnd + EidosDocument.CONTEXT_WINDOW_SIZE, sentenceText.length)
-      sentenceText.slice(matchEnd, end).indexOf(separator) match {
-        case -1 => end
-        case i => matchEnd + i
-      }
-    }
-
-    TextInterval(contextStart, contextEnd)
-  }
-
-  protected def getSentenceText(sentence: Sentence): String = {
-    text.map(text => text.slice(sentence.startOffsets.head, sentence.endOffsets.last))
-        .getOrElse(sentence.getSentenceText)
-  }
-
-  protected def mkMultiSentenceIndexAndTextInterval(sentenceIndex: Int, sentenceText: String, matches: Seq[Regex.Match]): Seq[SentenceIndexAndTextInterval] = {
-    val separateContexts: Seq[TextInterval] = matches.map(`match` => mkNearContext(sentenceText, `match`.start, `match`.end))
-    val joinedContexts: Seq[SentenceIndexAndTextInterval] = separateContexts.foldLeft(Seq.empty[SentenceIndexAndTextInterval]) { (list, context) =>
-      list match { // This name change it to keep IntelliJ from complaining
-        case li if li.isEmpty => List(SentenceIndexAndTextInterval(sentenceIndex, context))
-        case li if li.last.textInterval.end >= context.start => li.init :+ SentenceIndexAndTextInterval(sentenceIndex, TextInterval(li.last.textInterval.start, context.end))
-        case li => li :+ SentenceIndexAndTextInterval(sentenceIndex, context)
-      }
-    }
-
-    joinedContexts
-  }
-
-  protected def mkMultiSentenceIndexAndTextIntervalAndTimeIntervals(textIntervalsToParse: List[SentenceIndexAndTextInterval],
-      contextsTimeExpressions: Seq[List[TimeExpression]], sentenceBundles: Seq[SentenceBundle]):
-      Seq[SentenceIndexAndTextIntervalAndTimeIntervals] = {
-    val separateExpressions: Seq[SentenceIndexAndTextIntervalAndTimeIntervals] = (textIntervalsToParse zip contextsTimeExpressions).map { case (textSpanToParse, contextTimeExpressions) =>
-      val sentenceStart = sentenceBundles(textSpanToParse.sentenceIndex).start
-      val intervals: Seq[TextIntervalAndTimeIntervals] = contextTimeExpressions.map { contextTimeExpression =>
-        TextIntervalAndTimeIntervals(
-          TextInterval(
-            // This is now the entire correction for location in the sentence and document.
-            sentenceStart + textSpanToParse.textInterval.start + contextTimeExpression.span.start,
-            sentenceStart + textSpanToParse.textInterval.start + contextTimeExpression.span.end
-          ),
-          contextTimeExpression.intervals
-        )
-      }
-      SentenceIndexAndTextIntervalAndTimeIntervals(textSpanToParse.sentenceIndex, intervals)
-    }
-    val joinedExpressions: Seq[SentenceIndexAndTextIntervalAndTimeIntervals] = separateExpressions.foldLeft(List.empty[SentenceIndexAndTextIntervalAndTimeIntervals]) { (list, sTimExs) =>
-      list match {
-        case li if li.isEmpty => List(sTimExs)
-        case li if li.last.sentenceIndex == sTimExs.sentenceIndex => li.init :+ SentenceIndexAndTextIntervalAndTimeIntervals(li.last.sentenceIndex, li.last.multiTextIntervalAndTimeIntervals ++: sTimExs.multiTextIntervalAndTimeIntervals)
-        case li if li.last.sentenceIndex != sTimExs.sentenceIndex => li :+ sTimExs
-      }
-    }
-
-    joinedExpressions
-  }
-
-  protected def mkTimExs(sentenceBundle: SentenceBundle, multiTextIntervalAndTimeIntervals: Seq[TextIntervalAndTimeIntervals]): Seq[TimEx] = {
-    multiTextIntervalAndTimeIntervals.map { textIntervalAndTimeIntervals: TextIntervalAndTimeIntervals =>
-      val timeSteps: Seq[TimeStep] = textIntervalAndTimeIntervals.timeIntervals.map { timeInterval: TimeInterval =>
-        TimeStep(Option(timeInterval.start), Option(timeInterval.end), timeInterval.duration)
-      }
-      val text = sentenceBundle.text.slice(textIntervalAndTimeIntervals.textInterval.start - sentenceBundle.start,
-        textIntervalAndTimeIntervals.textInterval.end - sentenceBundle.start)
-
-      TimEx(textIntervalAndTimeIntervals.textInterval, timeSteps, text)
-    }
-  }
-
-  protected def updateNorms(sentenceBundle: SentenceBundle, multiTextIntervalAndTimeIntervals: Seq[TextIntervalAndTimeIntervals]): Unit = {
-    val sentence = sentenceBundle.sentence
-
-    // TODO: This might need to change to deal with overlapping TextIntervals.  There should be an
-    // issue filed against the problem.
-    // Update norms with B-I time expressions
-    sentence.norms.foreach { norms =>
-      norms.indices.foreach { index =>
-        val wordStart = sentence.startOffsets(index)
-        val wordEnd = sentence.endOffsets(index)
-        // This only finds the first one, but there may be more.
-        val matchIndex = multiTextIntervalAndTimeIntervals.indexWhere { textIntervalAndTimeIntervals =>
-          textIntervalAndTimeIntervals.textInterval.start <= wordStart &&
-              wordEnd <= textIntervalAndTimeIntervals.textInterval.end
-        }
-
-        if (matchIndex >= 0) // word was found inside time expression
-          norms(index) =
-              if (wordStart <= multiTextIntervalAndTimeIntervals(matchIndex).textInterval.start &&
-                  multiTextIntervalAndTimeIntervals(matchIndex).textInterval.start < wordEnd) "B-Time"
-              else "I-Time"
-      }
-    }
-  }
-
-  protected def parseTime(timenorm: TemporalNeuralParser, regexs: List[Regex], docTimeOpt: Option[String]): Array[Seq[TimEx]] = {
-    // Bundle up everything about a sentence that is needed later.
-    val sentenceBundles: Array[SentenceBundle] = sentences.zipWithIndex.map { case (sentence, index) =>
-      val text: String = getSentenceText(sentence)
-      // Only parse text where a regex detects a time expressions. Get the surrounding context.
-      val matches: Seq[Regex.Match] = regexs.flatMap(_.findAllMatchIn(text)).sortBy(_.start)
-      // If the contexts for different tokens overlap, join them.
-      val multiSentenceIndexAndTextInterval: Seq[SentenceIndexAndTextInterval] = mkMultiSentenceIndexAndTextInterval(index, text, matches)
-      val contexts: Seq[String] = multiSentenceIndexAndTextInterval.map { sentenceIndexAndTextInterval =>
-        text.slice(sentenceIndexAndTextInterval.textInterval.start, sentenceIndexAndTextInterval.textInterval.end)
-      }
-
-      SentenceBundle(index, sentence.startOffsets.head, sentence, text, multiSentenceIndexAndTextInterval, contexts)
-    }
-    // These next two lists work in parallel, allowing timeExpressions to be indexed to the sentences.
-    val (multiSentenceIndexAndTextInterval, contexts) = {
-      val listSentenceBundles = sentenceBundles.toList
-
-      (listSentenceBundles.flatMap(_.multiSentenceIndexAndTextInterval), listSentenceBundles.flatMap(_.contexts))
-    }
-    // Parse the contexts in batches of batch_size. The dct goes in the first batch.
-    val timeExpressions: Seq[List[TimeExpression]] = docTimeOpt match {
-      case Some(docTime) =>
-        val parsed = (docTime :: contexts).sliding(EidosDocument.BATCH_SIZE, EidosDocument.BATCH_SIZE).flatMap(timenorm.parse).toList
-        dct = Some(DCT(timenorm.dct(parsed.head), docTime)) // Note the side effect!
-        timenorm.intervals(parsed.tail, dct.map(_.interval))
-      case None =>
-        val parsed = contexts.sliding(EidosDocument.BATCH_SIZE, EidosDocument.BATCH_SIZE).flatMap(timenorm.parse).toList
-        timenorm.intervals(parsed)
-    }
-    // Correct offsets and combine them on a per sentence basis.
-    val timExMap = mkMultiSentenceIndexAndTextIntervalAndTimeIntervals(multiSentenceIndexAndTextInterval, timeExpressions, sentenceBundles)
-        // Recover the list of time expressions for each sentence.
-        .groupBy(_.sentenceIndex)
-        .map { case (sentenceIndex, multiSentenceIndexAndTextIntervalAndTimeIntervals) =>
-          val multiTextIntervalAndTimeIntervals = multiSentenceIndexAndTextIntervalAndTimeIntervals.flatMap(_.multiTextIntervalAndTimeIntervals)
-
-          updateNorms(sentenceBundles(sentenceIndex), multiTextIntervalAndTimeIntervals)
-          sentenceIndex -> mkTimExs(sentenceBundles(sentenceIndex), multiTextIntervalAndTimeIntervals)
-        }
-
-    // Make sure there is a Seq[TimEx] for each sentence.
-    sentenceBundles.map { sentenceBundle => timExMap.getOrElse(sentenceBundle.index, Seq.empty) }
-  }
-
-  def parseTime(timenorm: Option[TemporalNeuralParser], regexs: Option[List[Regex]], documentCreationTime: Option[String]): Unit =
-      times = timenorm.map(parseTime(_, regexs.get, documentCreationTime))
+  var dctString: Option[String] = None
 }
 
 object EidosDocument {
-  protected val CONTEXT_WINDOW_SIZE = 20
-  protected val BATCH_SIZE = 40
 
   def apply(document: Document, keepText: Boolean = true): EidosDocument = {
     val text = document.text // This will be the preprocessed text now.

--- a/src/main/scala/org/clulab/wm/eidos/extraction/Finder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/extraction/Finder.scala
@@ -4,7 +4,7 @@ import ai.lum.common.ConfigUtils._
 import com.typesafe.config.Config
 import org.clulab.odin.{Mention, State}
 import org.clulab.processors.Document
-import org.clulab.wm.eidos.context.GeoNormFinder
+import org.clulab.wm.eidos.context.{GeoNormFinder, TimeNormFinder}
 
 trait Finder {
   def extract(doc: Document, initialState: State = new State()): Seq[Mention]
@@ -19,6 +19,7 @@ object Finder {
         case "rulebased" => RuleBasedEntityFinder.fromConfig(config)
         case "gazetteer" => GazetteerEntityFinder.fromConfig(config)
         case "geonorm" => GeoNormFinder.fromConfig(config[Config]("geonorm"))
+        case "timenorm" => TimeNormFinder.fromConfig(config[Config]("timenorm"))
         case _ => ???
       }
     }

--- a/src/test/resources/englishTest.conf
+++ b/src/test/resources/englishTest.conf
@@ -5,8 +5,7 @@ EidosSystem {
           hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
         timeRegexPath = /org/clulab/wm/eidos/english/context/timenorm-regexes.txt
           useLexicons = true
-        entityFinders = ["gazetteer", "rulebased", "geonorm"]
-          useTimeNorm = true
+        entityFinders = ["gazetteer", "rulebased", "geonorm", "timenorm"]
  keepStatefulConcepts = false
       conceptExpander = ${actions.expander}
 }
@@ -80,6 +79,10 @@ geonorm {
   geoNormModelPath = /org/clulab/geonorm/model/geonorm_model.pb
   geoWord2IdxPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
   geoLoc2IdPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/geo_dict_with_population_SOUTH_SUDAN.txt
+}
+
+timenorm {
+  timeRegexPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/timenorm-regexes.txt
 }
 
 ruleBasedEntityFinder {

--- a/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc2.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc2.scala
@@ -40,7 +40,7 @@ class TestDoc2 extends EnglishTest {
     val tester = new GraphTester(text)
 
     val situation = NodeSpec("deteriorating situation", Dec("deteriorating"))
-    val leanSeason = NodeSpec("unusually long and harsh annual lean season", Quant("harsh"))
+    val leanSeason = NodeSpec("unusually long and harsh annual lean season", Quant("harsh"), TimEx("annual"))
     val foodStocks = NodeSpec("food stocks", Dec("depleted"))
     val foodInsecurity = NodeSpec("level of food insecurity this year", Quant("unprecedented"), TimEx("this year"))
 

--- a/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc3.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc3.scala
@@ -604,7 +604,7 @@ class TestDoc3 extends EnglishTest {
     val rainfall2 = NodeSpec("expected heavy rains", Quant("heavy"), Inc("heavy"))
     val maize = NodeSpec("ongoing maize harvesting", Quant("ongoing"), Dec("hamper"))
     val drying = NodeSpec("drying activities", Dec("hamper"))
-    val losses = NodeSpec("post-harvest losses", Dec("losses"))
+    val losses = NodeSpec("post-harvest losses", Dec("losses"), TimEx("post"))
     val dry = NodeSpec("dry days", Quant("significant")) // todo: this is a part of the hyper edge, should handle one day
 
     behavior of "TestDoc3 Paragraph 15"

--- a/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc5.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc5.scala
@@ -310,7 +310,7 @@ class TestDoc5 extends EnglishTest {
     val conflict     = NodeSpec("Conflict")
     val displacement = NodeSpec("new displacement")
     val stress       = NodeSpec("stress on available wild food sources", Inc("additional"))
-    val assistance   = NodeSpec("Little to no food assistance was distributed in these counties from August to November", Quant("Little"), Dec("Little to no"), TimEx("August"), TimEx("November"))
+    val assistance   = NodeSpec("Little to no food assistance was distributed in these counties from August to November", Quant("Little"), Dec("Little to no"), TimEx("August"), TimEx("August to"), TimEx("November"))
     val constraints   = NodeSpec("access constraints", Dec("constraints"))
 
     behavior of "TestDoc5 Paragraph 6"

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -324,18 +324,24 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
       objectToReturn += ""
 
     // TimeExpressions
-    objectToReturn += "<h2>Found TimeExpressions:</h2>"
-    if (time.isDefined)
-      time.get.foreach { t =>
-        objectToReturn += s"${DisplayUtils.webAppTimeExpressions(t)}"
+    val timeMentions = mentions.filter(_.odinMention matches "Time")
+    if (timeMentions.nonEmpty) {
+      objectToReturn += "<h2>Found TimeExpressions:</h2>"
+      val times = timeMentions.flatMap(_.odinMention.attachments).collect{
+        case time: Time => time.interval
       }
+      objectToReturn += s"${DisplayUtils.webAppTimeExpressions(times)}"
+    }
 
     // GeoLocations
-    objectToReturn += "<h2>Found GeoLocations:</h2>"
-    if (location.isDefined)
-      location.get.foreach { l =>
-        objectToReturn += s"${DisplayUtils.webAppGeoLocations(l)}"
+    val locationMentions = mentions.filter(_.odinMention matches "Location")
+    if (locationMentions.nonEmpty) {
+      objectToReturn += "<h2>Found GeoLocations:</h2>"
+      val locations = locationMentions.flatMap(_.odinMention.attachments).collect{
+        case location: Location => location.geoPhraseID
       }
+      objectToReturn += s"${DisplayUtils.webAppGeoLocations(locations)}"
+    }
 
 
     // Concepts


### PR DESCRIPTION
This gets rid of the use of `.norms` for times, simplifies `EidosDocument`, and simplifies some grammar rules and custom actions.

`EidosDocument` is almost empty now. We should be able to get rid of it completely after clulab/processors#335 is complete and we can use that to store the document creation time.
