### PR TITLE
Alleviate as a trigger (plus some of his friends... and enemies?)

### DIFF
--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -44,7 +44,7 @@ ontologies {
 
   // Caching, for quick loading, language dependent
   cacheDir = ${EidosSystem.cacheDir}/${EidosSystem.language}
-  useCache = false
+  useCache = true
 
   // Primary
   // Note that this first one is included via build.sbt.  It is not directly part of eidos.

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -44,7 +44,7 @@ ontologies {
 
   // Caching, for quick loading, language dependent
   cacheDir = ${EidosSystem.cacheDir}/${EidosSystem.language}
-  useCache = true
+  useCache = false
 
   // Primary
   // Note that this first one is included via build.sbt.  It is not directly part of eidos.

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/explicitModifiers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/explicitModifiers.yml
@@ -53,6 +53,14 @@ rules:
       trigger = little if any
       theme: Entity = >nmod_if
 
+  - name: Decrease_explicit_brought_down
+    priority: ${ rulepriority }
+    example: "He said in order to boost intra-African trade , tariffs needed to be brought down "
+    label: Decrease
+    action: ${ action }
+    pattern: |
+      trigger = [lemma=bring] down
+      theme: Entity = >dobj
 
 # ------------------- Specific Increase --------------------------
 

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/explicitModifiers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/explicitModifiers.yml
@@ -60,7 +60,7 @@ rules:
     action: ${ action }
     pattern: |
       trigger = [lemma=bring] down
-      theme: Entity = >dobj
+      theme: Entity = >/dobj|^nsubjpass/
 
 # ------------------- Specific Increase --------------------------
 

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/linkersTemplate.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/linkersTemplate.yml
@@ -53,7 +53,7 @@ rules:
         # agents (i.e., noun subjects)
         (${ agents })
         # optionally you can follow specified modifiers
-        /nmod_than|${ objects }|${ conjunctions }|${ noun_modifiers}/{,2}
+        /nmod_than|${ objects }|${ conjunctions }|${ noun_modifiers}|nmod_in|nmod_of/{,2}
         # if you land on another trigger, you are then licensed to follow more preps
         ([word=/(?i)^(${ trigger })/] /${ preps }/{,2})?
       effect: Entity =

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/reverse_direction_causal.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/reverse_direction_causal.yml
@@ -12,7 +12,7 @@ rules:
     pattern: |
       trigger = [word=/(?i)^(${ trigger })/] (in|to|into)
       cause: Entity  = nsubj /^nmod_/?
-      effect: Entity = (nmod_in | nmod_to){1,2} (amod | compound)? | ccomp (nsubj | dobj)?
+      effect: Entity = (nmod_in|nmod_of|nmod_on|nmod_to){1,2} (amod | compound)? | ccomp (nsubj | dobj)?
 
   - name: reverse_causal-noun-2
     priority: ${ rulepriority }

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
@@ -1,7 +1,7 @@
 increase_triggers: "acceler|aggravat|aid|augment|boost|compound|doubl|deep|elev|enhanc|exacerbat|exorbitant|favorable|height|improv|increas|intens|maximiz|prolong|promot|rais|reactivat|restor|sav(e|ed|es|ing)$|spike|spread|stimul|synerg|up-regul|upregul|uptick|widen"
 noncausal_increase_triggers: "above|above-average|better|good|greater|heav|(highs?$)|highe(r|s)|provid|rise|rising|widespread"
 
-decrease_triggers: "abat|alleviat|attenu|abolish|abrog|arrest|block|collaps|constrain|(cuts?$)|cutting|deactiv|decimat|decreas|degrad|deplet|depreciat|depress|destabili|deregul|deteriorat|diminish|disrupt|down-reg|downreg|drop|dysregul|elimin|^ends?$|eras|erod|exhaust|impair|imped|inhibit|hamper|limit|less|lower|minimiz|mitigat|negat|nullifi|prevent|reduc|reliev|repress|restrict|revers|sequester|short|shrink|shrunk|slow|starv|suppress|supress|undermin|worse"
+decrease_triggers: "abat|alleviat|attenu|abolish|abrog|arrest|block|collaps|constrain|curtail|(cuts?$)|cutting|deactiv|decimat|decreas|degrad|deplet|depreciat|depress|destabili|deregul|deteriorat|diminish|disrupt|down-reg|downreg|drain|drop|dysregul|elimin|^ends?$|eras|erod|exhaust|impair|imped|inhibit|hamper|limit|less|lower|minimiz|mitigat|negat|nullifi|prevent|reduc|reliev|repress|restrict|revers|sequester|short|shrink|shrunk|slow|starv|suppress|supress|undermin|worse"
 noncausal_decrease_triggers: "absence|below-average|declin|defici|discontinu|downturn|(fall$)|fail|(fell$)|inactiv|inadequate|knockdown|lack|loss|(lows?$)|plummet|poor|scarce|scarcity|shortage|shutdown"
 #advers|perturb|resist|
 

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
@@ -1,5 +1,5 @@
-increase_triggers: "acceler|aggravat|aid|augment|boost|compound|doubl|deep|elev|enhanc|exacerbat|exorbitant|favorable|height|improv|increas|intens|maximiz|prolong|promot|rais|reactivat|restor|sav(e|ed|es|ing)$|spike|spread|stimul|synerg|up-regul|upregul|uptick|widen"
-noncausal_increase_triggers: "above|above-average|better|good|greater|heav|(highs?$)|highe(r|s)|provid|rise|rising|widespread"
+increase_triggers: "acceler|aggravat|aid|ameliorat|amplif|augment|boost|compound|doubl|deep|elev|enhanc|escalat|exacerbat|exorbitant|favorable|height|improv|increas|intens|maximiz|multipl(y|ie)|prolong|promot|rais|reactivat|restor|sav(e|ed|es|ing)$|spike|spread|stimul|synerg|up-regul|upregul|uptick|widen"
+noncausal_increase_triggers: "above|above-average|better|climb|good|greater|heav|(highs?$)|highe(r|s)|provid|rise|rising|(up)?surg(ed?|ing)$|upturn|widespread"
 
 decrease_triggers: "abat|alleviat|attenu|abolish|abrog|arrest|block|collaps|constrain|curtail|(cuts?$)|cutting|deactiv|decimat|decreas|degrad|deplet|depreciat|depress|destabili|deregul|deteriorat|diminish|disrupt|down-reg|downreg|drain|drop|dysregul|elimin|^ends?$|eras|erod|exhaust|impair|imped|inhibit|hamper|limit|less|lower|minimiz|mitigat|negat|nullifi|prevent|reduc|reliev|repress|restrict|revers|sequester|short|shrink|shrunk|slow|starv|suppress|supress|undermin|worse"
 noncausal_decrease_triggers: "absence|below-average|declin|defici|discontinu|downturn|(fall$)|fail|(fell$)|inactiv|inadequate|knockdown|lack|loss|(lows?$)|plummet|poor|scarce|scarcity|shortage|shutdown"

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/triggers.yml
@@ -1,7 +1,7 @@
-increase_triggers: "acceler|aid|augment|boost|compound|doubl|deep|elev|enhanc|exacerbat|exorbitant|favorable|height|improv|increas|intens|prolong|promot|rais|reactivat|restor|sav(e|ed|es|ing)$|spike|spread|stimul|synerg|up-regul|upregul|uptick|widen"
+increase_triggers: "acceler|aggravat|aid|augment|boost|compound|doubl|deep|elev|enhanc|exacerbat|exorbitant|favorable|height|improv|increas|intens|maximiz|prolong|promot|rais|reactivat|restor|sav(e|ed|es|ing)$|spike|spread|stimul|synerg|up-regul|upregul|uptick|widen"
 noncausal_increase_triggers: "above|above-average|better|good|greater|heav|(highs?$)|highe(r|s)|provid|rise|rising|widespread"
 
-decrease_triggers: "attenu|abolish|abrog|arrest|block|collaps|constrain|(cuts?$)|cutting|deactiv|decimat|decreas|degrad|deplet|depreciat|depress|destabili|deregul|deteriorat|diminish|disrupt|down-reg|downreg|drop|dysregul|elimin|^ends?$|eras|erod|exhaust|impair|imped|inhibit|hamper|limit|less|lower|negat|nullifi|prevent|reduc|reliev|repress|restrict|revers|sequester|short|shrink|shrunk|slow|starv|suppress|supress|undermin|worse"
+decrease_triggers: "abat|alleviat|attenu|abolish|abrog|arrest|block|collaps|constrain|(cuts?$)|cutting|deactiv|decimat|decreas|degrad|deplet|depreciat|depress|destabili|deregul|deteriorat|diminish|disrupt|down-reg|downreg|drop|dysregul|elimin|^ends?$|eras|erod|exhaust|impair|imped|inhibit|hamper|limit|less|lower|minimiz|mitigat|negat|nullifi|prevent|reduc|reliev|repress|restrict|revers|sequester|short|shrink|shrunk|slow|starv|suppress|supress|undermin|worse"
 noncausal_decrease_triggers: "absence|below-average|declin|defici|discontinu|downturn|(fall$)|fail|(fell$)|inactiv|inadequate|knockdown|lack|loss|(lows?$)|plummet|poor|scarce|scarcity|shortage|shutdown"
 #advers|perturb|resist|
 

--- a/src/main/resources/org/clulab/wm/eidos/english/grammars/vars.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/grammars/vars.yml
@@ -12,7 +12,7 @@ negTriggers: "not"
 
 objects: "dobj"
 
-preps: "nmod_of|nmod_in|nmod_to|nmod_over|nmod_for|nmod_than|acl_of"
+preps: "nmod_of|nmod_in|nmod_to|nmod_over|nmod_for|nmod_on|nmod_than|acl_of"
 
 prep_dobjs: "nmod"
 

--- a/src/main/scala/org/clulab/wm/eidos/utils/StopwordManager.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/StopwordManager.scala
@@ -27,6 +27,7 @@ class StopwordManager(stopwordsPath: String, transparentPath: String, corefHandl
     val tags = mention.tags.get
     val entities = mention.entities.get
 
+    if (!tags.exists(_.startsWith("NN"))) return false
     //println(s"Checking mention: ${mention.text}")
     lemmas.indices.exists { i =>
       isContentPOS(tags(i)) &&

--- a/src/test/scala/org/clulab/wm/eidos/text/english/cag/TestExtraText.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/cag/TestExtraText.scala
@@ -1,0 +1,47 @@
+package org.clulab.wm.eidos.text.english.cag
+
+import org.clulab.wm.eidos.graph.{Causal, Correlation, Dec, EdgeSpec, Inc, NodeSpec, TimEx, Unmarked}
+import org.clulab.wm.eidos.test.TestUtils.{EnglishTest, Somebody, successful}
+
+class TestExtraText extends EnglishTest {
+  { // Paragraph 1
+    val text = """
+                 |Second , the sharp rise in the international price of oil in 2007
+                 |resulted in a significant drain on foreign reserves .
+                 |Anything which impedes this is bound to lead to tyranny and the
+                 |curtailment of the rights enshrined in the constitution .
+                 |To sum up , Ethiopia has to expand its business diplomacy horizons
+                 |and promote investment opportunities than ever before to alleviate
+                 |poverty and establish globally competitive economy .
+                 |He said in order to boost intra-African trade , tariffs needed to
+                 |be brought down .
+      """
+
+    val tester = new GraphTester(text)
+
+    val oil = NodeSpec("international price of oil", Inc("rise", "sharp"), TimEx("2007"))
+    val reserves = NodeSpec("foreign reserves", Dec("drain", "significant"))
+    val rights = NodeSpec("curtailment of the rights enshrined in the constitution", Dec("curtailment"))
+    val investment = NodeSpec("investment opportunities")
+    val poverty = NodeSpec("poverty", Dec("alleviate"))
+    val trade = NodeSpec("intra-African trade", Inc("boost"))
+    val tariffs = NodeSpec("tariffs", Dec("brought down"))
+
+
+    behavior of "inc/dec triggers test"
+
+    passingTest should "have correct edge 1" taggedAs(Somebody) in {
+      tester.test(EdgeSpec(oil, Causal, reserves)) should be (successful)
+    }
+    passingTest should "have correct singleton node 1" taggedAs(Somebody) in {
+      tester.test(rights) should be (successful)
+    }
+    passingTest should "have correct edge 2" taggedAs(Somebody) in {
+      tester.test(EdgeSpec(investment, Causal, poverty)) should be (successful)
+    }
+    passingTest should "have correct edge 3" taggedAs(Somebody) in {
+      tester.test(EdgeSpec(tariffs, Causal, trade)) should be (successful)
+    }
+  }
+
+}

--- a/src/test/scala/org/clulab/wm/eidos/text/english/cag/TestExtraText.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/cag/TestExtraText.scala
@@ -22,7 +22,7 @@ class TestExtraText extends EnglishTest {
     val oil = NodeSpec("international price of oil", Inc("rise", "sharp"), TimEx("2007"))
     val reserves = NodeSpec("foreign reserves", Dec("drain", "significant"))
     val rights = NodeSpec("curtailment of the rights enshrined in the constitution", Dec("curtailment"))
-    val investment = NodeSpec("investment opportunities")
+    val investment = NodeSpec("investment opportunities", Inc("promote"))
     val poverty = NodeSpec("poverty", Dec("alleviate"))
     val trade = NodeSpec("intra-African trade", Inc("boost"))
     val tariffs = NodeSpec("tariffs", Dec("brought down"))

--- a/webapp/app/views/index.scala.html
+++ b/webapp/app/views/index.scala.html
@@ -33,8 +33,6 @@
 
         <div id="groundedAdj" class="add-info"></div>
 
-
-
         <table id="parse"></table>
     </body>
 </html>

--- a/webapp/app/views/index.scala.html
+++ b/webapp/app/views/index.scala.html
@@ -27,9 +27,13 @@
 
         <div id="eidosMentions"></div>
 
-        <div id="groundedAdj" class="add-info"></div>
+        <br>
 
         <div id="syntax"></div>
+
+        <div id="groundedAdj" class="add-info"></div>
+
+
 
         <table id="parse"></table>
     </body>


### PR DESCRIPTION
Added triggers for inc/decrease, including the ones that @MihaiSurdeanu sent by email.
_In fact_, those were turned into tests! I know, right?!?
This is in advance of the planned rearrangement of semantically non-neutral triggers... hopefully there is more fun to come!

Also -- affirmed by the miraculous healing of the webapp (#735), I decided the stars were aligned, so I boldly moved the syntax up in the webapp display (to just below the extraction brat), something masha suggested in a diff project maybe and I liked...

ps -- i've been wanting to add more triggers for so long, this PR feels like scratching an itch! Is there a github PR label for that? :)