### PR TITLE
timenorm 1.0.2. catching exceptions in normalization.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ libraryDependencies ++= {
     "org.clulab"    %% "processors-modelsmain"    % procVer,
     "org.clulab"    %% "processors-modelscorenlp" % procVer,
     "org.clulab"    %% "geonorm"                  % "0.9.5",
-    "org.clulab"    %% "timenorm"                 % "1.0.1",
+    "org.clulab"    %% "timenorm"                 % "1.0.2",
     "ai.lum"        %% "common"                   % "0.0.8",
     "org.scalatest" %% "scalatest"                % "3.0.4" % "test",
     "commons-io"    %  "commons-io"               % "2.5",

--- a/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/TimeNormFinder.scala
@@ -203,13 +203,15 @@ class TimeNormFinder(parser: TemporalNeuralParser, timeRegexes: Seq[Regex]) exte
       }
 
       // get the Seq of Intervals for each TimeExpression and construct the attachment with the detailed time information
-      val timeSteps: Seq[TimeStep] = timeExpression match {
-        case timeInterval: TimExInterval if timeInterval.isDefined =>
-          Seq(TimeStep(timeInterval.start, timeInterval.end))
-        case timeIntervals: TimExIntervals if timeIntervals.isDefined =>
-          timeIntervals.iterator.toSeq.map(interval => TimeStep(interval.start, interval.end))
-        case _ => Seq()
-      }
+      val timeSteps: Seq[TimeStep] = Try { // Normalizing incorrectly parsed time expressions may throw an exception
+        timeExpression match {
+          case timeInterval: TimExInterval if timeInterval.isDefined =>
+          Seq (TimeStep (timeInterval.start, timeInterval.end) )
+          case timeIntervals: TimExIntervals if timeIntervals.isDefined =>
+          timeIntervals.iterator.toSeq.map (interval => TimeStep (interval.start, interval.end) )
+          case _ => Seq ()
+        }
+      }.getOrElse(Seq ())
       val attachment = TimEx(timeTextInterval, timeSteps, timeText)
 
       // create the Mention for this time expression


### PR DESCRIPTION
- New version of the timenorm parser. It solves the crashes after long process time caused by impossible dates,  https://github.com/clulab/eidos/issues/662. It does not produce negative intervals, https://github.com/clulab/eidos/issues/665.
- A handler has been added to capture exceptions thrown during the normalization of incorrectly parsed time expressions. https://github.com/clulab/eidos/issues/663 https://github.com/clulab/eidos/issues/664