### PR TITLE
New version of the TimeNorm parser.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ Test / parallelExecution := false // Keeps groups in their order   false then tr
 
 libraryDependencies ++= {
   val (major, minor) = CrossVersion.partialVersion(scalaVersion.value).get
-  val timenorm = "timenorm-0.12.0" + (if (minor == 11) "_2.11.11" else "")
+  val timenorm = "timenorm-0.12.1" + (if (minor == 11) "_2.11.11" else "")
 
   Seq("com.github.clulab" % "timenorm" % timenorm exclude("org.slf4j", "slf4j-log4j12"))
 }

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ Test / parallelExecution := false // Keeps groups in their order   false then tr
 
 libraryDependencies ++= {
   val (major, minor) = CrossVersion.partialVersion(scalaVersion.value).get
-  val timenorm = "timenorm-0.11.1" + (if (minor == 11) "_2.11.11" else "")
+  val timenorm = "timenorm-0.12.0" + (if (minor == 11) "_2.11.11" else "")
 
   Seq("com.github.clulab" % "timenorm" % timenorm exclude("org.slf4j", "slf4j-log4j12"))
 }

--- a/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
@@ -2,10 +2,13 @@ package org.clulab.wm.eidos.context
 
 import ai.lum.common.ConfigUtils._
 import com.typesafe.config.Config
+import org.clulab.anafora.Data
 import org.clulab.odin.{Mention, State, TextBoundMention}
 import org.clulab.processors.Document
 import org.clulab.struct.Interval
-import org.clulab.timenorm.neural.{TemporalNeuralParser, TimeExpression}
+import org.clulab.timenorm.formal._
+import org.clulab.timenorm.formal.{Interval => TimExInterval, Intervals => TimExIntervals}
+import org.clulab.timenorm.neural.TemporalNeuralParser
 import org.clulab.wm.eidos.attachments.Time
 import org.clulab.wm.eidos.document.{DCT, EidosDocument, TimEx, TimeStep}
 import org.clulab.wm.eidos.extraction.Finder
@@ -13,6 +16,7 @@ import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.Sourcer
 
 import scala.collection.mutable
+import scala.util.Try
 import scala.util.matching.Regex
 
 object TimeNormFinder {
@@ -32,6 +36,15 @@ class TimeNormFinder(parser: TemporalNeuralParser, timeRegexes: Seq[Regex]) exte
 
   private val CONTEXT_WINDOW_SIZE = 20
   private val BATCH_SIZE = 40
+
+  def parseBatch(text: String, spans: Array[(Int, Int)],
+                 textCreationTime: TimExInterval = UnknownInterval()): Array[Array[TimeExpression]] = {
+    for (xml <- parser.parseBatchToXML(text, spans)) yield {
+      implicit val data: Data = new Data(xml, Some(text))
+      val reader = new AnaforaReader(textCreationTime)
+      data.topEntities.map(e => Try(reader.temporal(e)).getOrElse(UnknownInterval(Some(e.expandedSpan)))).toArray
+    }
+  }
 
   override def extract(doc: Document, initialState: State): Seq[Mention] = doc match {
     case eidosDocument: EidosDocument =>
@@ -80,8 +93,8 @@ class TimeNormFinder(parser: TemporalNeuralParser, timeRegexes: Seq[Regex]) exte
           //assert(end2 <= end3 && end3 <= sentenceText.length)
 
           //assert(start3 <= end3)
-          // yield the context interval
-          Interval(start3, end3)
+          // yield the context interval adjusting the span to full-text character offsets
+          Interval(sentenceStart + start3, sentenceStart + end3)
         }
 
         // merge overlapping contexts
@@ -93,34 +106,32 @@ class TimeNormFinder(parser: TemporalNeuralParser, timeRegexes: Seq[Regex]) exte
 
         // get the text for each context
         for (interval <- mergedIntervals) yield {
-          ((sentenceIndex, interval.start), sentenceText.substring(interval.start, interval.end))
+          (sentenceIndex,(interval.start, interval.end))
         }
       }
-
-      // TODO: TemporalNeuralParser should take Array arguments, not List arguments, so the .toList here can be removed
-      val (contextLocations: List[(Int, Int)], contextTexts: List[String]) = sentenceContexts.flatten.toList.unzip
+      val (contextSentenceIndexes: Array[Int], contextSpans: Array[(Int, Int)]) = sentenceContexts.flatten.unzip
 
       // run the timenorm parser over batches of contexts to find and normalize time expressions
