### PR TITLE
Set fork to true even for simple runs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ import Tests._
 name := "eidos"
 organization := "org.clulab"
 
+fork := true
+
 scalaVersion := "2.12.4"
 crossScalaVersions := Seq("2.11.11", "2.12.4")
 


### PR DESCRIPTION
sbt sessions with involve multiple calls to runMain start reporting "2020-05-28 04:23:11.423336: F tensorflow/core/lib/monitoring/collection_registry.cc:77] Cannot register 2 metrics with the same name: /tensorflow/cc/saved_model/load_attempt_count" with the second call.  This is probably a longstanding problem that hadn't been noticed because we don't use sbt interactively very much and also because the tests we run already have the same setting.