### PR TITLE
Improve CountSpec testing

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
+++ b/src/main/scala/org/clulab/wm/eidos/EidosActions.scala
@@ -142,7 +142,10 @@ class EidosActions(val expansionHandler: Option[Expander], val coref: Option[Cor
 
             countAttachments +=
               new CountAttachment(
-                s"value=${count.get._2}, mod=${countModifier.get._1}, unit=${countUnit.get._1}",
+                // Include quotes around the "value" to indicate it is the text version and include after ->
+                // the Double that is used in MigrationGroupCount to show how it was converted.
+                // A CountSpec should match the double version.
+                s"""value="${count.get._2}" -> ${count.get._1}, mod=${countModifier.get._1}, unit=${countUnit.get._1}""",
                 MigrationGroupCount(count.get._1, countModifier.get._1, countUnit.get._1))
           }
         }

--- a/src/main/scala/org/clulab/wm/eidos/attachments/EidosAttachment.scala
+++ b/src/main/scala/org/clulab/wm/eidos/attachments/EidosAttachment.scala
@@ -6,7 +6,10 @@ import org.clulab.struct.Interval
 import org.clulab.wm.eidos.Aliases.Quantifier
 import org.clulab.wm.eidos.context.GeoPhraseID
 import org.clulab.wm.eidos.document.{DCT, TimEx}
-import org.clulab.wm.eidos.serialization.json.{JLDAttachment => JLDEidosAttachment, JLDContextAttachment => JLDEidosContextAttachment, JLDScoredAttachment => JLDEidosScoredAttachment, JLDSerializer => JLDEidosSerializer, JLDTriggeredAttachment => JLDEidosTriggeredAttachment}
+import org.clulab.wm.eidos.serialization.json.{JLDAttachment => JLDEidosAttachment,
+    JLDContextAttachment => JLDEidosContextAttachment, JLDScoredAttachment => JLDEidosScoredAttachment,
+    JLDSerializer => JLDEidosSerializer, JLDTriggeredAttachment => JLDEidosTriggeredAttachment,
+    JLDCountAttachment => JLDEidosCountAttachment}
 import org.clulab.wm.eidos.utils.QuicklyEqualable
 import org.json4s._
 import org.json4s.JsonDSL._
