### PR TITLE
Only read stopwords file once

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/utils/StopwordManager.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/StopwordManager.scala
@@ -12,7 +12,7 @@ trait StopwordManaging {
 }
 
 class StopwordManager(stopwordsPath: String, transparentPath: String, corefHandler: CorefHandler) extends StopwordManaging {
-  protected def stopwords: Set[String] = FileUtils.getCommentedTextSetFromResource(stopwordsPath)
+  protected val stopwords: Set[String] = FileUtils.getCommentedTextSetFromResource(stopwordsPath)
   protected def transparentWords: Set[String] = FileUtils.getCommentedTextSetFromResource(transparentPath)
 
   protected val bothWords = stopwords ++ transparentWords


### PR DESCRIPTION
It was a def before so that the results could be thrown away.  Now they are used repeatedly.