### PR TITLE
Add special characters to stop list

### DIFF
--- a/src/main/resources/org/clulab/wm/eidos/english/filtering/stops.txt
+++ b/src/main/resources/org/clulab/wm/eidos/english/filtering/stops.txt
@@ -56,6 +56,8 @@ g
 kg
 ml
 l
+%
+~
 # Discourse
 further
 however


### PR DESCRIPTION
This partially addresses https://github.com/clulab/eidos/issues/827 by adding % and ~ to the stop list since they are frequently picked up as entities.