@@ -563,8 +566,11 @@ object CountUnit extends Enumeration {
 
 case class MigrationGroupCount(value:Double, modifier:CountModifier.Value, unit:CountUnit.Value)
 
-class CountAttachment(t:String, v:MigrationGroupCount) extends ContextAttachment(text = t, value = v) {
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment = null // TODO: Keith, needs JSON output
+class CountAttachment(t:String, val v:MigrationGroupCount) extends ContextAttachment(text = t, value = v) {
+
+  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  // TODO, this "count" should be recorded somewhere else
+      new JLDEidosCountAttachment(serializer, "count", this)
 
   override def toJson(): JValue = null // TODO: Keith, needs JSON output
 }

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
@@ -234,6 +234,21 @@ object JLDAttachment {
   val kind = "State"
 }
 
+class JLDCountAttachment(serializer: JLDSerializer, kind: String, countAttachment: CountAttachment)
+    extends JLDAttachment(serializer, kind) {
+
+  override def toJObject: TidyJObject = {
+    TidyJObject(List(
+      serializer.mkType(this),
+      "type" -> kind,
+      "text" -> countAttachment.text,
+      "value" -> countAttachment.v.value,
+      "modifier" -> countAttachment.v.modifier.toString,
+      "unit" -> countAttachment.v.unit.toString
+    ))
+  }
+}
+
 class JLDTriggeredAttachment(serializer: JLDSerializer, kind: String, triggeredAttachment: TriggeredAttachment)
     extends JLDAttachment(serializer, JLDAttachment.kind) {
 
@@ -385,12 +400,16 @@ abstract class JLDExtraction(serializer: JLDSerializer, typeString: String, val 
         .collect{ case a: DCTime => a }
         .sortWith(DCTime.lessThan)
         .map(attachment => newJLDAttachment(attachment))
+    val jldCountAttachments = eidosMention.odinMention.attachments.toSeq
+        .collect{ case a: CountAttachment => a }
+        //.sortWith(Time.lessThan) TODO How should these be sorted w/o provenance?
+        .map(attachment => newJLDAttachment(attachment))
 
     // This might be used to test some groundings when they aren't configured to be produced.
     //val ontologyGroundings = mention.grounding.values.flatMap(_.grounding).toSeq
     //val ontologyGrounding = new OntologyGrounding(Seq(("hello", 4.5d), ("bye", 1.0d))).grounding
     val jldGroundings = eidosMention.grounding.map(pair => new JLDOntologyGroundings(serializer, pair._1, pair._2).toJObject).toSeq
-    val jldAllAttachments = (jldAttachments ++ jldTimeAttachments ++ jldLocationAttachments ++ jldDctAttachments).map(_.toJObject)
+    val jldAllAttachments = (jldAttachments ++ jldTimeAttachments ++ jldLocationAttachments ++ jldDctAttachments ++ jldCountAttachments).map(_.toJObject)
 
     TidyJObject(List(
       serializer.mkType(this),

--- a/src/test/scala/org/clulab/wm/eidos/graph/GraphSpec.scala
+++ b/src/test/scala/org/clulab/wm/eidos/graph/GraphSpec.scala
@@ -7,6 +7,8 @@ import org.clulab.odin.EventMention
 import org.clulab.odin.Mention
 import org.clulab.odin.TextBoundMention
 import org.clulab.wm.eidos.Aliases.Quantifier
+import org.clulab.wm.eidos.attachments.CountModifier.CountModifier
+import org.clulab.wm.eidos.attachments.CountUnit.CountUnit
 import org.clulab.wm.eidos.attachments._
 import org.clulab.wm.eidos.utils.QuicklyEqualable
 
@@ -248,7 +250,7 @@ object GeoLoc {
   def apply(text: String) =  new GeoLoc(text)
 }
 
-class CountSpec(val value: String, val modifier: String, val unit: String) extends ContextAttachmentSpec(value) {
+class CountSpec(val value: Double, val modifier: CountModifier, val unit: CountUnit) extends ContextAttachmentSpec("") {
   override protected val matchingClass: Class[_] = classOf[CountAttachment]
 
   override def calculateHashCode: Int = mix(mix(value.##, modifier.##), unit.##)
@@ -269,16 +271,16 @@ class CountSpec(val value: String, val modifier: String, val unit: String) exten
     val result = matchClass(attachment) && {
       val countAttachment = attachment.asInstanceOf[CountAttachment]
 
-      countAttachment.v.value.toString == value &&
-          countAttachment.v.modifier.toString == modifier &&
-          countAttachment.v.unit.toString == unit
+      countAttachment.v.value == value &&
+          countAttachment.v.modifier == modifier &&
+          countAttachment.v.unit == unit
     }
     result
   }
 }
 
 object CountSpec {
-  def apply(value: String, modifier: String, unit: String) =
+  def apply(value: Double, modifier: CountModifier = CountModifier.NoModifier, unit: CountUnit = CountUnit.Absolute) =
     new CountSpec(value, modifier, unit)
 }
 

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDSerializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDSerializer.scala
@@ -196,4 +196,22 @@ class TestJLDSerializer extends ExtractionTest {
   }
   else
     println("It didn't do it")
+
+  it should "serialize a count attachment" in {
+    val json = serialize(Seq(
+      newTitledAnnotatedDocument(
+        "Since the beginning of September 2016, almost 40,000 refugees arrived daily in Ethiopia from South Sudan as of mid-November.",
+        "This includes a migration event")
+    ))
+
+    inspect(json)
+    json.contains("count") should be (true)
+    json.contains("value") should be (true)
+    json.contains("modifier") should be (true)
+    json.contains("unit") should be (true)
+
+    json.contains("40000.0") should be (true)
+    json.contains("Max") should be (true)
+    json.contains("Daily") should be (true)
+  }
 }

--- a/src/test/scala/org/clulab/wm/eidos/text/english/TestMigrationSchema.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/TestMigrationSchema.scala
@@ -10,7 +10,7 @@ class TestMigrationSchema extends EnglishTest {
 
     val tester = new GraphTester(text)
 
-    val group = NodeSpec("almost 40,000 refugees")
+    val group = NodeSpec("almost 40,000 refugees", CountSpec("40000.0", "Max", "Absolute"))
     val moveTo = NodeSpec("Ethiopia")
     val moveFrom = NodeSpec("South Sudan")
     val timeStart = NodeSpec("the beginning of September 2016")

--- a/src/test/scala/org/clulab/wm/eidos/text/english/TestMigrationSchema.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/TestMigrationSchema.scala
@@ -1,5 +1,7 @@
 package org.clulab.wm.eidos.text.english
 
+import org.clulab.wm.eidos.attachments.CountModifier
+import org.clulab.wm.eidos.attachments.CountUnit
 import org.clulab.wm.eidos.graph._
 import org.clulab.wm.eidos.test.TestUtils._
 
@@ -10,7 +12,7 @@ class TestMigrationSchema extends EnglishTest {
 
     val tester = new GraphTester(text)
 
-    val group = NodeSpec("almost 40,000 refugees", CountSpec("40000.0", "Max", "Absolute"))
+    val group = NodeSpec("almost 40,000 refugees", CountSpec(40000, CountModifier.Max))
     val moveTo = NodeSpec("Ethiopia")
     val moveFrom = NodeSpec("South Sudan")
     val timeStart = NodeSpec("the beginning of September 2016")
@@ -1137,7 +1139,7 @@ class TestMigrationSchema extends EnglishTest {
 
     val tester = new GraphTester(text)
 
-    val group1 = NodeSpec("4,608 new arrival")
+    val group1 = NodeSpec("4,608 new arrivals", CountSpec(4608))
     val moveFrom1 = NodeSpec("Pagak")
     val moveTo1 = NodeSpec("Nguenyyiel camp")
     val time1 = NodeSpec("past week")
@@ -1603,7 +1605,7 @@ class TestMigrationSchema extends EnglishTest {
     val migration1 = HumanMigrationEdgeSpec(group = Some(group1), moveFrom = Some(moveFrom1))
 
 
-    val group2 = NodeSpec("14%")
+    val group2 = NodeSpec("14%", CountSpec(14))
     val moveFrom2 = NodeSpec("Jonglei State")
     val migration2 = HumanMigrationEdgeSpec(group = Some(group2), moveFrom = Some(moveFrom2))
 
@@ -1658,8 +1660,5 @@ class TestMigrationSchema extends EnglishTest {
       tester.test(migration1) should be (successful)
     }
   }
-
   */
-
-
 }


### PR DESCRIPTION
It uses the actual types like CountUnit rather than common denominator strings
The apply method uses default values to shorten the specification
The text representation of CountAttachment includes both "value" and value.d for comparison