### PR TITLE
Organize the various serialization formats better

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ package org.yourself.eidosClient
 import scala.collection.Seq
 import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 
 object YourClassName extends App {
   val text = "Water trucking has decreased due to the cost of fuel."

--- a/src/main/scala/org/clulab/wm/eidos/apps/AnnotationSheetAndSummary.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/AnnotationSheetAndSummary.scala
@@ -10,7 +10,7 @@ import org.clulab.utils.Configured
 import org.clulab.wm.eidos.{EidosSystem, utils}
 import org.clulab.wm.eidos.document.AnnotatedDocument
 import org.clulab.wm.eidos.exporters.GroundingAnnotationExporter
-import org.clulab.wm.eidos.serialization.json.JLDDeserializer
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer
 import org.clulab.wm.eidos.utils.{CsvWriter, FileUtils, FoundBy, ThreadUtils}
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractDocumentFromDirectory.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractDocumentFromDirectory.scala
@@ -5,7 +5,7 @@ import org.clulab.serialization.DocumentSerializer
 import org.clulab.serialization.json.{JSONSerializer, stringify}
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.document.AnnotatedDocument
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
 import org.json4s.jackson.JsonMethods

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractFromDirectory.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractFromDirectory.scala
@@ -3,7 +3,7 @@ package org.clulab.wm.eidos.apps
 import java.io.File
 
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
 

--- a/src/main/scala/org/clulab/wm/eidos/apps/ExtractJsonLDFromFile.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ExtractJsonLDFromFile.scala
@@ -2,7 +2,7 @@ package org.clulab.wm.eidos.apps
 
 import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
 

--- a/src/main/scala/org/clulab/wm/eidos/apps/ReconstituteAndExport.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ReconstituteAndExport.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import org.clulab.utils.Configured
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.exporters.Exporter
-import org.clulab.wm.eidos.serialization.json.JLDDeserializer
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer
 import org.clulab.wm.eidos.utils.FileUtils
 
 /**

--- a/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCdrMetaFromDirectory.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCdrMetaFromDirectory.scala
@@ -1,7 +1,7 @@
 package org.clulab.wm.eidos.apps.batch
 
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileEditor
 import org.clulab.wm.eidos.utils.FileUtils

--- a/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCluFromDirectoryFiltered.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCluFromDirectoryFiltered.scala
@@ -3,7 +3,7 @@ package org.clulab.wm.eidos.apps.batch
 import java.io.File
 
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
 import org.clulab.wm.eidos.utils.meta.CluText

--- a/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCluMetaFromDirectory.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCluMetaFromDirectory.scala
@@ -5,7 +5,7 @@ import java.io.File
 import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.groundings.EidosAdjectiveGrounder
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileEditor
 import org.clulab.wm.eidos.utils.FileUtils

--- a/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCluMetaFromDirectoryFiltered.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCluMetaFromDirectoryFiltered.scala
@@ -12,7 +12,7 @@ import java.nio.charset.StandardCharsets
 import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.groundings.EidosAdjectiveGrounder
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileEditor
 import org.clulab.wm.eidos.utils.FileUtils

--- a/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCluMetaFromDirectoryWithId.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/batch/ExtractCluMetaFromDirectoryWithId.scala
@@ -1,7 +1,7 @@
 package org.clulab.wm.eidos.apps.batch
 
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileEditor
 import org.clulab.wm.eidos.utils.FileUtils

--- a/src/main/scala/org/clulab/wm/eidos/apps/examples/ExtractFromText.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/examples/ExtractFromText.scala
@@ -4,7 +4,7 @@ import scala.collection.Seq
 import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.serialization.json.WMJSONSerializer
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.DisplayUtils.displayMention
 
 object ExtractFromText extends App {

--- a/src/main/scala/org/clulab/wm/eidos/attachments/EidosAttachment.scala
+++ b/src/main/scala/org/clulab/wm/eidos/attachments/EidosAttachment.scala
@@ -13,8 +13,12 @@ import org.clulab.wm.eidos.context.TimEx
 import org.clulab.wm.eidos.context.TimeStep
 import org.clulab.wm.eidos.groundings.AdjectiveGrounder
 import org.clulab.wm.eidos.groundings.AdjectiveGrounding
-import org.clulab.wm.eidos.serialization.json.JLDCountAttachment
-import org.clulab.wm.eidos.serialization.json.{JLDAttachment => JLDEidosAttachment, JLDContextAttachment => JLDEidosContextAttachment, JLDScoredAttachment => JLDEidosScoredAttachment, JLDSerializer => JLDEidosSerializer, JLDTriggeredAttachment => JLDEidosTriggeredAttachment}
+import org.clulab.wm.eidos.serialization.jsonld.JLDAttachment
+import org.clulab.wm.eidos.serialization.jsonld.JLDContextAttachment
+import org.clulab.wm.eidos.serialization.jsonld.JLDCountAttachment
+import org.clulab.wm.eidos.serialization.jsonld.JLDScoredAttachment
+import org.clulab.wm.eidos.serialization.jsonld.JLDSerializer
+import org.clulab.wm.eidos.serialization.jsonld.JLDTriggeredAttachment
 import org.clulab.wm.eidos.utils.QuicklyEqualable
 import org.json4s._
 import org.json4s.JsonDSL._
@@ -33,7 +37,7 @@ abstract class EidosAttachment extends Attachment with Serializable with Quickly
   @BeanProperty val argumentSize: Int = 0
 
   // Support for JLD serialization
-  def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment
+  def newJLDAttachment(serializer: JLDSerializer): JLDAttachment
 
   // Support for JSON serialization
   def toJson: JValue
@@ -195,8 +199,8 @@ abstract class TriggeredAttachment(@BeanProperty val trigger: String, @BeanPrope
     mix(trigger.##, sortedQuantifiers.##)
   }
 
-  def newJLDTriggeredAttachment(serializer: JLDEidosSerializer, kind: String): JLDEidosTriggeredAttachment =
-      new JLDEidosTriggeredAttachment(serializer, kind, this)
+  def newJLDTriggeredAttachment(serializer: JLDSerializer, kind: String): JLDTriggeredAttachment =
+      new JLDTriggeredAttachment(serializer, kind, this)
 
   def toJson(label: String): JValue = {
     val quants =
@@ -288,7 +292,7 @@ class Quantification(trigger: String, quantifiers: Option[Seq[String]],
     triggerProvenance: Option[Provenance] = None, quantifierProvenances: Option[Seq[Provenance]] = None)
     extends TriggeredAttachment(trigger, quantifiers, triggerProvenance, quantifierProvenances) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
       newJLDTriggeredAttachment(serializer, Quantification.kind)
 
   override def toJson: JValue = toJson(Quantification.label)
@@ -314,7 +318,7 @@ class Property(trigger: String, quantifiers: Option[Seq[String]],
     triggerProvenance: Option[Provenance] = None, quantifierProvenances: Option[Seq[Provenance]] = None)
     extends TriggeredAttachment(trigger, quantifiers, triggerProvenance, quantifierProvenances) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
     newJLDTriggeredAttachment(serializer, Property.kind)
 
   override def toJson: JValue = toJson(Property.label)
@@ -340,7 +344,7 @@ class Increase(trigger: String, quantifiers: Option[Seq[String]],
     triggerProvenance: Option[Provenance] = None, quantifierProvenances: Option[Seq[Provenance]] = None)
     extends TriggeredAttachment(trigger, quantifiers, triggerProvenance, quantifierProvenances) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
       newJLDTriggeredAttachment(serializer, Increase.kind)
 
   override def toJson: JValue = toJson(Increase.label)
@@ -366,7 +370,7 @@ class Decrease(trigger: String, quantifiers: Option[Seq[String]],
     triggerProvenance: Option[Provenance] = None, quantifierProvenances: Option[Seq[Provenance]] = None)
     extends TriggeredAttachment(trigger, quantifiers, triggerProvenance, quantifierProvenances) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
       newJLDTriggeredAttachment(serializer, Decrease.kind)
 
   override def toJson: JValue = toJson(Decrease.label)
@@ -392,7 +396,7 @@ class PosChange(trigger: String, quantifiers: Option[Seq[String]],
                 triggerProvenance: Option[Provenance] = None, quantifierProvenances: Option[Seq[Provenance]] = None)
   extends TriggeredAttachment(trigger, quantifiers, triggerProvenance, quantifierProvenances) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
     newJLDTriggeredAttachment(serializer, PosChange.kind)
 
   override def toJson: JValue = toJson(PosChange.label)
@@ -418,7 +422,7 @@ class NegChange(trigger: String, quantifiers: Option[Seq[String]],
                 triggerProvenance: Option[Provenance] = None, quantifierProvenances: Option[Seq[Provenance]] = None)
   extends TriggeredAttachment(trigger, quantifiers, triggerProvenance, quantifierProvenances) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
     newJLDTriggeredAttachment(serializer, NegChange.kind)
 
   override def toJson: JValue = toJson(NegChange.label)
@@ -444,7 +448,7 @@ class Hedging(trigger: String, quantifiers: Option[Seq[String]],
     triggerProvenance: Option[Provenance] = None, quantifierProvenances: Option[Seq[Provenance]] = None)
     extends TriggeredAttachment(trigger, quantifiers, triggerProvenance, quantifierProvenances) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment = newJLDTriggeredAttachment(serializer, Hedging.kind)
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment = newJLDTriggeredAttachment(serializer, Hedging.kind)
 
   override def toJson: JValue = toJson(Hedging.label)
 }
@@ -461,7 +465,7 @@ class Negation(trigger: String, quantifiers: Option[Seq[String]],
     triggerProvenance: Option[Provenance] = None, quantifierProvenances: Option[Seq[Provenance]] = None)
     extends TriggeredAttachment(trigger, quantifiers, triggerProvenance, quantifierProvenances) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment = newJLDTriggeredAttachment(serializer, Negation.kind)
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment = newJLDTriggeredAttachment(serializer, Negation.kind)
 
   override def toJson: JValue = toJson(Negation.label)
 }
@@ -480,8 +484,8 @@ abstract class ContextAttachment(val text: String, val value: Object) extends Ei
     getClass.getSimpleName + "(" + text + ")"
   }
 
-  def newJLDContextAttachment(serializer: JLDEidosSerializer, kind: String): JLDEidosContextAttachment =
-    new JLDEidosContextAttachment(serializer, kind, this)
+  def newJLDContextAttachment(serializer: JLDSerializer, kind: String): JLDContextAttachment =
+    new JLDContextAttachment(serializer, kind, this)
 
   def toJson(label: String): JValue = {
     EidosAttachment.TYPE -> label
@@ -505,7 +509,7 @@ object ContextAttachment {
 @SerialVersionUID(1L)
 class Time(val interval: TimEx) extends ContextAttachment(interval.text, interval) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
     newJLDContextAttachment(serializer, Time.kind)
 
   override def toJson: JValue = {
@@ -588,7 +592,7 @@ object Time {
 @SerialVersionUID(1L)
 class Location(val geoPhraseID: GeoPhraseID) extends ContextAttachment(geoPhraseID.text, geoPhraseID) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
     newJLDContextAttachment(serializer, Location.kind)
 
   override def toJson: JValue = ("type" -> Location.label) ~
@@ -652,7 +656,7 @@ object Location {
 @SerialVersionUID(1L)
 class DCTime(val dct: DCT) extends ContextAttachment(dct.text, dct) {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
     newJLDContextAttachment(serializer, DCTime.kind)
 
   override def toJson: JValue = ("type" -> DCTime.label) ~
@@ -697,8 +701,8 @@ object DCTime {
 @SerialVersionUID(1L)
 class Score(val score: Double) extends EidosAttachment {
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
-    new JLDEidosScoredAttachment(serializer, Score.kind, this)
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
+    new JLDScoredAttachment(serializer, Score.kind, this)
 
   override def equals(other: Any): Boolean = {
     if (other.isInstanceOf[Score]) {
@@ -760,7 +764,7 @@ class CountAttachment(text: String, val migrationGroupCount: MigrationGroupCount
   override def toString: String =
       s"""${CountAttachment.kind}("$text", value=${migrationGroupCount.value}, mod=${migrationGroupCount.modifier}, unit=${migrationGroupCount.unit})"""
 
-  override def newJLDAttachment(serializer: JLDEidosSerializer): JLDEidosAttachment =
+  override def newJLDAttachment(serializer: JLDSerializer): JLDAttachment =
       newJLDContextAttachment(serializer, JLDCountAttachment.typename)
 
   override def toJson: JValue = (EidosAttachment.TYPE -> CountAttachment.label) ~

--- a/src/main/scala/org/clulab/wm/eidos/exporters/JSONLDExporter.scala
+++ b/src/main/scala/org/clulab/wm/eidos/exporters/JSONLDExporter.scala
@@ -3,7 +3,7 @@ package org.clulab.wm.eidos.exporters
 import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.document.AnnotatedDocument
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
 

--- a/src/main/scala/org/clulab/wm/eidos/exporters/RegroundExporter.scala
+++ b/src/main/scala/org/clulab/wm/eidos/exporters/RegroundExporter.scala
@@ -3,7 +3,7 @@ package org.clulab.wm.eidos.exporters
 import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.document.AnnotatedDocument
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
 

--- a/src/main/scala/org/clulab/wm/eidos/serialization/jsonld/JLDDeserializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/jsonld/JLDDeserializer.scala
@@ -1,4 +1,4 @@
-package org.clulab.wm.eidos.serialization.json
+package org.clulab.wm.eidos.serialization.jsonld
 
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
@@ -16,27 +16,31 @@ import org.clulab.struct.DirectedGraph
 import org.clulab.struct.Edge
 import org.clulab.struct.GraphMap
 import org.clulab.struct.Interval
-import org.clulab.wm.eidos.attachments.{CountAttachment, CountModifier, CountUnit, DCTime, Decrease, Hedging, Increase, Location, MigrationGroupCount, NegChange, Negation, PosChange, Property, Provenance, Quantification, Time}
 import org.clulab.timenorm.scate.SimpleInterval
 import org.clulab.wm.eidos.actions.MigrationHandler
+import org.clulab.wm.eidos.attachments.CountAttachment
+import org.clulab.wm.eidos.attachments.CountModifier
+import org.clulab.wm.eidos.attachments.CountUnit
 import org.clulab.wm.eidos.attachments.DCTime
 import org.clulab.wm.eidos.attachments.Decrease
 import org.clulab.wm.eidos.attachments.Hedging
 import org.clulab.wm.eidos.attachments.Increase
 import org.clulab.wm.eidos.attachments.Location
 import org.clulab.wm.eidos.attachments.MigrationGroupCount
+import org.clulab.wm.eidos.attachments.NegChange
 import org.clulab.wm.eidos.attachments.Negation
-import org.clulab.wm.eidos.attachments.Time
-import org.clulab.wm.eidos.attachments.{Property, Quantification}
-import org.clulab.wm.eidos.document.AnnotatedDocument
-import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
-import org.clulab.wm.eidos.mentions.EidosMention
+import org.clulab.wm.eidos.attachments.PosChange
+import org.clulab.wm.eidos.attachments.Property
 import org.clulab.wm.eidos.attachments.Provenance
+import org.clulab.wm.eidos.attachments.Quantification
+import org.clulab.wm.eidos.attachments.Time
 import org.clulab.wm.eidos.attachments.TriggeredAttachment
 import org.clulab.wm.eidos.context.DCT
 import org.clulab.wm.eidos.context.GeoPhraseID
 import org.clulab.wm.eidos.context.TimEx
 import org.clulab.wm.eidos.context.TimeStep
+import org.clulab.wm.eidos.document.AnnotatedDocument
+import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
 import org.clulab.wm.eidos.document.attachments.DctDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.LocationDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.TitleDocumentAttachment
@@ -106,7 +110,7 @@ object JLDDeserializer {
 }
 
 class JLDDeserializer {
-  import org.clulab.wm.eidos.serialization.json.JLDDeserializer._
+  import JLDDeserializer._
   implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
 
   protected def requireType(jValue: JValue, typeName: String): Unit =

--- a/src/main/scala/org/clulab/wm/eidos/serialization/jsonld/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/jsonld/JLDSerializer.scala
@@ -1,12 +1,13 @@
-package org.clulab.wm.eidos.serialization.json
+package org.clulab.wm.eidos.serialization.jsonld
 
 import java.io.PrintWriter
+import java.time.LocalDateTime
 import java.util.{IdentityHashMap => JIdentityHashMap}
 import java.util.{Set => JavaSet}
-import java.time.LocalDateTime
 
+import org.clulab.odin.Attachment
 import org.clulab.odin.EventMention
-import org.clulab.odin.{Attachment, Mention}
+import org.clulab.odin.Mention
 import org.clulab.processors.Document
 import org.clulab.processors.Sentence
 import org.clulab.serialization.json.stringify
@@ -19,16 +20,21 @@ import org.clulab.wm.eidos.context.GeoNormFinder
 import org.clulab.wm.eidos.context.GeoPhraseID
 import org.clulab.wm.eidos.context.TimEx
 import org.clulab.wm.eidos.context.TimeNormFinder
-import org.clulab.wm.eidos.document._
 import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
+import org.clulab.wm.eidos.document._
 import org.clulab.wm.eidos.document.attachments.DctDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.LocationDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.TitleDocumentAttachment
-import org.clulab.wm.eidos.groundings.{AdjectiveGrounding, OntologyGrounding}
+import org.clulab.wm.eidos.groundings.AdjectiveGrounding
+import org.clulab.wm.eidos.groundings.OntologyGrounding
 import org.clulab.wm.eidos.mentions.EidosCrossSentenceEventMention
-import org.clulab.wm.eidos.mentions.{EidosCrossSentenceMention, EidosEventMention, EidosMention, EidosTextBoundMention}
-import org.json4s._
+import org.clulab.wm.eidos.mentions.EidosCrossSentenceMention
+import org.clulab.wm.eidos.mentions.EidosEventMention
+import org.clulab.wm.eidos.mentions.EidosMention
+import org.clulab.wm.eidos.mentions.EidosTextBoundMention
+import org.clulab.wm.eidos.serialization.utils.TidyJObject
 import org.json4s.JsonDSL._
+import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
 import scala.collection.mutable

--- a/src/main/scala/org/clulab/wm/eidos/serialization/utils/TidyJObject.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/utils/TidyJObject.scala
@@ -1,4 +1,4 @@
-package org.clulab.wm.eidos.serialization.json
+package org.clulab.wm.eidos.serialization.utils
 
 import org.json4s._
 

--- a/src/main/scala/org/clulab/wm/eidos/utils/FileUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/FileUtils.scala
@@ -11,7 +11,7 @@ import org.clulab.serialization.json.stringify
 import org.clulab.utils.ClassLoaderObjectInputStream
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.document.AnnotatedDocument
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.Constructor

--- a/src/test/scala/org/clulab/wm/eidos/serialization/TestDocSerialization.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/TestDocSerialization.scala
@@ -7,7 +7,6 @@ import org.clulab.processors.Document
 import org.clulab.serialization.DocumentSerializer
 import org.clulab.serialization.json.stringify
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.{JLDCorpus => JLDEidosCorpus}
 import org.clulab.wm.eidos.test.TestUtils.Test
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
@@ -15,7 +14,8 @@ import org.clulab.serialization.json.{DocOps, JSONSerializer}
 import org.clulab.wm.eidos.document.AnnotatedDocument
 import org.clulab.wm.eidos.groundings.AdjectiveGrounder
 import org.clulab.wm.eidos.groundings.EidosAdjectiveGrounder
-import org.clulab.wm.eidos.serialization.json.JLDDeserializer
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer
 import org.clulab.wm.eidos.utils.Canonicalizer
 import org.json4s.jackson.JsonMethods.{parse, pretty, render}
 
@@ -103,7 +103,7 @@ class TestDocSerialization extends Test {
 
       def serialize(original: AnnotatedDocument): Unit = {
         val corpus = Seq(original)
-        val jldCorpus = new JLDEidosCorpus(corpus)
+        val jldCorpus = new JLDCorpus(corpus)
         val jValue = jldCorpus.serialize()
         val json = stringify(jValue, pretty = true)
         val copy = new JLDDeserializer().deserialize(json)

--- a/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJSONFormat.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/json/TestJSONFormat.scala
@@ -1,9 +1,9 @@
 package org.clulab.wm.eidos.serialization.json
 
 import org.clulab.serialization.json.stringify
+import org.clulab.wm.eidos.serialization.utils.TidyJObject
 import org.clulab.wm.eidos.test.TestUtils.Test
 import org.clulab.wm.eidos.utils.PlayUtils
-
 import org.json4s.{JField, JObject}
 import org.json4s.JsonDSL._
 

--- a/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDDeserializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDDeserializer.scala
@@ -3,14 +3,6 @@ package org.clulab.wm.eidos.serialization.json
 import java.time.LocalDateTime
 
 import org.clulab.serialization.json.stringify
-import org.clulab.wm.eidos.document.AnnotatedDocument
-import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
-import org.clulab.wm.eidos.serialization.json.{JLDCorpus => JLDEidosCorpus}
-import org.clulab.wm.eidos.test.TestUtils.ExtractionTest
-import org.clulab.wm.eidos.text.english.cag.CAG._
-import org.json4s.jackson.JsonMethods._
-import JLDDeserializer.DocumentMap
-import JLDDeserializer.DocumentSentenceMap
 import org.clulab.struct.Interval
 import org.clulab.timenorm.scate.SimpleInterval
 import org.clulab.wm.eidos.attachments.CountAttachment
@@ -33,15 +25,23 @@ import org.clulab.wm.eidos.context.DCT
 import org.clulab.wm.eidos.context.GeoPhraseID
 import org.clulab.wm.eidos.context.TimEx
 import org.clulab.wm.eidos.context.TimeStep
-import org.clulab.wm.eidos.groundings.AdjectiveGrounder
+import org.clulab.wm.eidos.document.AnnotatedDocument
+import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
 import org.clulab.wm.eidos.mentions.CrossSentenceEventMention
-import org.clulab.wm.eidos.serialization.json.JLDDeserializer.CountMap
-import org.clulab.wm.eidos.serialization.json.JLDDeserializer.DctMap
-import org.clulab.wm.eidos.serialization.json.JLDDeserializer.GeolocMap
-import org.clulab.wm.eidos.serialization.json.JLDDeserializer.MentionMap
-import org.clulab.wm.eidos.serialization.json.JLDDeserializer.ProvenanceMap
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.CountMap
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.DctMap
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.DocumentMap
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.DocumentSentenceMap
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.GeolocMap
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.MentionMap
+import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.ProvenanceMap
+import org.clulab.wm.eidos.test.TestUtils.ExtractionTest
+import org.clulab.wm.eidos.text.english.cag.CAG._
 import org.clulab.wm.eidos.utils.FileUtils
 import org.json4s.JArray
+import org.json4s.jackson.JsonMethods._
 
 import scala.collection.Seq
 
@@ -61,7 +61,7 @@ class TestJLDDeserializer extends ExtractionTest {
 
   def serialize(corpus: Corpus): String = {
     val json = {
-      val jldCorpus = new JLDEidosCorpus(corpus)
+      val jldCorpus = new JLDCorpus(corpus)
       val jValue = jldCorpus.serialize()
       stringify(jValue, pretty = true)
     }
@@ -770,7 +770,7 @@ class TestJLDDeserializer extends ExtractionTest {
 
       def serialize(original: AnnotatedDocument): String = {
         val corpus = Seq(original)
-        val jldCorpus = new JLDEidosCorpus(corpus)
+        val jldCorpus = new JLDCorpus(corpus)
         val jValue = jldCorpus.serialize()
         val json = stringify(jValue, pretty = true)
 

--- a/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDDeserializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDDeserializer.scala
@@ -1,4 +1,4 @@
-package org.clulab.wm.eidos.serialization.json
+package org.clulab.wm.eidos.serialization.jsonld
 
 import java.time.LocalDateTime
 
@@ -28,8 +28,6 @@ import org.clulab.wm.eidos.context.TimeStep
 import org.clulab.wm.eidos.document.AnnotatedDocument
 import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
 import org.clulab.wm.eidos.mentions.CrossSentenceEventMention
-import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
-import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer
 import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.CountMap
 import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.DctMap
 import org.clulab.wm.eidos.serialization.jsonld.JLDDeserializer.DocumentMap

--- a/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDFormat.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDFormat.scala
@@ -1,16 +1,15 @@
-package org.clulab.wm.eidos.serialization.json
+package org.clulab.wm.eidos.serialization.jsonld
 
 import java.util.{HashMap => JHashMap}
 
-import org.clulab.serialization.json.stringify
-import org.clulab.wm.eidos.document.AnnotatedDocument
-import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
-import org.clulab.wm.eidos.text.english.cag.CAG._
 import com.github.jsonldjava.core.JsonLdOptions
 import com.github.jsonldjava.core.JsonLdProcessor
 import com.github.jsonldjava.utils.JsonUtils
-import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
+import org.clulab.serialization.json.stringify
+import org.clulab.wm.eidos.document.AnnotatedDocument
+import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
 import org.clulab.wm.eidos.test.TestUtils.ExtractionTest
+import org.clulab.wm.eidos.text.english.cag.CAG._
 
 import scala.collection.Seq
 

--- a/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDFormat.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDFormat.scala
@@ -9,6 +9,7 @@ import org.clulab.wm.eidos.text.english.cag.CAG._
 import com.github.jsonldjava.core.JsonLdOptions
 import com.github.jsonldjava.core.JsonLdProcessor
 import com.github.jsonldjava.utils.JsonUtils
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.test.TestUtils.ExtractionTest
 
 import scala.collection.Seq

--- a/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDSerializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDSerializer.scala
@@ -1,4 +1,4 @@
-package org.clulab.wm.eidos.serialization.json
+package org.clulab.wm.eidos.serialization.jsonld
 
 import java.time.LocalDateTime
 
@@ -30,10 +30,7 @@ import org.clulab.wm.eidos.context.TimeStep
 import org.clulab.wm.eidos.document.AnnotatedDocument
 import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
 import org.clulab.wm.eidos.document.attachments.DctDocumentAttachment
-import org.clulab.wm.eidos.groundings.AdjectiveGrounder
-import org.clulab.wm.eidos.groundings.EidosAdjectiveGrounder
 import org.clulab.wm.eidos.mentions.EidosMention
-import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.test.TestUtils.ExtractionTest
 import org.clulab.wm.eidos.text.english.cag.CAG._
 

--- a/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDSerializer.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/jsonld/TestJLDSerializer.scala
@@ -33,7 +33,7 @@ import org.clulab.wm.eidos.document.attachments.DctDocumentAttachment
 import org.clulab.wm.eidos.groundings.AdjectiveGrounder
 import org.clulab.wm.eidos.groundings.EidosAdjectiveGrounder
 import org.clulab.wm.eidos.mentions.EidosMention
-import org.clulab.wm.eidos.serialization.json.{JLDCorpus => JLDEidosCorpus}
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.test.TestUtils.ExtractionTest
 import org.clulab.wm.eidos.text.english.cag.CAG._
 
@@ -52,7 +52,7 @@ class TestJLDSerializer extends ExtractionTest {
   
   def serialize(corpus: Corpus): String = {
     val json = {
-      val jldCorpus = new JLDEidosCorpus(corpus)
+      val jldCorpus = new JLDCorpus(corpus)
       val jValue = jldCorpus.serialize()
       stringify(jValue, pretty = true)
     }

--- a/src/test/scala/org/clulab/wm/eidos/serialization/obj/TestObjSerialization.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/obj/TestObjSerialization.scala
@@ -1,8 +1,11 @@
-package org.clulab.wm.eidos.serialization
+package org.clulab.wm.eidos.serialization.obj
 
-import java.io.{ByteArrayOutputStream, ObjectOutputStream}
+import java.io.ByteArrayOutputStream
+import java.io.ObjectOutputStream
 
-import org.clulab.odin.{EventMention, Mention, TextBoundMention}
+import org.clulab.odin.EventMention
+import org.clulab.odin.Mention
+import org.clulab.odin.TextBoundMention
 import org.clulab.wm.eidos.EidosSystem
 import org.clulab.wm.eidos.test.TestUtils.Test
 import org.clulab.wm.eidos.utils.Closer.AutoCloser

--- a/src/test/scala/org/clulab/wm/eidos/serialization/txt/TestTxtSerialization.scala
+++ b/src/test/scala/org/clulab/wm/eidos/serialization/txt/TestTxtSerialization.scala
@@ -1,0 +1,51 @@
+package org.clulab.wm.eidos.serialization.txt
+
+import com.typesafe.config.Config
+import org.clulab.processors.Document
+import org.clulab.serialization.DocumentSerializer
+import org.clulab.wm.eidos.EidosSystem
+import org.clulab.wm.eidos.document.AnnotatedDocument
+import org.clulab.wm.eidos.groundings.AdjectiveGrounder
+import org.clulab.wm.eidos.groundings.EidosAdjectiveGrounder
+import org.clulab.wm.eidos.test.TestUtils.Test
+import org.clulab.wm.eidos.utils.Canonicalizer
+
+class TestTxtSerialization extends Test {
+  val config: Config = this.defaultConfig // Do not use EidosSystem's defaultConfig!
+  val reader: EidosSystem = new EidosSystem(config)
+  val adjectiveGrounder: AdjectiveGrounder = EidosAdjectiveGrounder.fromEidosConfig(config)
+  val canonicalizer: Canonicalizer = reader.components.ontologyHandler.canonicalizer
+
+
+  def testCusomSerialization(annotatedDocument: AnnotatedDocument): Unit = {
+    val document = annotatedDocument.document
+    val text = document.text.get
+
+    behavior of "Custom serializer"
+
+    it should s"""process "$text" properly""" in {
+
+      def serialize(original: Document): Unit = {
+        val serializer = new DocumentSerializer
+        val serial = serializer.save(original, encoding = "UTF-8", keepText = true)
+        val copy = serializer.load(serial)
+
+        copy should not be None
+//        copy should be (original)
+//        document.hashCode should be (copy.hashCode)
+      }
+
+      serialize(document)
+    }
+  }
+
+  val texts = Seq(
+    "Water trucking has decreased due to the cost of fuel last week.",
+    "300 refugees fled South Sudan; they left the country for Ethiopia. They left in 1997."
+  )
+  val annotateDocuments: Seq[AnnotatedDocument] = texts.map(reader.extractFromText(_))
+
+  annotateDocuments.foreach { annotatedDocument =>
+    testCusomSerialization(annotatedDocument)
+  }
+}

--- a/src/test/scala/org/clulab/wm/eidos/system/TestParallel.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestParallel.scala
@@ -1,7 +1,7 @@
 package org.clulab.wm.eidos.system
 
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.test.TestUtils._
 
 import scala.util.Random

--- a/src/test/scala/org/clulab/wm/eidos/system/TestSerial.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestSerial.scala
@@ -1,7 +1,7 @@
 package org.clulab.wm.eidos.system
 
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import org.clulab.wm.eidos.test.TestUtils._
 
 import scala.util.Random

--- a/webapp/app/controllers/HomeController.scala
+++ b/webapp/app/controllers/HomeController.scala
@@ -20,8 +20,8 @@ import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.{DisplayUtils, DomainParams, GroundingUtils, MaaSUtils, PlayUtils}
 import play.api.mvc._
 import play.api.libs.json._
-import org.clulab.wm.eidos.serialization.json.JLDCorpus
 import org.clulab.wm.eidos.groundings.EidosAdjectiveGrounder
+import org.clulab.wm.eidos.serialization.jsonld.JLDCorpus
 import play.api.mvc.Action
 
 /**


### PR DESCRIPTION
This should account for an expanding repertoire.  Although jsonld is valid json, the code is unrelated, and the jsonld should not be part of that package.