### PR TITLE
Deserialize groundings

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/apps/ReconstituteAndExport.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ReconstituteAndExport.scala
@@ -34,7 +34,7 @@ object ReconstituteAndExport extends App with Configured {
     println(s"Extracting from ${file.getName}")
     // 2. Get the input file contents (extractions)
     val json = FileUtils.getTextFromFile(file)
-    val corpus = deserializer.deserialize(json, reader.postProcessors)
+    val corpus = deserializer.deserialize(json)
     // 3. Export to all desired formats
     exportAs.foreach { format =>
       ExportUtils.getExporter(format, s"$outputDir/${file.getName}", reader, groundAs, topN).export(corpus)

--- a/src/main/scala/org/clulab/wm/eidos/mentions/EidosMention.scala
+++ b/src/main/scala/org/clulab/wm/eidos/mentions/EidosMention.scala
@@ -77,7 +77,7 @@ abstract class EidosMention(val odinMention: Mention, mentionMapper: MentionMapp
 }
 
 object EidosMention {
-  protected val NO_ONTOLOGY_GROUNDINGS = Map.empty[String, OntologyGrounding]
+  val NO_ONTOLOGY_GROUNDINGS = Map.empty[String, OntologyGrounding]
 
   def newEidosMention(odinMention: Mention, mentionMapper: MentionMapper): EidosMention = {
     odinMention match {

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDDeserializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDDeserializer.scala
@@ -1,6 +1,8 @@
 package org.clulab.wm.eidos.serialization.json
 
 import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.util
 
 import org.clulab.odin.Attachment
 import org.clulab.odin.CrossSentenceMention
@@ -39,7 +41,10 @@ import org.clulab.wm.eidos.document.PostProcessing
 import org.clulab.wm.eidos.document.attachments.DctDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.LocationDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.TitleDocumentAttachment
+import org.clulab.wm.eidos.groundings.OntologyAliases
+import org.clulab.wm.eidos.groundings.OntologyGrounding
 import org.clulab.wm.eidos.mentions.CrossSentenceEventMention
+import org.clulab.wm.eidos.utils.PassThruNamer
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
@@ -56,33 +61,34 @@ object IdAndValue {
       idsAndValues.map(_.value) // .toArray
 }
 
-class IdAndDct(id: String, value: DCT) extends IdAndValue[DCT](id, value)
+class IdAndDct(id: String, dct: DCT) extends IdAndValue[DCT](id, dct)
 
-class IdAndTimex(id: String, value: TimEx) extends IdAndValue[TimEx](id, value)
+class IdAndTimex(id: String, timEx: TimEx) extends IdAndValue[TimEx](id, timEx)
 
-class IdAndGeoPhraseId(id: String, value: GeoPhraseID) extends IdAndValue[GeoPhraseID](id, value)
+class IdAndGeoPhraseId(id: String, geoPhraseId: GeoPhraseID) extends IdAndValue[GeoPhraseID](id, geoPhraseId)
 
-class IdAndCountAttachment(id: String, value: CountAttachment) extends IdAndValue[CountAttachment](id, value)
+class IdAndCountAttachment(id: String, countAttachment: CountAttachment) extends IdAndValue[CountAttachment](id, countAttachment)
 
 case class WordSpec(startOffset: Int, endOffset: Int, word: String, tag: String, lemma: String, entity: String,
     norm: String, chunk: String)
-class IdAndWordSpec(id: String, value: WordSpec) extends IdAndValue[WordSpec](id, value)
+class IdAndWordSpec(id: String, wordSpec: WordSpec) extends IdAndValue[WordSpec](id, wordSpec)
 
-class IdAndSentence(id: String, value: Sentence) extends IdAndValue[Sentence](id, value)
+class IdAndSentence(id: String, sentence: Sentence) extends IdAndValue[Sentence](id, sentence)
 
 case class SentencesSpec(sentences: Array[Sentence], sentenceMap: Map[String, Int],
     timexes: Array[Seq[TimEx]], timexMap: Map[String, TimEx],
     geolocs: Array[Seq[GeoPhraseID]], geolocMap: Map[String, GeoPhraseID],
     counts: Array[Seq[CountAttachment]], countMap: Map[String, CountAttachment])
 
-class IdAndDocument(id: String, value: Document) extends IdAndValue(id, value)
+class IdAndDocument(id: String, document: Document) extends IdAndValue(id, document)
 
 case class DocumentSpec(idAndDocument: IdAndDocument, idAndDctOpt: Option[IdAndDct], sentencesSpec: SentencesSpec)
 
-class IdAndMention(id: String, value: Mention) extends IdAndValue[Mention](id,value)
+class IdAndMention(id: String, mention: Mention) extends IdAndValue[Mention](id,mention)
 
-case class Extraction(id: String, extractionType: String, extractionSubtype: String, provenance: Provenance,
-    triggerProvenanceOpt: Option[Provenance], argumentMap: Map[String, Seq[String]])
+case class Extraction(id: String, extractionType: String, extractionSubtype: String, labels: List[String],
+    foundBy: String, canonicalNameOpt: Option[String], ontologyGroundingsOpt:  Option[OntologyAliases.OntologyGroundings],
+    provenance: Provenance, triggerProvenanceOpt: Option[Provenance], argumentMap: Map[String, Seq[String]])
 
 object JLDDeserializer {
   type DocumentMap = Map[String, Document]
@@ -243,12 +249,12 @@ class JLDDeserializer {
     var geolocMap: Map[String, GeoPhraseID] = Map.empty
     var counts: List[Seq[CountAttachment]] = List.empty
     var countMap: Map[String, CountAttachment] = Map.empty
-    var sentencesOpt = sentencesValue.extractOpt[JArray].map(_.arr)
+    val sentencesOpt = sentencesValue.extractOpt[JArray].map(_.arr)
     val idsAndSentences = sentencesOpt.map { sentences => sentences.map { sentenceValue: JValue =>
       requireType(sentenceValue, JLDSentence.typename)
       val sentenceId = getId(sentenceValue)
       // A sentence, if it exists at all, must have words; therefore, no extractOpt here.
-      val idsAndWordSpecs = (sentenceValue \ "words").extract[JArray].arr.map(deserializeWordData).toArray
+      val idsAndWordSpecs: Array[IdAndWordSpec] = (sentenceValue \ "words").extract[JArray].arr.map(deserializeWordData).toArray
       val wordMap = idsAndWordSpecs.indices.map(index => idsAndWordSpecs(index).id -> index).toMap // why not directly to wordspec?
       // This doesn't work if there are double spaces in the text.  Too many elements will be made.
       // val raw: Array[String] = (sentenceValue \ "text").extract[String].split(' ')
@@ -283,16 +289,16 @@ class JLDDeserializer {
       countMap = countMap ++ idsAndCountAttachments.map { idAndCountAttachment => idAndCountAttachment.id -> idAndCountAttachment.value }
 
       // IntelliJ doesn't like these, but the compiler is OK with them.
-      val startOffsets: Array[Int] = idsAndWordSpecs.map(idAndSpec => idAndSpec.value.startOffset)
-      val endOffsets: Array[Int] = idsAndWordSpecs.map(idAndSpec => idAndSpec.value.endOffset)
+      val startOffsets: Array[Int] = idsAndWordSpecs.map(_.value.startOffset)
+      val endOffsets: Array[Int] = idsAndWordSpecs.map(_.value.endOffset)
       val raw = mkRaw(idsAndWordSpecs, documentText)
-      val words: Array[String] = idsAndWordSpecs.map(idAndSpec => idAndSpec.value.word)
+      val words: Array[String] = idsAndWordSpecs.map(_.value.word)
       val sentence = Sentence(raw, startOffsets, endOffsets, words)
-      sentence.tags = Some(idsAndWordSpecs.map(idAndSpec => idAndSpec.value.tag))
-      sentence.lemmas = Some(idsAndWordSpecs.map(idAndSpec => idAndSpec.value.lemma))
-      sentence.entities = Some(idsAndWordSpecs.map(idAndSpec => idAndSpec.value.entity))
-      sentence.norms = Some(idsAndWordSpecs.map(idAndSpec => idAndSpec.value.norm))
-      sentence.chunks = Some(idsAndWordSpecs.map(idAndSpec => idAndSpec.value.chunk))
+      sentence.tags = Some(idsAndWordSpecs.map(_.value.tag))
+      sentence.lemmas = Some(idsAndWordSpecs.map(_.value.lemma))
+      sentence.entities = Some(idsAndWordSpecs.map(_.value.entity))
+      sentence.norms = Some(idsAndWordSpecs.map(_.value.norm))
+      sentence.chunks = Some(idsAndWordSpecs.map(_.value.chunk))
       sentence.syntacticTree = None // Documented on Wiki
       sentence.graphs = graphMap
       sentence.relations = None // Documented on Wiki
@@ -356,9 +362,9 @@ class JLDDeserializer {
     val idAndDctOpt = deserializeDct(nothingToNone((documentValue \ JLDDCT.singular).extractOpt[JValue]))
     // Text is required here!  Can't otherwise make raw for sentences.
     val sentencesSpec = deserializeSentences(documentValue \ "sentences", textOpt)
-    val timexCount = sentencesSpec.timexes.map(_.size).sum
-    val geolocsCount = sentencesSpec.geolocs.map(_.size).sum
-    val countsCounts = sentencesSpec.counts.map(_.size).sum
+//    val timexCount = sentencesSpec.timexes.map(_.size).sum
+//    val geolocsCount = sentencesSpec.geolocs.map(_.size).sum
+//    val countsCounts = sentencesSpec.counts.map(_.size).sum
     val sentences = sentencesSpec.sentences
     val document = new Document(sentences)
     document.id = documentIdOpt
@@ -416,11 +422,20 @@ class JLDDeserializer {
     val extractionId = getId(extractionValue)
     val extractionType = (extractionValue \ "type").extract[String]
     val extractionSubtype = (extractionValue \ "subtype").extract[String]
+    val labels = (extractionValue \ "labels").extract[List[String]]
+    val foundBy = (extractionValue \ "rule").extract[String]
+
+    val canonicalNameOpt = (extractionValue \ "canonicalName").extractOpt[String]
+    val ontologyGroundingsOpt = (extractionValue \ "groundings").extractOpt[JArray].map { jArray =>
+      deserializeGroundings(jArray)
+    }
+
     val provenance = deserializeProvenance((extractionValue \ "provenance").extractOpt[JValue], documentMap, documentSentenceMap).get
     val triggerProvenanceOpt = deserializeTrigger((extractionValue \ "trigger").extractOpt[JValue], documentMap, documentSentenceMap)
     val argumentMap = deserializeArguments((extractionValue \ "arguments").extractOpt[JValue])
 
-    Extraction(extractionId, extractionType, extractionSubtype, provenance, triggerProvenanceOpt, argumentMap)
+    Extraction(extractionId, extractionType, extractionSubtype, labels, foundBy, canonicalNameOpt,
+        ontologyGroundingsOpt, provenance, triggerProvenanceOpt, argumentMap)
   }
 
   protected def deserializeModifier(modifierValue: JValue, documentMap: DocumentMap, documentSentenceMap: DocumentSentenceMap): (String, Provenance) = {
@@ -503,6 +518,40 @@ class JLDDeserializer {
     attachment
   }
 
+  def deserializeGroundings(groundingsValue: JArray): OntologyAliases.OntologyGroundings = {
+    val nameAndGroundings = groundingsValue.arr.map { groundingValue =>
+      requireType(groundingValue, JLDOntologyGroundings.typename)
+      val rawName = (groundingValue \ "name").extract[String]
+      val categoryOpt = (groundingValue \ "category").extractOpt[String]
+      val cookedName = categoryOpt.map { category =>
+        if (rawName.endsWith("/" + category))
+          rawName.substring(0, rawName.length - category.length - 1)
+        else
+          rawName
+      }.getOrElse(rawName)
+      val versionOpt = (groundingValue \ "version").extractOpt[String]
+      val versionDateOpt = (groundingValue \ "versionDate").extractOpt[String].map { versionDate =>
+        ZonedDateTime.parse(versionDate)
+      }
+      val valuesValue = (groundingValue \ "values").extractOpt[JArray].map { valueValue =>
+        valueValue.arr.map { value =>
+          requireType(value, JLDOntologyGrounding.typename)
+          val ontologyConcept = (value \ "ontologyConcept").extract[String]
+          val floatVal = (value \ "value").extract[Double].toFloat
+          val namer = new PassThruNamer(ontologyConcept)
+
+          (namer, floatVal)
+        }
+      }.getOrElse(List.empty)
+
+      val ontologyGrounding = OntologyGrounding(versionOpt, versionDateOpt, valuesValue, categoryOpt)
+
+      (cookedName, ontologyGrounding)
+    }
+
+    nameAndGroundings.toMap
+  }
+
   def deserializeStates(statesValueOpt: Option[JArray], documentMap: DocumentMap, documentSentenceMap: DocumentSentenceMap,
       timexMap: TimexMap, geolocMap: GeolocMap, dctMap: DctMap, countMap: CountMap): Set[Attachment] = {
     val attachments = statesValueOpt.map { statesValue =>
@@ -530,12 +579,12 @@ class JLDDeserializer {
     requireType(extractionValue, JLDExtraction.typename)
     val extractionType = extraction.extractionType
     val extractionSubtype = extraction.extractionSubtype
-    val labels = (extractionValue \ "labels").extract[List[String]]
+    val labels = extraction.labels
     val tokenInterval = extraction.provenance.interval
     val sentence = extraction.provenance.sentence
     val document = extraction.provenance.document
     val keep = true // Documented on Wiki
-    val foundBy = (extractionValue \ "rule").extract[String]
+    val foundBy = extraction.foundBy
     val paths: Map[String, Map[Mention, SynPath]] = Map.empty // Documented on Wiki
     val misnamedArguments: Map[String, Seq[Mention]] = extraction.argumentMap.map { case (name, ids) =>
       name -> ids.map { id => mentionMap(id) }
@@ -675,7 +724,7 @@ class JLDDeserializer {
     remainingMentions
   }
 
-  def deserializeCorpus(corpusValue: JValue, postProcessors: Seq[PostProcessing]): Corpus = {
+  def deserializeCorpus(corpusValue: JValue /*, postProcessors: Seq[PostProcessing]*/): Corpus = {
     requireType(corpusValue, JLDCorpus.typename)
     // A corpus with no documents is hardly a corpus, so no extractOpt is used (for now).
     val documentSpecs = (corpusValue \ "documents").extract[JArray].arr.map(deserializeDocument)
@@ -715,21 +764,53 @@ class JLDDeserializer {
     val annotatedDocuments = documentSpecs.map { documentSpec =>
       val document = documentSpec.idAndDocument.value
       val annotatedDocument = AnnotatedDocument(document, odinMentions)
-      val lastAnnotatedDocument = postProcessors.foldLeft(annotatedDocument) { (nextAnnotatedDocument, postProcessor) =>
-        postProcessor.process(nextAnnotatedDocument)
-      }
+      // This one will use the deserialized groundings.
+      val newAnnotatedDocument = addEidosExtras1(annotatedDocument, extractions, mentionMap)
+      // This one will rerun the postProcessors, which hopefully match what was used
+      // for the original grounding.
+      // val newAnnotatedDocument = addEidosExtras2(annotatedDocument, postProcessors)
 
-      lastAnnotatedDocument
+      newAnnotatedDocument
     }
     val corpus = annotatedDocuments
 
     corpus
   }
 
-  // TODO: Remove these post processors.  Deserialize completely here without their help.
-  def deserialize(json: String, postProcessors: Seq[PostProcessing]): Corpus = {
+  def addEidosExtras1(annotatedDocument: AnnotatedDocument, extractions: Seq[Extraction],
+      mentionMap: Map[String, Mention]): AnnotatedDocument = {
+    val extractionsMap = extractions.map { extraction => extraction.id -> extraction }.toMap
+    val mentionToExtractionMap = new util.IdentityHashMap[Mention, Extraction]()
+
+    mentionMap.foreach { case (id, mention) =>
+      mentionToExtractionMap.put(mention, extractionsMap(id))
+    }
+    annotatedDocument.allEidosMentions.foreach { eidosMention =>
+      val odinMention = eidosMention.odinMention
+      // There could be a "fabricated" trigger mention which is not included in the map, because we only track
+      // provenance for those in the jsonld and there isn't an entry in the map for them.
+      val extractionOpt = Option(mentionToExtractionMap.get(odinMention))
+
+      extractionOpt.foreach { extraction =>
+        extraction.canonicalNameOpt.foreach { canonicalName => eidosMention.canonicalName = canonicalName }
+        extraction.ontologyGroundingsOpt.foreach { ontologyGroundings => eidosMention.grounding = ontologyGroundings }
+      }
+    }
+
+    annotatedDocument
+  }
+
+  def addEidosExtras2(annotatedDocument: AnnotatedDocument, postProcessors: Seq[PostProcessing]): AnnotatedDocument = {
+    val lastAnnotatedDocument = postProcessors.foldLeft(annotatedDocument) { (nextAnnotatedDocument, postProcessor) =>
+      postProcessor.process(nextAnnotatedDocument)
+    }
+
+    lastAnnotatedDocument
+  }
+
+  def deserialize(json: String /*, postProcessors: Seq[PostProcessing]*/): Corpus = {
     val jValue: JValue = parse(json)
-    val corpus = deserializeCorpus(jValue, postProcessors)
+    val corpus = deserializeCorpus(jValue) // , postProcessors)
     corpus
   }
 }

--- a/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/json/JLDSerializer.scala
@@ -179,7 +179,7 @@ object JLDArgument {
 }
 
 class JLDOntologyGrounding(serializer: JLDSerializer, name: String, value: Float)
-    extends JLDObject(serializer, "Grounding") {
+    extends JLDObject(serializer, JLDOntologyGrounding.typename) {
 
   override def toJObject: TidyJObject = TidyJObject(List(
     serializer.mkType(this),
@@ -189,12 +189,13 @@ class JLDOntologyGrounding(serializer: JLDSerializer, name: String, value: Float
 }
 
 object JLDOntologyGrounding {
+  val typename = "Grounding"
   val singular = "grounding"
   val plural: String = singular // Mass noun
 }
 
 class JLDOntologyGroundings(serializer: JLDSerializer, name: String, grounding: OntologyGrounding)
-    extends JLDObject(serializer, "Groundings") {
+    extends JLDObject(serializer, JLDOntologyGroundings.typename) {
   val jldGroundings: Seq[JObject] = grounding.grounding.map { case (namer, value) =>
     new JLDOntologyGrounding(serializer, namer.name, value).toJObject
   }
@@ -211,6 +212,7 @@ class JLDOntologyGroundings(serializer: JLDSerializer, name: String, grounding: 
 }
 
 object JLDOntologyGroundings {
+  val typename = "Groundings"
   val singular = "groundings"
   val plural: String = singular
 }
@@ -1043,7 +1045,10 @@ class JLDCorpus protected (serializer: JLDSerializer, corpus: Corpus) extends JL
             if (leftAttachmentNames != rightAttachmentNames)
               leftAttachmentNames < rightAttachmentNames
             else
-              true // Tie goes in favor of the left just because it came first.
+              if (leftOdinMention.foundBy != rightOdinMention.foundBy)
+                leftOdinMention.foundBy < rightOdinMention.foundBy
+              else
+                true // Tie goes in favor of the left just because it came first.
         }
       }
     }

--- a/src/test/scala/org/clulab/wm/eidos/serialization/TestDocSerialization.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/TestDocSerialization.scala
@@ -105,7 +105,7 @@ class TestDocSerialization extends Test {
         val jldCorpus = new JLDEidosCorpus(corpus)
         val jValue = jldCorpus.serialize()
         val json = stringify(jValue, pretty = true)
-        val copy = new JLDDeserializer().deserialize(json, reader.postProcessors)
+        val copy = new JLDDeserializer().deserialize(json)
 
         copy should not be (None)
 //        copy should be (original)

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDDeserializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJLDDeserializer.scala
@@ -38,7 +38,6 @@ import org.clulab.wm.eidos.serialization.json.JLDDeserializer.DctMap
 import org.clulab.wm.eidos.serialization.json.JLDDeserializer.GeolocMap
 import org.clulab.wm.eidos.serialization.json.JLDDeserializer.MentionMap
 import org.clulab.wm.eidos.serialization.json.JLDDeserializer.ProvenanceMap
-import org.clulab.wm.eidos.utils.Canonicalizer
 import org.clulab.wm.eidos.utils.FileUtils
 import org.clulab.wm.eidos.utils.FileUtils.findFiles
 import org.json4s.JArray
@@ -46,7 +45,7 @@ import org.json4s.JArray
 import scala.collection.Seq
 
 class TestJLDDeserializer extends ExtractionTest {
-  val adjectiveGrounder = EidosAdjectiveGrounder.fromEidosConfig(config)
+  val adjectiveGrounder: EidosAdjectiveGrounder = EidosAdjectiveGrounder.fromEidosConfig(config)
 
   def newTitledAnnotatedDocument(text: String): AnnotatedDocument = newTitledAnnotatedDocument(text, text)
   
@@ -60,11 +59,11 @@ class TestJLDDeserializer extends ExtractionTest {
     annotatedDocument
   }
 
-  def serialize(corpus: Corpus) = {
+  def serialize(corpus: Corpus): String = {
     val json = {
       val jldCorpus = new JLDEidosCorpus(corpus)
       val jValue = jldCorpus.serialize(adjectiveGrounder)
-      stringify(jValue, true)
+      stringify(jValue, pretty = true)
     }
     
     json
@@ -76,7 +75,7 @@ class TestJLDDeserializer extends ExtractionTest {
   behavior of "JLDDeserializer"
 
 
-  def testParts() = {
+  def testParts(): Unit = {
     it should "deserialize DCT from jsonld" in {
       val json = """
         |{
@@ -191,7 +190,7 @@ class TestJLDDeserializer extends ExtractionTest {
       val wordDataValue = parse(json)
       val idAndWordData = new JLDDeserializer().deserializeWordData(wordDataValue)
       val id = idAndWordData.id
-      val wordData = idAndWordData.value
+//      val wordData = idAndWordData.value
 
       id should be("_:Word_19")
     }
@@ -210,7 +209,7 @@ class TestJLDDeserializer extends ExtractionTest {
         |}""".stripMargin
       val wordMap = Map("_:Word_2" -> 2, "_:Word_1" -> 1)
       val dependencyValue = parse(json)
-      val dependency = new JLDDeserializer().deserializeDependency(dependencyValue, wordMap)
+      /*val dependency =*/ new JLDDeserializer().deserializeDependency(dependencyValue, wordMap)
     }
 
     it should "deserialize Sentence from jsonld" in {
@@ -332,7 +331,7 @@ class TestJLDDeserializer extends ExtractionTest {
         |  } ]
         |} ]""".stripMargin
       val sentencesValue = parse(json)
-      val sentenceSpec = new JLDDeserializer().deserializeSentences(sentencesValue, Some(documentText))
+      /*val sentenceSpec =*/ new JLDDeserializer().deserializeSentences(sentencesValue, Some(documentText))
     }
 
     it should "deserialize Interval from jsonld" in {
@@ -373,7 +372,7 @@ class TestJLDDeserializer extends ExtractionTest {
       val provenanceValue = parse(json)
       val documentMap: DocumentMap = Map("_:Document_1" -> null)
       val documentSentenceMap: DocumentSentenceMap = Map("_:Document_1" -> Map("_:Sentence_35" -> 34))
-      val provenance = new JLDDeserializer().deserializeProvenance(Option(provenanceValue), documentMap, documentSentenceMap)
+      /*val provenance =*/ new JLDDeserializer().deserializeProvenance(Option(provenanceValue), documentMap, documentSentenceMap)
     }
 
     it should "deserialize Trigger from jsonld" in {
@@ -404,7 +403,7 @@ class TestJLDDeserializer extends ExtractionTest {
       val triggerValue = Option(parse(json))
       val documentMap: DocumentMap = Map("_:Document_1" -> null)
       val documentSentenceMap: DocumentSentenceMap = Map("_:Document_1" -> Map("_:Sentence_35" -> 0))
-      val provenanceOpt = new JLDDeserializer().deserializeTrigger(triggerValue, documentMap, documentSentenceMap)
+      /*val provenanceOpt =*/ new JLDDeserializer().deserializeTrigger(triggerValue, documentMap, documentSentenceMap)
     }
 
     it should "deserialize Extraction from jsonld" in {
@@ -418,6 +417,14 @@ class TestJLDDeserializer extends ExtractionTest {
         |  "text" : "conflict are also forcing many families to leave South Sudan for neighbouring countries",
         |  "rule" : "ported_syntax_1_verb-Causal",
         |  "canonicalName" : "conflict force leave",
+        |  "groundings" : [ {
+        |    "@type" : "Groundings",
+        |    "name" : "wm"
+        |  }, {
+        |    "@type" : "Groundings",
+        |    "name" : "wm_compositional/concept",
+        |    "category" : "concept"
+        |  } ],
         |  "provenance" : [ {
         |    "@type" : "Provenance",
         |    "document" : {
@@ -477,7 +484,7 @@ class TestJLDDeserializer extends ExtractionTest {
       val extractionValue = parse(json)
       val documentMap: DocumentMap = Map("_:Document_1" -> null)
       val documentSentenceMap: DocumentSentenceMap = Map("_:Document_1" -> Map("_:Sentence_7" -> 0))
-      val extraction = new JLDDeserializer().deserializeExtraction(extractionValue, documentMap, documentSentenceMap)
+      /*val extraction =*/ new JLDDeserializer().deserializeExtraction(extractionValue, documentMap, documentSentenceMap)
     }
 
     it should "deserialize Modifiers from jsonld" in {
@@ -511,7 +518,7 @@ class TestJLDDeserializer extends ExtractionTest {
       val modifiersValue = parse(json).asInstanceOf[JArray]
       val documentMap: DocumentMap = Map("_:Document_1" -> null)
       val documentSentenceMap: DocumentSentenceMap = Map("_:Document_1" -> Map("_:Sentence_253" -> 0))
-      val (textsOpt, provenancesOpt) = new JLDDeserializer().deserializeModifiers(Option(modifiersValue), documentMap, documentSentenceMap)
+      /*val (textsOpt, provenancesOpt) =*/ new JLDDeserializer().deserializeModifiers(Option(modifiersValue), documentMap, documentSentenceMap)
     }
 
     it should "deserialize States from jsonld" in {
@@ -667,7 +674,7 @@ class TestJLDDeserializer extends ExtractionTest {
         |  }
         |} ]""".stripMargin
       val argumentsValue = parse(json).asInstanceOf[JArray]
-      val argumentMap = new JLDDeserializer().deserializeArguments(Option(argumentsValue))
+      /*val argumentMap =*/ new JLDDeserializer().deserializeArguments(Option(argumentsValue))
     }
 
     it should "deserialize Mention from jsonld" in {
@@ -681,6 +688,22 @@ class TestJLDDeserializer extends ExtractionTest {
         |  "text" : "Prices",
         |  "rule" : "simple-np++property-lexiconner",
         |  "canonicalName" : "Prices",
+        |  "groundings" : [ {
+        |    "@type" : "Groundings",
+        |    "name" : "wm_compositional/concept",
+        |    "category" : "concept",
+        |    "version" : "359829afbe9bb5ba9af990121c1bd936a52e7a2e",
+        |    "versionDate" : "2019-02-24T01:21:07Z",
+        |    "values" : [ {
+        |      "@type" : "Grounding",
+        |      "ontologyConcept" : "wm_compositional/concept/causal_factor/economic_and_commerce/economic activity/market/revenue",
+        |      "value" : 0.5095548033714294
+        |    } ]
+        |  }, {
+        |    "@type" : "Groundings",
+        |    "name" : "wm_compositional/property",
+        |    "category" : "property"
+        |  } ],
         |  "provenance" : [ {
         |    "@type" : "Provenance",
         |    "document" : {
@@ -725,14 +748,13 @@ class TestJLDDeserializer extends ExtractionTest {
       val mentionMap: MentionMap = Map.empty
       val provenanceMap: ProvenanceMap = Map(Provenance(null, 480, Interval(0, 1)) -> "_:Extraction_1")
       val dctMap: DctMap = Map.empty
-      val mention = new JLDDeserializer().deserializeMention(extractionValue, extraction, mentionMap,
+      /*val mention =*/ new JLDDeserializer().deserializeMention(extractionValue, extraction, mentionMap,
         documentMap, documentSentenceMap, timexMap, geolocMap, provenanceMap, dctMap, countMap)
     }
   }
 
-  def testCrossSentenceEventMention() = {
+  def testCrossSentenceEventMention(): Unit = {
     it should "deserialize CrossSentenceEventMention from jsonld" in {
-      val canonicalizer = ieSystem.components.ontologyHandler.canonicalizer
 
       def serialize(original: AnnotatedDocument): String = {
         val corpus = Seq(original)
@@ -747,43 +769,62 @@ class TestJLDDeserializer extends ExtractionTest {
       val text = "300 refugees fled South Sudan; they left the country for Ethiopia. They left in 1997."
       val annotatedDocument = ieSystem.extractFromText(text)
       val json = serialize(annotatedDocument)
-      val copy = new JLDDeserializer().deserialize(json, ieSystem.postProcessors)
+      val copy = new JLDDeserializer().deserialize(json)
       val mentions = copy.head.odinMentions
 
       mentions.count(_.isInstanceOf[CrossSentenceEventMention]) should be(1)
     }
   }
 
-  def testCorpus(text: String, name: String) = {
+  def testCorpus(text: String, name: String): Unit = {
     it should "deserialize corpus " + name + " from jsonld" in {
-      val canonicalizer = new Canonicalizer(ieSystem.components.stopwordManager)
-
       val oldCorpus = Seq(newTitledAnnotatedDocument(text, name))
       val oldJson = serialize(oldCorpus)
 
-      val newCorpus = new JLDDeserializer().deserialize(oldJson, ieSystem.postProcessors)
+      val newCorpus = new JLDDeserializer().deserialize(oldJson)
       val newJson = serialize(newCorpus)
 
       val oldLineCount = oldJson.count(_ == '\n')
       val newLineCount = newJson.count(_ == '\n')
 
       oldLineCount should be (newLineCount)
-      oldJson.size should be (newJson.size)
+      oldJson.length should be (newJson.length)
       oldJson should be (newJson)
     }
   }
 
-  def testFiles(directoryName: String): Unit = {
+  def testTextFiles(directoryName: String): Unit = {
     val files = findFiles(directoryName, "txt")
 
     files.foreach { file =>
       val text = FileUtils.getTextFromFile(file)
 
-      testCorpus(text, file.getName())
+      testCorpus(text, file.getName)
     }
   }
 
-  def testSentences() = {
+  def testJsonldFiles(directoryName: String): Unit = {
+    val files = findFiles(directoryName, "jsonld")
+
+    files.foreach { file =>
+      val oldText = FileUtils.getTextFromFile(file)
+      val oldCorpus = new JLDDeserializer().deserialize(oldText)
+      val newText = serialize(oldCorpus)
+      val newCorpus = new JLDDeserializer().deserialize(newText)
+      val newerText = serialize(newCorpus)
+
+      val oldCanonicalText = oldText.trim.replace("\r", "")
+      val newCanonicalText = newText.trim.replace("\r", "")
+      val newerCanonicalText = newerText.trim.replace("\r", "")
+
+      if (oldCanonicalText != newCanonicalText)
+        println("There was a first problem with " + file.getAbsolutePath)
+      if (newCanonicalText != newerCanonicalText)
+        println("There was a second problem with " + file.getAbsolutePath)
+    }
+  }
+
+  def testSentences(): Unit = {
     testCorpus(p1s1, "p1s1")
     testCorpus(p1s2, "p1s2")
     testCorpus(p1s3, "p1s3")
@@ -817,7 +858,7 @@ class TestJLDDeserializer extends ExtractionTest {
     testCorpus("", "noTextCorpus")
   }
 
-  def testParagraphs() = {
+  def testParagraphs(): Unit = {
     testCorpus(p1, "p1")
     testCorpus(p2, "p2")
     testCorpus(p3, "p3")
@@ -826,7 +867,7 @@ class TestJLDDeserializer extends ExtractionTest {
     testCorpus(p6, "p6")
   }
 
-  def testDocuments() = {
+  def testDocuments(): Unit = {
     testCorpus(fullText, "fullText")
   }
 
@@ -835,7 +876,9 @@ class TestJLDDeserializer extends ExtractionTest {
   testParagraphs()
   testDocuments()
   testCrossSentenceEventMention()
+
   // Do not run this last test on Travis, but instead periodically on a real corpus
   // with all options enabled (useW2V, useTimeNorm, useGeoNorm, etc.)
-//  testFiles("../corpora/Doc52/txt")
+//  testTextFiles("../corpora/Doc52/txt")
+//  testJsonldFiles("../jsonldtmp")
 }


### PR DESCRIPTION
Groundings are now stored in an EidosMention var, so they can and should be set upon deserialization.  This was previously impossible because they were a lazy val.