-      val contextTimeExpressions: Seq[List[TimeExpression]] = eidosDocument.dctString match {
+      val contextTimeExpressions: Array[Array[TimeExpression]] = eidosDocument.dctString match {
         case Some(dctString) =>
-          val parsed = (dctString :: contextTexts).sliding(BATCH_SIZE, BATCH_SIZE).flatMap(parser.parse).toList
-          eidosDocument.dct = Some(DCT(parser.dct(parsed.head), dctString)) // Note the side effect!
-          parser.intervals(parsed.tail, eidosDocument.dct.map(_.interval))
+          val Array(dct: TimExInterval) = parser.parse(dctString)
+          // use a SimpleInterval (character span = None) so it doesn't interfere with character span of TimeExpressions
+          val dctSimpleInterval = SimpleInterval(dct.start, dct.end)
+          eidosDocument.dct = Some(DCT(dctSimpleInterval, dctString))
+          contextSpans.sliding(BATCH_SIZE, BATCH_SIZE).
+            flatMap(batch => parseBatch(text, batch, textCreationTime = eidosDocument.dct.get.interval)).toArray
         case None =>
-          val parsed = contextTexts.sliding(BATCH_SIZE, BATCH_SIZE).flatMap(parser.parse).toList
-          parser.intervals(parsed)
+          contextSpans.sliding(BATCH_SIZE, BATCH_SIZE).
+            flatMap(batch => parseBatch(text, batch)).toArray
       }
 
       // create mentions for each of the time expressions that were found
       for {
-        ((sentenceIndex, contextSentenceStart), timeExpressions) <- contextLocations zip contextTimeExpressions
+        (sentenceIndex, timeExpressions) <- contextSentenceIndexes zip contextTimeExpressions
         timeExpression <- timeExpressions
       } yield {
-        // reconstruct full-text character offsets from sentence-level character offsets
         val sentence = eidosDocument.sentences(sentenceIndex)
-        val contextStart = sentence.startOffsets.head + contextSentenceStart
-        val timeTextStart = contextStart + timeExpression.span.start
-        val timeTextEnd = contextStart + timeExpression.span.end
+        val (timeTextStart, timeTextEnd) = timeExpression.charSpan.get
         val timeTextInterval = Interval(timeTextStart, timeTextEnd)
         val timeText = text.substring(timeTextStart, timeTextEnd)
 
@@ -139,9 +150,13 @@ class TimeNormFinder(parser: TemporalNeuralParser, timeRegexes: Seq[Regex]) exte
           Interval(wordIndexBefore, wordIndexBefore + 1)
         }
 
-        // construct the attachment with the detailed time information
-        val timeSteps = for (timeInterval <- timeExpression.intervals) yield {
-          TimeStep(Option(timeInterval.start), Option(timeInterval.end), timeInterval.duration)
+        // get the Seq of Intervals for each TimeExpression and construct the attachment with the detailed time information
+        val timeSteps: Seq[TimeStep] = timeExpression match {
+          case timeInterval: TimExInterval if timeInterval.isDefined =>
+            Seq(TimeStep(Option(timeInterval.start), Option(timeInterval.end)))
+          case timeIntervals: TimExIntervals if timeIntervals.isDefined =>
+            timeIntervals.iterator.toSeq.map(interval => TimeStep(Option(interval.start), Option(interval.end)))
+          case _ => Seq(TimeStep(None, None))
         }
         val attachment = TimEx(timeTextInterval, timeSteps, timeText)
 

--- a/src/main/scala/org/clulab/wm/eidos/document/EidosDocument.scala
+++ b/src/main/scala/org/clulab/wm/eidos/document/EidosDocument.scala
@@ -5,7 +5,6 @@ import java.time.LocalDateTime
 import org.clulab.processors.Document
 import org.clulab.processors.Sentence
 import org.clulab.processors.corenlp.CoreNLPDocument
-import org.clulab.timenorm.neural.TimeInterval
 import org.clulab.timenorm.formal.{Interval => TimExInterval}
 import org.clulab.struct.{Interval => TextInterval}
 import org.clulab.wm.eidos.context.GeoPhraseID
@@ -33,18 +32,8 @@ object EidosDocument {
 }
 
 @SerialVersionUID(1L)
-case class TimeStep(startDateOpt: Option[LocalDateTime], endDateOpt: Option[LocalDateTime], duration: Long)
+case class TimeStep(startDateOpt: Option[LocalDateTime], endDateOpt: Option[LocalDateTime])
 @SerialVersionUID(1L)
 case class TimEx(span: TextInterval, intervals: Seq[TimeStep], text: String)
 @SerialVersionUID(1L)
 case class DCT(interval: TimExInterval, text: String)
-
-@SerialVersionUID(1L)
-case class SentenceIndexAndTextInterval(sentenceIndex: Int, textInterval: TextInterval)
-@SerialVersionUID(1L)
-case class TextIntervalAndTimeIntervals(textInterval: TextInterval, timeIntervals: Seq[TimeInterval])
-@SerialVersionUID(1L)
-case class SentenceIndexAndTextIntervalAndTimeIntervals(sentenceIndex: Int, multiTextIntervalAndTimeIntervals: Seq[TextIntervalAndTimeIntervals])
-
-@SerialVersionUID(1L)
-case class SentenceBundle(index: Int, start: Int, sentence: Sentence, text: String, multiSentenceIndexAndTextInterval: Seq[SentenceIndexAndTextInterval], contexts: Seq[String])

--- a/src/main/scala/org/clulab/wm/eidos/document/EidosDocument.scala
+++ b/src/main/scala/org/clulab/wm/eidos/document/EidosDocument.scala
@@ -32,7 +32,7 @@ object EidosDocument {
 }
 
 @SerialVersionUID(1L)
-case class TimeStep(startDateOpt: Option[LocalDateTime], endDateOpt: Option[LocalDateTime])
+case class TimeStep(startDate: LocalDateTime, endDate: LocalDateTime)
 @SerialVersionUID(1L)
 case class TimEx(span: TextInterval, intervals: Seq[TimeStep], text: String)
 @SerialVersionUID(1L)

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDDeserializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDDeserializer.scala
@@ -122,7 +122,7 @@ class JLDDeserializer {
       val optEnd = (dctValue \ "end").extractOpt[String]
 
       val dct =
-        if (optStart.isEmpty && optEnd.isEmpty) DCT(UnknownInterval, text)
+        if (optStart.isEmpty && optEnd.isEmpty) DCT(UnknownInterval(), text)
         else {
           val start = optStart.getOrElse(optEnd.get)
           val end = optEnd.getOrElse(optStart.get)
@@ -144,9 +144,8 @@ class JLDDeserializer {
     val endOpt = (timeIntervalValue \ "end").extractOpt[String]
     val startDateOpt = startOpt.map(LocalDateTime.parse)
     val endDateOpt = endOpt.map(LocalDateTime.parse)
-    val duration = (timeIntervalValue \ "duration").extract[Long]
 
-    TimeStep(startDateOpt, endDateOpt, duration)
+    TimeStep(startDateOpt, endDateOpt)
   }
 
   def deserializeTimex(timexValue: JValue): IdAndTimex = {

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDDeserializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDDeserializer.scala
@@ -140,12 +140,12 @@ class JLDDeserializer {
   def deserializeTimeInterval(timeIntervalValue: JValue): TimeStep = {
     requireType(timeIntervalValue, JLDTimeInterval.typename)
     val _ = id(timeIntervalValue) // This is never used, so why do we have it?
-    val startOpt = (timeIntervalValue \ "start").extractOpt[String]
-    val endOpt = (timeIntervalValue \ "end").extractOpt[String]
-    val startDateOpt = startOpt.map(LocalDateTime.parse)
-    val endDateOpt = endOpt.map(LocalDateTime.parse)
+    val start = (timeIntervalValue \ "start").extract[String]
+    val end = (timeIntervalValue \ "end").extract[String]
+    val startDate = LocalDateTime.parse(start)
+    val endDate = LocalDateTime.parse(end)
 
-    TimeStep(startDateOpt, endDateOpt)
+    TimeStep(startDate, endDate)
   }
 
   def deserializeTimex(timexValue: JValue): IdAndTimex = {
@@ -154,9 +154,11 @@ class JLDDeserializer {
     val text = (timexValue \ "text").extract[String]
     val startOffset = (timexValue \ "startOffset").extract[Int]
     val endOffset = (timexValue \ "endOffset").extract[Int]
-    // A TimeExpression, if it exists at all, must have intervals; therefore, no extractOpt here.
-    val intervals = (timexValue \ "intervals").extract[JArray].arr.map { timeIntervalValue =>
-      deserializeTimeInterval(timeIntervalValue)
+    val intervals = (timexValue \ "intervals").extractOpt[JArray] match {
+      case Some(timeIntervalsValue: JArray) => timeIntervalsValue.arr.map { timeIntervalValue: JValue =>
+        deserializeTimeInterval(timeIntervalValue)
+      }
+      case _ => Seq()
     }
     new IdAndTimex(timexId, TimEx(Interval(startOffset, endOffset), intervals, text))
   }

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
@@ -626,13 +626,13 @@ object JLDWord {
   val typename = "Word"
 }
 
-class JLDTimeInterval(serializer:JLDSerializer, val start: Option[LocalDateTime], val end: Option[LocalDateTime])
+class JLDTimeInterval(serializer:JLDSerializer, val start: LocalDateTime, val end: LocalDateTime)
     // The document, sentence, index above will be used to recognized words.
     extends JLDObject(serializer, JLDTimeInterval.typename) {
   
   override def toJObject: TidyJObject = {
-    val startDateTime = start.map(_.toString)
-    val endDateTime = end.map(_.toString)
+    val startDateTime = start.toString
+    val endDateTime = end.toString
 
     TidyJObject(List(
       serializer.mkType(this),
@@ -655,7 +655,7 @@ class JLDTimex(serializer:JLDSerializer, val timex: TimEx)
     extends JLDObject(serializer, JLDTimex.typename, timex) {
   
   override def toJObject: TidyJObject = {
-    val jldIntervals = timex.intervals.map(interval => new JLDTimeInterval(serializer, interval.startDateOpt, interval.endDateOpt).toJObject)
+    val jldIntervals = timex.intervals.map(interval => new JLDTimeInterval(serializer, interval.startDate, interval.endDate).toJObject)
 
     TidyJObject(List(
       serializer.mkType(this),

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
@@ -626,7 +626,7 @@ object JLDWord {
   val typename = "Word"
 }
 
-class JLDTimeInterval(serializer:JLDSerializer, val start: Option[LocalDateTime], val end: Option[LocalDateTime], val duration: Long)
+class JLDTimeInterval(serializer:JLDSerializer, val start: Option[LocalDateTime], val end: Option[LocalDateTime])
     // The document, sentence, index above will be used to recognized words.
     extends JLDObject(serializer, JLDTimeInterval.typename) {
   
@@ -638,8 +638,7 @@ class JLDTimeInterval(serializer:JLDSerializer, val start: Option[LocalDateTime]
       serializer.mkType(this),
       serializer.mkId(this),
       "start" -> startDateTime,
-      "end" -> endDateTime,
-      "duration" -> duration
+      "end" -> endDateTime
     ))
   }
 }
@@ -656,7 +655,7 @@ class JLDTimex(serializer:JLDSerializer, val timex: TimEx)
     extends JLDObject(serializer, JLDTimex.typename, timex) {
   
   override def toJObject: TidyJObject = {
-    val jldIntervals = timex.intervals.map(interval => new JLDTimeInterval(serializer, interval.startDateOpt, interval.endDateOpt, interval.duration).toJObject)
+    val jldIntervals = timex.intervals.map(interval => new JLDTimeInterval(serializer, interval.startDateOpt, interval.endDateOpt).toJObject)
 
     TidyJObject(List(
       serializer.mkType(this),

--- a/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
@@ -59,7 +59,6 @@ object DisplayUtils {
 
         sb.append(s"$tab start: $start $nl")
         sb.append(s"$tab end: $end $nl")
-        sb.append(s"$tab duration: ${i.duration} $nl")
       }
       sb.append(nl)
     }

--- a/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
@@ -54,8 +54,8 @@ object DisplayUtils {
     for (timex <- timexes) {
       sb.append(s"$tab span: ${timex.span.start},${timex.span.end} $nl")
       for (i <- timex.intervals) {
-        val start = i.startDateOpt.map(_.toString).getOrElse("Undef")
-        val end = i.endDateOpt.map(_.toString).getOrElse("Undef")
+        val start = i.startDate.toString
+        val end = i.endDate.toString
 
         sb.append(s"$tab start: $start $nl")
         sb.append(s"$tab end: $end $nl")

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDDeserializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDDeserializer.scala
@@ -86,15 +86,13 @@ class TestJLDDeserializer extends ExtractionTest {
         |  "@type" : "TimeInterval",
         |  "@id" : "_:TimeInterval_5",
         |  "start" : "2017-01-01T00:00",
-        |  "end" : "2017-02-01T00:00",
-        |  "duration" : 2678400
+        |  "end" : "2017-02-01T00:00"
         |}""".stripMargin
       val timeIntervalValue = parse(json)
       val timeStep = new JLDDeserializer().deserializeTimeInterval(timeIntervalValue)
 
       timeStep.startDateOpt.get should be(LocalDateTime.parse("2017-01-01T00:00"))
       timeStep.endDateOpt.get should be(LocalDateTime.parse("2017-02-01T00:00"))
-      timeStep.duration should be(2678400)
     }
 
     it should "deserialize TimexExpression from jsonld" in {
@@ -109,8 +107,7 @@ class TestJLDDeserializer extends ExtractionTest {
         |    "@type" : "TimeInterval",
         |    "@id" : "_:TimeInterval_5",
         |    "start" : "2017-01-01T00:00",
-        |    "end" : "2017-02-01T00:00",
-        |    "duration" : 2678400
+        |    "end" : "2017-02-01T00:00"
         |  } ]
         |}""".stripMargin
       val timexValue = parse(json)

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDDeserializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDDeserializer.scala
@@ -91,8 +91,8 @@ class TestJLDDeserializer extends ExtractionTest {
       val timeIntervalValue = parse(json)
       val timeStep = new JLDDeserializer().deserializeTimeInterval(timeIntervalValue)
 
-      timeStep.startDateOpt.get should be(LocalDateTime.parse("2017-01-01T00:00"))
-      timeStep.endDateOpt.get should be(LocalDateTime.parse("2017-02-01T00:00"))
+      timeStep.startDate should be(LocalDateTime.parse("2017-01-01T00:00"))
+      timeStep.endDate should be(LocalDateTime.parse("2017-02-01T00:00"))
     }
 
     it should "deserialize TimexExpression from jsonld" in {

--- a/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc5.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc5.scala
@@ -310,7 +310,7 @@ class TestDoc5 extends EnglishTest {
     val conflict     = NodeSpec("Conflict")
     val displacement = NodeSpec("new displacement")
     val stress       = NodeSpec("stress on available wild food sources", Inc("additional"))
-    val assistance   = NodeSpec("Little to no food assistance was distributed in these counties from August to November", Quant("Little"), Dec("Little to no"), TimEx("August"), TimEx("August to"), TimEx("November"))
+    val assistance   = NodeSpec("Little to no food assistance was distributed in these counties from August to November", Quant("Little"), Dec("Little to no"), TimEx("August to November"))
     val constraints   = NodeSpec("access constraints", Dec("constraints"))
 
     behavior of "TestDoc5 Paragraph 6"

--- a/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc7.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/eval6/TestDoc7.scala
@@ -53,7 +53,7 @@ class TestDoc7 extends EnglishTest {
 
     val foodAvailability = NodeSpec("food availability",
                                     Inc("improvements", "slight"))
-    val seasonalHarvests = NodeSpec("seasonal harvests from October", TimEx("October"))
+    val seasonalHarvests = NodeSpec("seasonal harvests from October", TimEx("October to December, the 2018"))
     val leanSeasons = NodeSpec("lean seasons")
     val foodSecurity = NodeSpec("Food security", Dec("deteriorate"), TimEx("March"))
     val foodInsecurity = NodeSpec("levels of acute food insecurity", Dec("worse"))

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -493,9 +493,8 @@ class HomeController @Inject()(cc: ControllerComponents) extends AbstractControl
           "TimeExpression",
           Json.arr(Json.arr(i.span.start, i.span.end)),
           Json.toJson(for (d <- i.intervals) yield (
-              d.startDateOpt.map(_.toString).getOrElse("Undef"),
-              d.endDateOpt.map(_.toString).getOrElse("Undef"),
-              d.duration))
+              d.startDate.toString,
+              d.endDate.toString))
         )
       }
       Json.toJson(timexs)


### PR DESCRIPTION
- The parser gets as arguments the full text of the document and an Array of spans representing the batch of contexts to be processed. This makes unnecessary some case classes in `EidosDocument`. 

- The parser does not return the duration anymore.

- The parser avoids cycles in the inner representation of the time expressions. This should solve https://github.com/clulab/eidos/issues/630 and https://github.com/clulab/eidos/issues/631.
