### PR TITLE
geonameID type is now Option[String]

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/context/GeoNormFinder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/context/GeoNormFinder.scala
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory
 import scala.collection.JavaConverters._
 
 @SerialVersionUID(1L)
-case class GeoPhraseID(text: String, geonameID: Option[Int], startOffset: Int, endOffset: Int)
+case class GeoPhraseID(text: String, geonameID: Option[String], startOffset: Int, endOffset: Int)
 
 object GeoNormFinder {
 
@@ -29,7 +29,7 @@ object GeoNormFinder {
   class CacheManager(config: Config) {
     val geoNamesIndexPath: Path = Paths.get(config[String]("geoNamesIndexPath")).toAbsolutePath.normalize
     protected lazy val segmentsPath: Path = geoNamesIndexPath.resolve("segments_1")
-    protected lazy val zipPath: Path = geoNamesIndexPath.resolve("geonames-index.zip")
+    protected lazy val zipPath: Path = geoNamesIndexPath.resolve("geonames+woredas.zip")
 
     // The default is not to replace any files on a machine that is simply running Eidos.
     // This can be overruled by programs that are managing the cache.
@@ -134,7 +134,7 @@ class GeoNormFinder(extractor: GeoLocationExtractor, normalizer: GeoLocationNorm
       val charEndIndex = sentence.endOffsets(wordEndIndex - 1)
       val locationPhrase = text.substring(charStartIndex, charEndIndex)
       val geoID = normalizer(text, (charStartIndex, charEndIndex)).headOption.map {
-        case (entry, _) => entry.id.toInt
+        case (entry, _) => entry.id
       }
       val geoPhraseID = GeoPhraseID(locationPhrase, geoID, charStartIndex, charEndIndex)
 

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDDeserializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDDeserializer.scala
@@ -166,7 +166,7 @@ class JLDDeserializer {
     val startOffset = (geoIdValue \ "startOffset").extract[Int]
     val endOffset = (geoIdValue \ "endOffset").extract[Int]
     val text = (geoIdValue \ "text").extract[String]
-    val geoId = (geoIdValue \ "geoID").extractOpt[String].map(Integer.parseInt)
+    val geoId = (geoIdValue \ "geoID").extractOpt[String]
     val geoPhraseId = GeoPhraseID(text, geoId, startOffset, endOffset)
 
     new IdAndGeoPhraseId(geoIdId, geoPhraseId)

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
@@ -693,7 +693,7 @@ class JLDGeoID(serializer:JLDSerializer, val geoid: GeoPhraseID)
     "startOffset" -> geoid.startOffset,
     "endOffset" -> geoid.endOffset,
     "text" -> geoid.text,
-    "geoID" -> geoid.geonameID.map(_.toString)
+    "geoID" -> geoid.geonameID
     // JLDTimeInterval.plural -> toJObjects(jldIntervals)
   ))
 }

--- a/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/DisplayUtils.scala
@@ -70,7 +70,7 @@ object DisplayUtils {
   def displayLocationExpressions(geolocations: Seq[GeoPhraseID]): String = {
     val sb = new StringBuffer()
     for (location <- geolocations) {
-      val geonameID = location.geonameID.map(_.toString).getOrElse("Undef")
+      val geonameID = location.geonameID.getOrElse("Undef")
 
       sb.append(s"$tab span: ${location.startOffset},${location.endOffset} $nl")
       sb.append(s"$tab geoNameID: $geonameID$nl")

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDDeserializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDDeserializer.scala
@@ -132,7 +132,7 @@ class TestJLDDeserializer extends ExtractionTest {
       val geoPhraseID = idAndGeoPhraseID.value
 
       id should be("_:GeoLocation_15")
-      geoPhraseID.geonameID should be(Some(7909807))
+      geoPhraseID.geonameID should be(Some("7909807"))
     }
 
     it should "deserialize Word from jsonld" in {

--- a/src/test/scala/org/clulab/wm/eidos/system/TestGeonorm.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestGeonorm.scala
@@ -24,7 +24,7 @@ class TestGeonorm extends ExtractionTest {
       to Resolve the Crisis in South Sudan.
     """
     locations(text).map(_.text) should contain allElementsOf Set("Juba", "South Sudan")
-    locations(text).flatMap(_.geoPhraseID.geonameID) should contain (7909807) // South Sudan
+    locations(text).flatMap(_.geoPhraseID.geonameID) should contain ("7909807") // South Sudan
     // (no test for Juba since it's ambiguous between the city and the state)
 
     // The model sometimes generates I-LOC tags at the beginning of a sentence.


### PR DESCRIPTION
Changes to allow GADM ID as described in https://github.com/clulab/eidos/issues/688
- The type of geonameID of GeoPhraseID has been changed to Option[String].
- The geoNamesIndex has been changed to geonames+woredas.zip.