### PR TITLE
Coordinate different users of cache directory

### DIFF
--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -8,6 +8,7 @@ EidosSystem {
         entityFinders = ["gazetteer", "rulebased", "geonorm"]
           useTimeNorm = true
  keepStatefulConcepts = true
+             cacheDir = ./cache
 }
 
 filtering {
@@ -42,8 +43,8 @@ ontologies {
   // Activated Ontologies
   ontologies = ["un", "props", "mitre12", "who", "interventions"] // , "icasa", "mesh"]
 
-  // Caching, for quick loading
-  cacheDir = ./cache/${EidosSystem.language}
+  // Caching, for quick loading, language dependent
+  cacheDir = ${EidosSystem.cacheDir}/${EidosSystem.language}
   useCache = false
 
   // Primary
@@ -65,7 +66,7 @@ geonorm {
   taggerWordToIndexPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
   normalizerModelPath   = /org/clulab/wm/eidos/${EidosSystem.language}/context/geonames-reranker.model
   geoNamesIndexURL      = "http://clulab.cs.arizona.edu/models/geonames-index.zip"
-  geoNamesIndexPath     = geonames/index
+  geoNamesIndexPath     = ${EidosSystem.cacheDir}/geonames/index
 }
 
 adjectiveGrounder {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,6 +9,7 @@ EidosSystem {
           useTimeNorm = false
            useGeoNorm = false
  keepStatefulConcepts = false
+            cacheDir = ./cache
       conceptExpander {
         expansionType = "textbound"
         maxHops = 5
@@ -120,7 +121,7 @@ ontologies {
   wordToVecPath = /org/clulab/wm/eidos/english/w2v/vectors.txt
   //      wordToVecPath = /org/clulab/wm/eidos/english/w2v/glove.840B.300d.txt
   topKNodeGroundings = 10
-  cacheDir  = ./cache/english
+  cacheDir = ${EidosSystem.cacheDir}/english
   useCache = false
 
   ontologies = ["un", "wdi", "fao", "props", "mitre12", "who", "interventions"] // , "icasa", "mesh"]

--- a/src/main/scala/org/clulab/wm/eidos/context/GeoNorm.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/GeoNorm.scala
@@ -26,27 +26,49 @@ object GeoNormFinder {
 
   private lazy val logger = LoggerFactory.getLogger(getClass)
 
-  def fromConfig(config: Config): GeoNormFinder = {
-    val geoNamesIndexPath = Paths.get(config[String]("geoNamesIndexPath"))
-    val geoNamesIndexURL: URL = config[URL]("geoNamesIndexURL")
+  class CacheManager(config: Config) {
+    lazy val geoNamesIndexPath: Path = Paths.get(config[String]("geoNamesIndexPath"))
+    protected lazy val segmentsPath = geoNamesIndexPath.resolve("segments_1")
+    protected lazy val zipPath = geoNamesIndexPath.resolve("geonames-index.zip")
 
-    // if the index is not yet local, download it
-    if (!Files.exists(geoNamesIndexPath.resolve("segments_1"))) {
-      logger.info(s"No GeoNames index at $geoNamesIndexPath.")
-
+    // The default is not to replace any files on a machine that is simply running Eidos.
+    // This can be overruled by programs that are managing the cache.
+    def mkCache(replaceOnUnzip: Boolean = false): Unit = {
       // copy the zip file to the local machine
+      val geoNamesIndexURL: URL = config[URL]("geoNamesIndexURL")
       logger.info(s"Downloading the GeoNames index from $geoNamesIndexURL.")
-      val zipPath = geoNamesIndexPath.resolve("geonames-index.zip")
       Files.createDirectories(geoNamesIndexPath)
       Files.copy(geoNamesIndexURL.openStream, zipPath)
 
       // unzip the zip file
       logger.info(s"Extracting the GeoNames index to $geoNamesIndexPath.")
-      FileUtils.unzip(zipPath, geoNamesIndexPath)
-
-      // remove the downloaded zip file
+      FileUtils.unzip(zipPath, geoNamesIndexPath, replace = replaceOnUnzip)
       Files.delete(zipPath)
+
+      if (!isCached)
+        throw new RuntimeException(s"The caching operation was apparently unsuccessful.")
     }
+
+    def rmCache(): Unit = {
+      Files.deleteIfExists(segmentsPath)
+      Files.deleteIfExists(zipPath)
+    }
+
+    def isCached: Boolean = {
+      val cached = Files.exists(segmentsPath)
+
+      if (cached)
+        logger.info(s"No GeoNames index at $geoNamesIndexPath.")
+      else
+        logger.info(s"GeoNames index found at $geoNamesIndexPath.")
+      cached
+    }
+  }
+
+  def fromConfig(config: Config): GeoNormFinder = {
+    val cacheManager = new CacheManager(config)
+    if (!cacheManager.isCached)
+      cacheManager.mkCache()
 
     def getStream(path: String) = getClass.getResourceAsStream(config[String](path))
 
@@ -55,7 +77,7 @@ object GeoNormFinder {
         GeoLocationExtractor.loadNetwork(getStream("taggerModelPath")),
         GeoLocationExtractor.loadVocabulary(getStream("taggerWordToIndexPath"))),
       new GeoLocationNormalizer(
-        new GeoNamesSearcher(geoNamesIndexPath),
+        new GeoNamesSearcher(cacheManager.geoNamesIndexPath),
         Some(GeoLocationNormalizer.loadModel(getStream("normalizerModelPath")))))
   }
 }
@@ -87,7 +109,7 @@ class GeoNormFinder(extractor: GeoLocationExtractor, normalizer: GeoLocationNorm
           sentenceIndex,
           eidosDoc,
           true,
-          getClass.getSimpleName(),
+          getClass.getSimpleName,
           Set(Location(geoPhraseID))
         )
       }

--- a/src/main/scala/org/clulab/wm/eidos/utils/FileUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/FileUtils.scala
@@ -3,6 +3,7 @@ package org.clulab.wm.eidos.utils
 import java.io._
 import java.net.URL
 import java.nio.channels.Channels
+import java.nio.file.StandardCopyOption
 import java.nio.file.{Files, Path, Paths}
 import java.util.Collection
 import java.util.zip.ZipFile
@@ -183,7 +184,7 @@ object FileUtils {
   def newObjectInputStream(filename: String): ObjectInputStream =
       new ObjectInputStream(newBufferedInputStream(filename))
 
-  def unzip(zipPath: Path, outputPath: Path): Unit = {
+  def unzip(zipPath: Path, outputPath: Path, replace: Boolean = false): Unit = {
     new ZipFile(zipPath.toFile).autoClose { zipFile =>
       for (entry <- zipFile.entries.asScala) {
         val path = outputPath.resolve(entry.getName)
@@ -191,7 +192,10 @@ object FileUtils {
           Files.createDirectories(path)
         } else {
           Files.createDirectories(path.getParent)
-          Files.copy(zipFile.getInputStream(entry), path)
+          if (replace)
+            Files.copy(zipFile.getInputStream(entry), path, StandardCopyOption.REPLACE_EXISTING)
+          else
+            Files.copy(zipFile.getInputStream(entry), path)
         }
       }
     }

--- a/src/test/resources/englishTest.conf
+++ b/src/test/resources/englishTest.conf
@@ -8,6 +8,7 @@ EidosSystem {
         entityFinders = ["gazetteer", "rulebased", "geonorm"]
           useTimeNorm = true
  keepStatefulConcepts = false
+             cacheDir = ./cache
       conceptExpander = ${actions.expander}
 }
 
@@ -62,7 +63,7 @@ ontologies {
    wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
       ontologies = ["un", "wdi", "fao", "mitre12", "who", "interventions"] // , "icasa", "mesh"]
         useCache = false
-        cacheDir = ./cache/${EidosSystem.language}
+        cacheDir = ${EidosSystem.cacheDir}/${EidosSystem.language}
 
   // Paths to the ontologies
   un            = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_ontology.yml
@@ -81,7 +82,7 @@ geonorm {
   taggerWordToIndexPath = /org/clulab/wm/eidos/${EidosSystem.language}/context/word2idx_file.txt
   normalizerModelPath   = /org/clulab/wm/eidos/${EidosSystem.language}/context/geonames-reranker.model
   geoNamesIndexURL      = "http://clulab.cs.arizona.edu/models/geonames-index.zip"
-  geoNamesIndexPath     = geonames/index
+  geoNamesIndexPath     = ${EidosSystem.cacheDir}/geonames/index
 }
 
 ruleBasedEntityFinder {

--- a/src/test/resources/portugueseTest.conf
+++ b/src/test/resources/portugueseTest.conf
@@ -1,18 +1,20 @@
 EidosSystem {
 // Override the default values here
-           language = portuguese
-    masterRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/master.yml
-       taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
-      wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
-        hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
-        useLexicons = true
-      entityFinders = ["gazetteer", "rulebased"]
-  keepStatefulConcepts = false
-    conceptExpander = ${actions.expander}
-        useTimeNorm = false
-           useCache = false
-           useCoref = true
-          corefType = "causalBasic"
+            language = portuguese
+     masterRulesPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/master.yml
+        taxonomyPath = /org/clulab/wm/eidos/${EidosSystem.language}/grammars/taxonomy.yml
+       wordToVecPath = /org/clulab/wm/eidos/${EidosSystem.language}/w2v/vectors.txt
+         hedgingPath = /org/clulab/wm/eidos/${EidosSystem.language}/confidence/hedging.txt
+         useLexicons = true
+       entityFinders = ["gazetteer", "rulebased"]
+keepStatefulConcepts = false
+            cacheDir = ./cache
+
+     conceptExpander = ${actions.expander}
+         useTimeNorm = false
+            useCache = false
+            useCoref = true
+           corefType = "causalBasic"
 }
 
 filtering {
@@ -65,7 +67,7 @@ ontologies {
   useW2V = false
   ontologies = ["un", "wdi", "fao", "props", "mitre12", "who", "interventions"] // , "icasa", "mesh"]
   useCache = false
-  cacheDir = ./cache/${EidosSystem.language}
+  cacheDir = ${EidosSystem.cacheDir}/${EidosSystem.language}
   // Paths to the ontologies
   un            = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/un_ontology.yml
   interventions = /org/clulab/wm/eidos/${EidosSystem.language}/ontologies/interventions.yml


### PR DESCRIPTION
Rearrange the config files so that EidosSystem (in eidos.conf) controls the base cacheDir and then things like ontologies and geonorm can (optionally) put their caches inside it.  Flesh out the caching in GeoNormFinder into a CacheManager which can be reused by CacheOntologies to update the cache.