### PR TITLE
Remove warnings for imports hiding local classes

### DIFF
--- a/src/test/scala/org/clulab/wm/eidos/utils/TestCloser.scala
+++ b/src/test/scala/org/clulab/wm/eidos/utils/TestCloser.scala
@@ -1,7 +1,6 @@
 package org.clulab.wm.eidos.utils
 
 import org.clulab.wm.eidos.test.TestUtils._
-import org.clulab.wm.eidos.utils.Closer
 
 class TestCloser extends Test {
 

--- a/src/test/scala/org/clulab/wm/eidos/utils/TestFileEditor.scala
+++ b/src/test/scala/org/clulab/wm/eidos/utils/TestFileEditor.scala
@@ -3,7 +3,6 @@ package org.clulab.wm.eidos.utils
 import java.io.File
 
 import org.clulab.wm.eidos.test.TestUtils._
-import org.clulab.wm.eidos.utils.FileEditor
 
 class TestFileEditor extends Test {
   

--- a/src/test/scala/org/clulab/wm/eidos/utils/TestLoop.scala
+++ b/src/test/scala/org/clulab/wm/eidos/utils/TestLoop.scala
@@ -1,7 +1,6 @@
 package org.clulab.wm.eidos.utils
 
 import org.clulab.wm.eidos.test.TestUtils._
-import org.clulab.wm.eidos.utils.Timer
 
 import scala.annotation.tailrec
 

--- a/src/test/scala/org/clulab/wm/eidos/utils/TestQuicklyEqualable.scala
+++ b/src/test/scala/org/clulab/wm/eidos/utils/TestQuicklyEqualable.scala
@@ -2,7 +2,6 @@
 package org.clulab.wm.eidos.utils
 
 import org.clulab.wm.eidos.test.TestUtils._
-import org.clulab.wm.eidos.utils.QuicklyEqualable
 
 class TestQuicklyEqualable extends Test {
 

--- a/src/test/scala/org/clulab/wm/eidos/utils/TestThreading.scala
+++ b/src/test/scala/org/clulab/wm/eidos/utils/TestThreading.scala
@@ -1,7 +1,6 @@
 package org.clulab.wm.eidos.utils
 
 import org.clulab.wm.eidos.test.TestUtils._
-import org.clulab.wm.eidos.utils.ThreadUtils
 
 import scala.collection.parallel.ForkJoinTaskSupport
 


### PR DESCRIPTION
This is just for the test branch compilation which we don't usually observe