### PR TITLE
added method to make it easy to load in external grounding/aligning apps

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.Config
 import org.clulab.odin.TextBoundMention
 import org.clulab.processors.Document
 import org.clulab.struct.Interval
-import org.clulab.wm.eidos.SentencesExtractor
+import org.clulab.wm.eidos.{EidosProcessor, EidosSystem, SentencesExtractor}
 import org.clulab.wm.eidos.document.AnnotatedDocument
 import org.clulab.wm.eidos.groundings.HalfTreeDomainOntology.HalfTreeDomainOntologyBuilder
 import org.clulab.wm.eidos.groundings.EidosOntologyGrounder.mkGrounder
@@ -188,6 +188,13 @@ class OntologyHandler(
 
 object OntologyHandler {
   protected lazy val logger: Logger = LoggerFactory.getLogger(this.getClass)
+
+  def fromConfig(config: Config = EidosSystem.defaultConfig): OntologyHandler = {
+    val sentenceExtractor  = EidosProcessor("english", cutoff = 150)
+    val tagSet = sentenceExtractor.getTagSet
+    val stopwordManager = StopwordManager.fromConfig(config, tagSet)
+    OntologyHandler.load(config[Config]("ontologies"), sentenceExtractor, stopwordManager, tagSet)
+  }
 
   def load(config: Config, proc: SentencesExtractor, stopwordManager: StopwordManager, tagSet: TagSet): OntologyHandler = {
     val canonicalizer = new Canonicalizer(stopwordManager, tagSet)


### PR DESCRIPTION
I'd like to add this method, bc I'm wanting to easily ingest WM format ontologies in the mapping project (ConceptAlignment), and it turns this:
```
import org.clulab.wm.eidos.{EidosProcessor, EidosSystem}
import org.clulab.wm.eidos.groundings.OntologyHandler
import org.clulab.wm.eidos.utils.{Canonicalizer, StopwordManager}

...
  // Second, load the ontology nodes.
  val config = EidosSystem.defaultConfig
  val sentenceExtractor  = EidosProcessor("english", cutoff = 150)
  val tagSet = sentenceExtractor.getTagSet
  val stopwordManager = StopwordManager.fromConfig(config, tagSet)
  val ontologyHandler = OntologyHandler.load(config[Config]("ontologies"), sentenceExtractor, stopwordManager, tagSet)
```

into this:

```
import org.clulab.wm.eidos.groundings.OntologyHandler

...
  // Get the WM ontology(ies) being used
  val ontologyHandler = OntologyHandler.fromConfig()
```


note @MihaiSurdeanu  that we'll still be using this class imported from the wm eidos project, but that seems to make sense to me