### PR TITLE
semantic role label grounding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,10 @@ resolvers ++= Seq(
   "Artifactory" at "http://artifactory.cs.arizona.edu:8081/artifactory/sbt-release" // org.clulab/glove-840b-300d
 )
 
+val becky = ""
+
 libraryDependencies ++= {
-  val      procVer = "8.1.3"
+  val      procVer = "8.2.1-SNAPSHOT"
   val procModelVer = "7.5.4"
   val    luceneVer = "6.6.6"
   val   lihaoyiVer = "0.7.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.1.6

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -73,7 +73,8 @@ ontologies {
   // Note that these first two are included via the build.sbt libraryDependencies on WorldModelers % Ontologies.
   wm               = ${ontologies.path}/wm_metadata.yml
   wm_flattened     = ${ontologies.path}/wm_flat_metadata.yml
-  wm_compositional = ${ontologies.path}/wm_compositional_metadata.yml
+  // This compositional is local only...
+  wm_compositional = ${ontologies.path}/Compositional_2.1_local_metadata.yml
   interventions    = ${ontologies.path}/interventions_metadata.yml
 }
 

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -36,10 +36,9 @@ apps {
   exportAs = ["serialized", "jsonld", "mitre"] // "incdec"
 
   groundAs = ${ontologies.ontologies}
-  groundTopN = 5
   ontologymapper {
     dir = ./src/main/resources/org/clulab/${EidosSystem.domain}/eidos/${EidosSystem.language}/ontologies
-
+    // groundTopN = 2 // TODO: remove from here
     // outfile = ${apps.ontologymapper.dir}/wm_to_edited_MaaS_model.tsv
     outfile = ${apps.ontologymapper.dir}/wm_to_MaaS_parameter.tsv
     // outfile = ${apps.ontologymapper.dir}/wm_to_MaaS_variable.tsv
@@ -57,7 +56,8 @@ ontologies {
   useCacheForOntologies = false
   useCacheForW2V = ${ontologies.useCacheForOntologies}
   includeParents = true
-
+  groundTopN = 1
+  groundThreshold = 0.5
   // Activated ontologies which should be taken from the collection (wm..mesh) below
   ontologies = ["wm_flattened"]
   path = ${EidosSystem.path}/ontologies

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -20,8 +20,14 @@ filtering {
 }
 
 apps {
-  inputDirectory = "."
-  outputDirectory = "."
+  inputDirectory = "/Users/bsharp/data/WM/doc_sample_2020-09-05/jsonld_flat/"
+  outputDirectory = "/Users/bsharp/data/WM/doc_sample_2020-09-05/regrounded_compositional/"
+  exportAs = ["reground"] // "incdec"
+
+  //inputDirectory = "/Users/bsharp/data/WM/doc_sample_2020-09-05/regrounded_compositional/"
+  //outputDirectory = "/Users/bsharp/data/WM/doc_sample_2020-09-05/compositional_debug/"
+  //exportAs = ["debugGrounding"] // "incdec"
+
   outputFile = "../incdec/Doc500.tsv"
   inputFileExtension = ".txt"
   // valid modes:
@@ -33,7 +39,8 @@ apps {
   //    serialized : java serialized mention objects
   //    grounding : a csv format used to evaluate the grounding of the cause/effect
   //    reground : regrounds the mentions and exports them as jsonld
-  exportAs = ["serialized", "jsonld", "mitre"] // "incdec"
+  //exportAs = ["debugGrounding"] // "incdec"
+
 
   groundAs = ${ontologies.ontologies}
   ontologymapper {
@@ -48,18 +55,18 @@ apps {
 ontologies {
   // W2V
   useGrounding = true
-  //wordToVecPath = ${EidosSystem.path}/w2v/vectors.txt
+  wordToVecPath = ${EidosSystem.path}/w2v/vectors.txt
   //wordToVecPath = ${EidosSystem.path}/w2v/glove.840B.300d.txt // Local resource
-  wordToVecPath = /org/clulab/glove/glove.840B.300d.txt // Remote resource
+  //wordToVecPath = /org/clulab/glove/glove.840B.300d.txt // Remote resource
   // Caching, for quick loading, language dependent
   cacheDir = ${EidosSystem.cacheDir}/${EidosSystem.language}
   useCacheForOntologies = false
-  useCacheForW2V = ${ontologies.useCacheForOntologies}
+  useCacheForW2V = true
   includeParents = true
   groundTopN = 1
-  groundThreshold = 0.5
+  groundThreshold = 0.2
   // Activated ontologies which should be taken from the collection (wm..mesh) below
-  ontologies = ["wm_flattened"]
+  ontologies = ["wm_compositional"] //, "wm_flattened"]
   path = ${EidosSystem.path}/ontologies
 
   // Primary

--- a/src/main/resources/eidos.conf
+++ b/src/main/resources/eidos.conf
@@ -21,7 +21,7 @@ filtering {
 
 apps {
   inputDirectory = "/Users/bsharp/data/WM/doc_sample_2020-09-05/jsonld_flat/"
-  outputDirectory = "/Users/bsharp/data/WM/doc_sample_2020-09-05/regrounded_compositional/"
+  outputDirectory = "/Users/bsharp/data/WM/doc_sample_2020-09-05/regrounded_compositional_ranked/"
   exportAs = ["reground"] // "incdec"
 
   //inputDirectory = "/Users/bsharp/data/WM/doc_sample_2020-09-05/regrounded_compositional/"
@@ -63,10 +63,10 @@ ontologies {
   useCacheForOntologies = false
   useCacheForW2V = true
   includeParents = true
-  groundTopN = 1
+  groundTopN = 3
   groundThreshold = 0.2
   // Activated ontologies which should be taken from the collection (wm..mesh) below
-  ontologies = ["wm_compositional"] //, "wm_flattened"]
+  ontologies = ["wm_compositional", "wm_flattened"]
   path = ${EidosSystem.path}/ontologies
 
   // Primary

--- a/src/main/resources/englishActionsExpander.conf
+++ b/src/main/resources/englishActionsExpander.conf
@@ -2,7 +2,7 @@
   validArguments = ["cause", "effect", "group"]
   validLabels = ["Causal", "Correlation", "Coreference", "HumanMigration", "PositiveAffect", "NegativeAffect"]
   expansionType = "argument"
-  maxHops = 5
+  maxHops = 3
   // Avoid expanding along these dependencies.
   invalidOutgoing = [
     "aux",

--- a/src/main/resources/englishConceptExpander.conf
+++ b/src/main/resources/englishConceptExpander.conf
@@ -1,6 +1,6 @@
 {
   expansionType = "textbound"
-  maxHops = 5
+  maxHops = 3
   // Avoid expanding along these dependencies.
   invalidOutgoing = [
     "aux",

--- a/src/main/resources/org/clulab/wm/eidos/english/ontologies/Compositional_2.1_local_metadata.yml
+++ b/src/main/resources/org/clulab/wm/eidos/english/ontologies/Compositional_2.1_local_metadata.yml
@@ -1,0 +1,1666 @@
+- wm_compositional:
+  - concept:
+    - agriculture:
+      - crop:
+        - OntologyNode:
+          examples:
+          - maize
+          - wheat
+          - tef
+          - barley
+          - sorghum
+          - cereals
+          name: cereals
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - vegetables
+          - lettuce
+          - tomato
+          - cabbage
+          - carrots
+          - beets
+          - horticulture
+          name: horticulture
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - lentils
+          - beans
+          - peas
+          - pulses
+          name: pulses
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - potato
+          - cassava
+          - sweet potato
+          - tubers
+          name: tubers
+          polarity: 1
+      - disease:
+        - OntologyNode:
+          examples:
+          - blight
+          - crop disease
+          name: crop_disease
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - livestock disease
+          name: livestock_disease
+          polarity: -1
+      - OntologyNode:
+        examples:
+        - cow
+        - chicken
+        - pigs
+        - sheep
+        - goats
+        - livestock
+        name: livestock
+        polarity: 1
+      - pest:
+        - OntologyNode:
+          examples:
+          - army worm
+          name: army_worm
+          polarity: -1
+        - locust:
+          - OntologyNode:
+            examples:
+            - locust eggs
+            name: locust_eggs
+            polarity: -1
+          - OntologyNode:
+            examples:
+            - locust breeding
+            - breeding area locust
+            name: locust_breeding
+            polarity: -1
+          - OntologyNode:
+            examples:
+            - locust hatching
+            name: locust_hatching
+            polarity: -1
+          - solitary:
+            - OntologyNode:
+              examples:
+              - solitarious hopper
+              - solitary
+              - hopper
+              - immature
+              - instar
+              name: solitary_hopper
+              polarity: -1
+            - OntologyNode:
+              examples:
+              - solitary locust
+              - solitarious adult locust
+              - mature
+              name: solitary_locust
+              polarity: -1
+          - gregarious:
+            - OntologyNode:
+              pattern:
+              - (hopper\s+band)|(bands?\s+of\s+hoppers)
+              examples:
+              - bands of hoppers
+              - locust hopper groups
+              - hopper outbreak upsurge
+              - immature
+              name: hopper_band
+              polarity: -1
+            - OntologyNode:
+              pattern:
+              - locust
+              - \bDL\b
+              - (locust\s+swarm)|(swarms?\s+of\s+locust)
+              examples:
+              - swarm
+              - locust swarm
+              - mature maturation
+              - adult
+              - locust infestation
+              - locust outbreak
+              name: locust_swarm
+              polarity: -1
+    - crisis_or_disaster:
+      - conflict:
+        - OntologyNode:
+          examples:
+          - crime
+          - crimes
+          - criminal
+          - bribery
+          - cybercrimes
+          - murdered
+          - sexual abuse
+          - assault
+          - stealing
+          - stolen
+          - looted
+          - looting
+          - theft
+          - riots
+          - violations
+          - violent crime
+          - lawlessness
+          - illegal
+          name: crime
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - conflict
+          - war
+          - fighting
+          - infighting
+          - oppression
+          - tyranny
+          - oppressive regime
+          - genocide
+          - clash
+          - clashes
+          - armed clash
+          - raid
+          - regional turmoil
+          - violence
+          - outbreak of violence in the region
+          - hostility
+          - insurgency
+          - armed groups
+          - armed mobilization
+          - sabotage
+          - vandalized
+          - army mobilization
+          name: hostility
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - insecurity
+          - instability
+          - physical insecurity
+          - perceived security
+          - dangerous
+          name: physical_insecurity
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - political tension
+          - political tensions
+          - adversity
+          - political instability
+          - stress
+          - distress
+          - challenge
+          - hardship
+          - burden
+          - threatening
+          name: tension
+          polarity: -1
+      - OntologyNode:
+        examples:
+        - pandemic
+        - global pandemic
+        - epidemic
+        - disease outbreak
+        name: disease_outbreak
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - depression
+        - recession
+        - economic crisis
+        - financial crisis
+        - economic volatility
+        name: economic_crisis
+        polarity: -1
+      - environmental:
+        - OntologyNode:
+          examples:
+          - drought
+          - droughts
+          - low rainfall
+          name: drought
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - flood
+          - flooding
+          - flash flood
+          name: flood
+          polarity: -1
+      - OntologyNode:
+        examples:
+        - evacuation
+        name: evacuation
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - famine
+        - hunger
+        name: famine
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - taskforce
+        name: taskforce
+        polarity: 1
+    - economy:
+      - OntologyNode:
+        examples:
+        - assets
+        - land property assets
+        name: assets
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - budget
+        name: budget
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - competition
+        name: competition
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - currency
+        name: currency
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - domestic market
+        - GDP
+        - GNP
+        - stock market
+        - employment
+        name: domestic_market
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - economic development
+        - investment
+        - growth of the economy
+        name: economic_development
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - finance
+        - loan
+        name: finance
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - farm
+        - household
+        - income
+        - revenue
+        - paycheck
+        - compensation
+        - wages
+        name: income
+        polarity: 1
+      - livelihoods:
+        - OntologyNode:
+          examples:
+          - rural livelihoods
+          - employment
+          name: rural_livelihoods
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - employment
+          - urban livelihoods
+          name: urban_livelihoods
+          polarity: 1
+    - OntologyNode:
+      examples:
+      - literacy
+      - education
+      - access to education
+      name: education
+      polarity: 1
+    - environment:
+      - OntologyNode:
+        examples:
+        - climate
+        name: climate
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - climate change
+        - global warming
+        name: climate_change
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - afforestation
+        - agroforestry
+        - forest management
+        - reforestation
+        - forestry
+        - logging
+        name: forestry
+        polarity: 1
+      - meteorology:
+        - OntologyNode:
+          examples:
+          - rainfall
+          - storm
+          - precipitation
+          - rain
+          name: precipitation
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - temperature
+          name: temperature
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - weather
+          - weather systems
+          - rains
+          - rainfall
+          - extreme winds
+          - wet
+          - wetter
+          - climate variability
+          - snow
+          - humid
+          - storm
+          name: weather
+          polarity: 1
+      - natural_resources:
+        - OntologyNode:
+          examples:
+          - fossil fuels
+          - oil
+          - carbon
+          - natural gas
+          - crude oil
+          name: fossil_fuels
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - land
+          - acreage
+          - plot
+          name: land
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - pastoral conditions
+          - pasture conditions
+          - rangeland conditions
+          - vegetation conditions
+          - grazing conditions
+          - pasture
+          name: pasture
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - soil types
+          - soil
+          - soil quality
+          - leaching into the soil
+          name: soil
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - lake
+          - river
+          - pond
+          - ocean
+          - water bodies
+          - resevoir
+          - aqueduct
+          name: water_bodies
+          polarity: 1
+      - OntologyNode:
+        examples:
+        - air pollution
+        - land pollution
+        - water pollution
+        name: pollution
+        polarity: -1
+    - OntologyNode:
+      examples:
+      - food security
+      - food availability
+      name: food_security
+      polarity: 1
+    - goods:
+      - agricultural:
+        - OntologyNode:
+          examples:
+          - farm equipment
+          - machinery
+          - tractor
+          - power tiller
+          - row planter
+          - plow
+          - winnower
+          name: farm_equipment
+          polarity: 1
+        - OntologyNode:
+          pattern:
+          - \b(manure|fertilizers?|nitrogen)\b
+          examples:
+          - DAP
+          - urea
+          - nitrogen
+          - compost
+          - manure
+          - potassium
+          - phospherous
+          - fertilizer
+          name: fertilizer
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - drip
+          - pump
+          - irrigation equipment
+          - water pumps
+          - treadle
+          - electric pump
+          - small scale irrigation pump
+          - field irrigation
+          - sprinklers
+          name: irrigation_equipment
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - livestock feed
+          - hay
+          - CSB
+          - silage
+          - corn meal
+          - soybean hulls
+          name: livestock_feed
+          polarity: 1
+        - OntologyNode:
+          pattern:
+          - \b(DDT|dicamba|round-up)\b 
+          examples:
+          - organic
+          - chemical
+          - pesticide
+          - integrated pest management 
+          - IPM
+          name: pesticide
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - improved seed
+          - GMO
+          - heirloom seed
+          - organic seed
+          - seed
+          name: seed
+          polarity: 1
+      - OntologyNode:
+        examples:
+        - chalkboard
+        - pencil
+        - notebook
+        - smartboard
+        - textbooks
+        - education supplies
+        name: education_supplies
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - food
+        name: food
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - fuel
+        - gas
+        - oil
+        name: fuel
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - ventilator
+        - bed
+        - respirator
+        - blood
+        - bandages
+        - medical supplies
+        name: medical_supplies
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - drugs
+        - pharmaceuticals
+        - antibiotics
+        - medicine
+        name: medicine
+        polarity: 1
+    - government:
+      - OntologyNode:
+        examples:
+        - corruption
+        name: corruption
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - election
+        - voting
+        - ballot
+        name: election
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - political
+        - politics
+        - laws
+        - reforms
+        name: political_system
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - census
+        - social security
+        - program
+        name: government_program
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - sanction
+        name: sanction
+        polarity: -1
+    - health:
+      - OntologyNode:
+        examples:
+        - biometrics
+        - fingerprint
+        - DNA
+        name: biometrics
+        polarity: 1
+      - disease:
+        - OntologyNode:
+          examples:
+          - disease cases
+          - new cases
+          name: case_volume
+          polarity: -1
+        - OntologyNode:
+          pattern:
+          - (COVID|covid|SARS-CoV)
+          - corona(\s+)?virus
+          examples:
+          - corona virus
+          - coronavirus
+          - virus
+          name: COVID
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - flu
+          - influenza
+          name: flu
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - malaria
+          name: malaria
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - water
+          - mosquitos
+          - excrement
+          - vector
+          name: vector
+          polarity: -1
+      - healthcare_system:
+        - OntologyNode:
+          examples:
+          - community health worker
+          - CHW
+          - doctor
+          - nurse
+          - physicians assistant
+          - health worker
+          - medical worker
+          - nursing staff
+          - first responders
+          name: health_worker
+          polarity: 1
+      - OntologyNode:
+        examples:
+        - injury
+        - wound
+        name: injury
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - living condition
+        name: living_condition
+        polarity: 1
+      - nutrition:
+        - OntologyNode:
+          examples:
+          - breast feeding
+          - lactation
+          - weening
+          name: breast_feeding
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - food intake
+          - food consumption
+          - eating
+          name: food_intake
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - food preference
+          - seed preference
+          - dietary preferences
+          - food taste choice
+          name: food_preference
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - fortification
+          name: fortification
+          polarity: 1
+        - OntologyNode:
+          pattern:
+          - (malnutrition|stunting|undernourishment|malnourishment|undernutrition)
+          examples:
+          - malnutrition
+          - stunting
+          - food gap
+          - undernutrition
+          - undernourishment
+          - nutritional deficiency
+          - vitamin deficiencies
+          - food riots
+          name: malnutrition
+          polarity: -1
+        - supplementary_feeding:
+          - OntologyNode:
+            pattern:
+            - (IYCF|iycf)
+            examples:
+            - infant and young child feeding
+            - iycf
+            name: iycf
+            polarity: 1
+          - OntologyNode:
+            pattern:
+            - (RUTF|rutf)
+            examples:
+            - ready to use theraputic foods
+            - rutf
+            name: rutf
+            polarity: 1
+      - OntologyNode:
+        examples:
+        - public health
+        name: public_health
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - public safety
+        name: public_safety
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - alcohol
+        - drugs
+        - prescription drug abuse
+        - narcotics
+        - cocaine
+        - heroin
+        - substance abuse
+        name: substance_abuse
+        polarity: -1
+      - treatment:
+        - OntologyNode:
+          examples:
+          - intensive care
+          name: intensive_care
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - preventative treatment
+          - vaccine
+          - prophylactic
+          - well visit
+          name: preventative_treatment
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - psychological services
+          - therapy
+          - anti-depressant
+          - counseling
+          - psychiatrist
+          name: psychological_services
+          polarity: 1
+      - OntologyNode:
+        examples:
+        - immunization
+        - vaccine
+        - vaccination
+        name: vaccination
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - masks
+        - face covering
+        - hand sanitizer
+        - soap
+        - PPE
+        - personal protective equipment
+        - hygiene materials
+        name: hygiene_materials
+        polarity: 1
+    - humanitarian_assistance:
+      - OntologyNode:
+        examples:
+        - CSB
+        - ration
+        - food aid
+        - food for work
+        - free food distribution
+        - school feeding
+        name: food_aid
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - NFI
+        - buckets
+        - soap
+        - tarp
+        - pots
+        - pans
+        - jerry can
+        - non food items
+        name: non_food_items
+        polarity: 1
+      - OntologyNode:
+        pattern:
+        - \bvouchers?\b
+        - \bcash\b
+        examples:
+        - food voucher
+        - voucher or cash
+        name: voucher_or_cash
+        polarity: 1
+    - infrastructure:
+      - agriculture:
+        - OntologyNode:
+          examples:
+          - livestock enclosure
+          - barn
+          - greenhouse
+          - nursery
+          - silos
+          - farm infrastructure
+          name: farm_infrastructure
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - warehouse
+          - processing equipment
+          - packaging
+          - post harvest infrastructure
+          - post harvest agriculture
+          name: post_harvest_infrastructure
+          polarity: 1
+      - OntologyNode:
+        examples:
+        - bridge
+        name: bridge
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - communication
+        - media
+        - telephone
+        - internet
+        - television
+        - news
+        - social media
+        name: communication
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - construction materials
+        - lumber
+        - concrete cement
+        name: construction_materials
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - school
+        - college
+        - university
+        - faculty
+        - lecture hall
+        - child friendly learning spaces
+        - community centers
+        - school rehabilitation
+        - education facilities
+        name: education_facilities
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - electrical wiring
+        - electricity
+        name: electrical_infrastucture
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - generator
+        - solar panel
+        - wind turbine
+        - micro grid
+        - dam
+        - power station
+        - energy
+        - power plant
+        name: energy_infrastucture
+        polarity: 1
+      - OntologyNode:
+        pattern:
+        - \brefugee\s+camps?\b
+        - \bcamps?\b
+        examples:
+        - refugee camp
+        - temporary housing
+        - humanitarian
+        name: humanitarian_infrastucture
+        polarity: 1
+      - OntologyNode:
+        pattern:
+        - irrigation
+        examples:
+        - canal
+        - irrigation
+        name: irrigation_infrastucture
+        polarity: 1
+      - OntologyNode:
+        pattern:
+        - hospital
+        - \bclinics\b
+        examples:
+        - hosptial
+        - clinic
+        - health post
+        - doctors office
+        - mobile clinics
+        - field hospitals
+        - medical facilities
+        name: medical_facilities
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - road and rail
+        - highway
+        - railroad
+        - train
+        - trucks
+        name: road_and_rail_infrastucture
+        polarity: 1
+      - WASH:
+        - OntologyNode:
+          pattern:
+          - \blatrines?\b
+          - \btoilets?\b
+          examples:
+          - latrines
+          - toilets
+          - handwashing station
+          - sanitation
+          name: sanitation_infrastucture
+          polarity: 1
+        - OntologyNode:
+          pattern:
+          - \bborehole
+          examples:
+          - boreholes
+          - wells
+          - water point
+          - water treatment center
+          - water facilities
+          name: water_facilities
+          polarity: 1
+    - migration:
+      - OntologyNode:
+        examples:
+        - animal migration
+        - livestock
+        name: animal_migration
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - human
+        - migration
+        - refugee camps
+        name: human_migration
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - IDP
+        - displaced persons
+        - refugee
+        - migrant
+        name: IDP
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - returnees
+        - refugee
+        name: returnees
+        polarity: 1
+    - OntologyNode:
+      examples:
+      - physical market
+      - grocery storage
+      - produce market
+      name: physical_market
+      polarity: 1
+    - population:
+      - demographics:
+        - OntologyNode:
+          examples:
+          - age
+          name: age
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - gender
+          - male
+          - female
+          - sex
+          - gender demographics
+          name: gender
+          polarity: 1
+        - OntologyNode:
+          examples:
+          - race
+          - ethnicity
+          name: race_or_ethnicity
+          polarity: 1
+      - density:
+        - OntologyNode:
+          examples:
+          - de-population
+          - depopulation
+          - population decline
+          name: de-population
+          polarity: -1
+        - OntologyNode:
+          examples:
+          - overcrowding
+          name: overcrowding
+          polarity: -1
+    - OntologyNode:
+      examples:
+      - poverty
+      name: poverty
+      polarity: -1
+    - security:
+      - OntologyNode:
+        examples:
+        - policing
+        - mine clearance
+        - community
+        name: community_security
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - inflation
+        - depreciation
+        - economy
+        - recession
+        - economic security
+        name: economic_security
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - environmental security
+        name: environmental_security
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - military
+        - diplomacy
+        - national security
+        name: national_security
+        polarity: 1
+    - service:
+      - information:
+        - OntologyNode:
+          examples:
+          - track
+          - monitor
+          - surveillance system
+          name: surveillance_system
+          polarity: 1
+    - storage:
+      - OntologyNode:
+        examples:
+        - silo
+        - granary
+        - agricultural storage
+        name: agricultural_storage
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - storage facilities
+        - storage
+        name: general_storage_facilities
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - household food storage
+        - storage
+        name: household_food_storage
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - stockpile
+        name: stockpile_goods
+        polarity: 1
+    - OntologyNode:
+      examples:
+      - demographics
+      - bias
+      - pattern
+      - trend
+      name: trend
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - water
+      name: water
+      polarity: 1
+  - process:
+    - OntologyNode:
+      examples:
+      - access
+      name: access
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - adapt
+      name: adapt
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - breeding
+      - breed
+      - reproduce
+      name: breeding
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - shelter
+      - build
+      - construct
+      - establish
+      name: build
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - collaborate
+      - cooperate
+      - partner
+      name: collaborate
+      polarity: 1
+    - communicate:
+      - OntologyNode:
+        examples:
+        - campaign
+        - promote
+        - advocate
+        name: campaign
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - debate
+        - disagree
+        - discuss
+        name: debate
+        polarity: 1
+    - conflict:
+      - OntologyNode:
+        examples:
+        - child abductions
+        - abduction
+        - kidnapping
+        - forced recruitment
+        - abducted
+        - kidnapped
+        name: abduct
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - bombard
+        - genocide
+        - clash
+        - attack
+        - assault
+        - destroyed in combat
+        - combat
+        - fight
+        - battle
+        - attacking
+        - attacked
+        - attacks
+        - invaded
+        - raiding
+        - shoots
+        - shooting
+        - crossfire
+        - invasion
+        - massacre
+        - psychological warfare
+        - strike
+        - airstrike
+        - offense
+        - attack
+        name: attack
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - civil unrest
+        - social unrest
+        - clash
+        - protest
+        - picket
+        - strikes
+        - boycott
+        - rally
+        - turmoil
+        - demands
+        - riot
+        name: demonstrate
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - disarmament
+        name: disarmament
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - exploit
+        name: exploit
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - cattle raid
+        - livestock raid
+        - steal livestock
+        - cattle raiding
+        name: livestock_raid
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - treaty
+        - agreement
+        - peace deal
+        - resolution
+        name: resolution
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - terrorism
+        - insurgency
+        - terrorist attack
+        - terrorist activity
+        - roadside bombing
+        - bomb threat
+        name: terrorism
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - threat
+        name: threat
+        polarity: -1
+      - OntologyNode:
+        examples:
+        - bombard
+        - genocide
+        - clash
+        - attack
+        - war
+        - warlord
+        - civil war
+        - insurgency
+        - revolt
+        - rebel
+        - uprising
+        - militia
+        - military aggression
+        - invaded
+        - warfare
+        - the outbreak of war
+        name: war
+        polarity: -1
+    - OntologyNode:
+      examples:
+      - demand
+      name: demand
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - depreciate
+      - devaluation
+      name: depreciate
+      polarity: -1
+    - OntologyNode:
+      examples:
+      - manufacturing
+      - cleaning
+      - sorting
+      - grading
+      - packing
+      - shipping
+      - processing
+      name: processing
+      polarity: 1
+    - farming:
+      - OntologyNode:
+        examples:
+        - harvesting
+        - harvest
+        - reap
+        name: harvesting
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - planting
+        - sow
+        name: planting
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - tilling
+        name: tilling
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - weeding
+        name: weeding
+        polarity: 1
+    - OntologyNode:
+      examples:
+      - forage
+      name: forage
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - hatching
+      - hatch
+      name: hatching
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - hunt
+      name: hunt
+      polarity: 1
+    - OntologyNode:
+      pattern:
+      - \b[iI]nfest
+      examples:
+      - infest
+      name: infest
+      polarity: -1
+    - OntologyNode:
+      examples:
+      - inflation
+      name: inflation
+      polarity: -1
+    - legislate:
+      - OntologyNode:
+        pattern:
+        - \b(regulations?|laws?)\b
+        examples:
+        - regulate
+        - legislate
+        - mandate
+        name: regulate
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - subsidize
+        name: subsidize
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - tax
+        name: tax
+        polarity: 1
+    - OntologyNode:
+      examples:
+      - NRM
+      - manage
+      - administrate
+      name: manage
+      polarity: 1
+    - medical:
+      - OntologyNode:
+        pattern:
+        - (quarantin|shelter[- ]in[- ]place)
+        - \b(restrict\s+movement)
+        examples:
+        - isolation
+        - quarantine
+        name: quarantine
+        polarity: 1
+      - OntologyNode:
+        pattern:
+        - (contact tracing)
+        examples:
+        - contact tracing
+        name: contact_tracing
+        polarity: 1
+      - OntologyNode:
+        pattern:
+        - (social distanc)
+        examples:
+        - social distancing
+        - curfew
+        name: social_distancing
+        polarity: 1
+    - OntologyNode:
+      examples:
+      - mitigate
+      name: mitigate
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - plan
+      - strategy
+      name: plan
+      polarity: 1
+    - population:
+      - OntologyNode:
+        pattern:
+        - birth
+        examples:
+        - birth
+        name: birth
+        polarity: 1
+      - OntologyNode:
+        pattern:
+        - death
+        examples:
+        - death
+        name: death
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - emigrate
+        name: emmigrate
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - immigrate
+        - asylum
+        name: immigrate
+        polarity: 1
+    - OntologyNode:
+      examples:
+      - prepare
+      - plan
+      - organize
+      name: prepare
+      polarity: 1
+    - OntologyNode:
+      pattern:
+      - \b([pP]roduction|[yY]ields?)\b
+      examples:
+      - produce
+      - create
+      - production
+      name: produce
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - distribute
+      - provide
+      - give
+      name: provide
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - research
+      name: research
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - protect
+      - defend
+      - secure
+      name: secure
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - supply
+      name: supply
+      polarity: 1
+    - trade:
+      - OntologyNode:
+        pattern:
+        - \bexports?\b
+        examples:
+        - export
+        name: export
+        polarity: 1
+      - OntologyNode:
+        pattern:
+        - \bimports?\b
+        examples:
+        - import
+        name: import
+        polarity: 1
+    - train_or_educate:
+      - OntologyNode:
+        examples:
+        - production practices
+        - weed control
+        - pest control
+        - post harvest
+        - agriculture training
+        name: agriculture_training
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - financial training
+        name: financial_training
+        polarity: 1
+      - humanitarian_training:
+        - OntologyNode:
+          pattern: 
+          - (SPHERE)
+          examples:
+          - humanitarian certifications
+          - SPHERE
+          - emergency preparedness training
+          name: emergency_preparedness_training
+          polarity: 1
+      - OntologyNode:
+        examples:
+        - medical training
+        name: medical_training
+        polarity: 1
+    - OntologyNode:
+      examples:
+      - sale
+      - buy
+      - sell
+      - purchase
+      - oil transaction
+      - food transaction
+      - transaction
+      name: transaction
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - disease transmission
+      - transmission
+      - community spread
+      - airborne
+      name: transmission
+      polarity: -1
+    - transport:
+      - OntologyNode:
+        examples:
+        - public transport
+        - commercial transportation
+        - air travel
+        name: commercial_transportation
+        polarity: 1
+      - OntologyNode:
+        examples:
+        - personal transportation
+        - commute
+        - taxi
+        name: personal_transportation
+        polarity: 1
+  - property:
+    - OntologyNode:
+      examples:
+      - availability
+      name: availability
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - diversity
+      name: diversity
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - insecurity
+      name: insecurity
+      polarity: -1
+    - OntologyNode:
+      examples:
+      - instability
+      name: instability
+      polarity: -1
+    - OntologyNode:
+      examples:
+      - nonutilization
+      name: nonutilization
+      polarity: -1
+    - OntologyNode:
+      pattern:
+      - \b([Cc]osts?|[Pp]rices?)\b 
+      examples:
+      - cost
+      - price
+      name: price_or_cost
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - safety
+      name: safety
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - security
+      name: security
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - stability
+      name: stability
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - unavailability
+      name: unavailability
+      polarity: -1
+    - OntologyNode:
+      examples:
+      - utilization
+      name: utilization
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - variability
+      name: variability
+      polarity: 1
+  - entity:
+    - OntologyNode:
+      examples:
+      - artifact
+      name: artifact
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - community
+      - society
+      - group
+      - village
+      name: community
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - geo-location
+      - country
+      - city
+      name: geo-location
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - agency
+      - institution
+      - government entity
+      name: government_entity
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - GPE
+      - nation
+      - city
+      name: geo-political_entity
+      polarity: 1
+    - OntologyNode:
+      pattern:
+      - household
+      examples:
+      - household
+      - family
+      name: household
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - NGO
+      - cooperative
+      - community group
+      - community based organization
+      - organization
+      name: organization
+      polarity: 1
+    - OntologyNode:
+      examples:
+      - person or group
+      name: person_or_group
+      polarity: 1
+  - time:
+    - OntologyNode:
+      examples:
+      - lean
+      - crop
+      - crop calendar
+      - planting season
+      - harvesting season
+      - season
+      name: season
+      polarity: 1

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -49,7 +49,7 @@ ontologies {
   useGrounding = false
   wordToVecPath = ${EidosSystem.path}/w2v/vectors.txt
   //wordToVecPath = ${EidosSystem.path}/w2v/glove.840B.300d.txt
-  topKNodeGroundings = 10
+  topKNodeGroundings = 10 // FIXME: we should not be maintaining the these in multiple places
   // Caching, for quick loading, language dependent
   cacheDir = ${EidosSystem.cacheDir}/${EidosSystem.language}
   useCacheForOntologies = false

--- a/src/main/scala/org/clulab/wm/eidos/apps/EvalGroundings.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/EvalGroundings.scala
@@ -36,7 +36,7 @@ object EvalGroundings {
     protected def getTop5(allGroundings: OntologyGroundings): Seq[String] =
         allGroundings(grounderName)
           .take(5)
-          .map(_._1.name)
+          .map(_.name)
 
     def evaluate(allGroundings: OntologyGroundings, gold: String): (String, String) = {
       val top5 = getTop5(allGroundings)

--- a/src/main/scala/org/clulab/wm/eidos/apps/EvalOntologyGrounders.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/EvalOntologyGrounders.scala
@@ -4,7 +4,7 @@ import java.io.File
 import java.io.PrintWriter
 
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.groundings.OntologyAliases
+import org.clulab.wm.eidos.groundings.{IndividualGrounding, OntologyAliases, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.First
@@ -179,11 +179,11 @@ object EvalOntologyGrounders extends App {
     val singleOntologyGroundingOpt = multipleOntologyGroundingsOpt.map { multipleOntologyGroundingsOpt =>
       multipleOntologyGroundingsOpt.head // Can it be assumed not to be empty?
     }
-    val nameAndValue = singleOntologyGroundingOpt.map { case (namer, value) =>
-      val name = namer.name
+    val nameAndValue = singleOntologyGroundingOpt.map { case g: IndividualGrounding =>
+      val name = g.name
       val shorterName = getShorterName(name)
 
-      (shorterName, value.toDouble)
+      (shorterName, g.score.toDouble)
     }.getOrElse("", 0d)
 
     nameAndValue
@@ -198,8 +198,8 @@ object EvalOntologyGrounders extends App {
     if (multipleOntologyGroundingsOpt.isDefined) {
       if (!correct) {
         // See how far down the list the expected value is.
-        val shorterNames = multipleOntologyGroundingsOpt.get.map { case (namer, _) =>
-          getShorterName(namer.name)
+        val shorterNames = multipleOntologyGroundingsOpt.get.map { case g =>
+          getShorterName(g.name)
         }
         val index = shorterNames.indexOf(expectedName)
 

--- a/src/main/scala/org/clulab/wm/eidos/apps/GenerateGoldGroundingTSV.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/GenerateGoldGroundingTSV.scala
@@ -3,7 +3,7 @@ package org.clulab.wm.eidos.apps
 import ai.lum.common.ConfigUtils._
 import org.clulab.struct.Interval
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.groundings.OntologyHandler
+import org.clulab.wm.eidos.groundings.{IndividualGrounding, OntologyHandler}
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
 import org.clulab.wm.eidos.utils.Sourcer
@@ -29,8 +29,8 @@ object GenerateGoldGroundingTSV extends App {
         Evaluator.grounderNames.map { groundingName =>
           allGroundings(groundingName)
               .headOption
-              .map { case (namer, score) =>
-                (namer.name, score.toString)
+              .map { case g: IndividualGrounding =>
+                (g.name, g.score.toString)
               }
               .getOrElse(("None", "None"))
         }

--- a/src/main/scala/org/clulab/wm/eidos/apps/GroundCanonicalNames.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/GroundCanonicalNames.scala
@@ -2,8 +2,7 @@ package org.clulab.wm.eidos.apps
 
 import org.clulab.struct.Interval
 import org.clulab.wm.eidos.EidosSystem
-import org.clulab.wm.eidos.groundings.OntologyGrounder
-import org.clulab.wm.eidos.groundings.OntologyHandler
+import org.clulab.wm.eidos.groundings.{OntologyGrounder, OntologyHandler, PredicateGrounding, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.Sinker
 import org.clulab.wm.eidos.utils.Sourcer
@@ -31,7 +30,10 @@ object GroundCanonicalNames extends App {
     protected def topGroundingNameAndValue(strings: Array[String]): Option[(String, Float)] = {
       val allGroundings = ontologyGrounder.groundStrings(strings)
       val namerAndFloatOpt = allGroundings.head.headOption
-      val nameAndValueOpt = namerAndFloatOpt.map { case (namer, value) => (namer.name, value) }
+      val nameAndValueOpt = namerAndFloatOpt.map {
+        case g: SingleOntologyNodeGrounding => (g.name, g.score)
+        case pred: PredicateGrounding => ???
+      }
 
       nameAndValueOpt
     }
@@ -56,9 +58,9 @@ object GroundCanonicalNames extends App {
         val groundings = ontologyHandler.reground(text, Interval(start, stop + canonicalNameParts.last.length))
 
         if (groundings.nonEmpty && groundings.head._2.nonEmpty) {
-          val (namer, value) = groundings.head._2.headOption.get
+          val individualGrounding = groundings.head._2.headOption.get
 
-          Some((namer.name, value, false))
+          Some((individualGrounding.name, individualGrounding.score, false))
         }
         else None
       }

--- a/src/main/scala/org/clulab/wm/eidos/apps/ReconstituteAndExport.scala
+++ b/src/main/scala/org/clulab/wm/eidos/apps/ReconstituteAndExport.scala
@@ -38,7 +38,8 @@ object ReconstituteAndExport extends App with Configured {
     val annotatedDocument = deserializer.deserialize(json).head
     // 3. Export to all desired formats
     exportAs.foreach { format =>
-      Exporter(format, s"$outputDir/${file.getName}", reader, groundAs, topN).export(annotatedDocument)
+      val exporter = Exporter(format, s"$outputDir/${file.getName}", reader, groundAs, topN)
+      exporter.export(annotatedDocument)
     }
   }
 }

--- a/src/main/scala/org/clulab/wm/eidos/document/SentenceClassifier.scala
+++ b/src/main/scala/org/clulab/wm/eidos/document/SentenceClassifier.scala
@@ -3,8 +3,7 @@ package org.clulab.wm.eidos.document
 import ai.lum.common.ConfigUtils._
 import com.typesafe.config.Config
 import org.clulab.processors.Sentence
-import org.clulab.wm.eidos.groundings.ConceptEmbedding
-import org.clulab.wm.eidos.groundings.OntologyHandler
+import org.clulab.wm.eidos.groundings.{ConceptEmbedding, OntologyHandler, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.groundings.grounders.FlatOntologyGrounder
 import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.Language
@@ -18,9 +17,10 @@ class SentenceClassifier(val classificationThreshold: Float, idfWeights: Map[Str
     val words = sentence.words
     val weights = words.map(idfWeights.getOrElse(_, 1.0f))
     val similarities = ontologyHandler.wordToVec.calculateSimilaritiesWeighted(words, weights, conceptEmbeddings)
-    val grounding = flatOntologyGrounder.newOntologyGrounding(similarities)
+    // FIXME: assumes flat grounding
+    val grounding = flatOntologyGrounder.newOntologyGrounding(similarities.map(SingleOntologyNodeGrounding(_)))
     // The correlation score of a sentence is set to 0 if it is below the threshold. Change it later if needed.
-    val classificationRaw = grounding.headOption.map(_._2).getOrElse(0.0f)
+    val classificationRaw = grounding.headOption.map(_.score).getOrElse(0.0f)
 
     if (classificationRaw>classificationThreshold) {classificationRaw} else 0.0f
   }

--- a/src/main/scala/org/clulab/wm/eidos/exporters/DebugGroundingExporter.scala
+++ b/src/main/scala/org/clulab/wm/eidos/exporters/DebugGroundingExporter.scala
@@ -7,23 +7,34 @@ import org.clulab.wm.eidos.utils.FileUtils
 class DebugGroundingExporter(filename: String) extends Exporter {
 
   override def export(annotatedDocument: AnnotatedDocument): Unit = {
-    FileUtils.printWriterFromFile(filename).autoClose { pw =>
+    FileUtils.printWriterFromFile(filename + ".debug.txt").autoClose { pw =>
       annotatedDocument.eidosMentions.filter(_.odinMention matches "Causal").foreach { em =>
         val args = em.eidosArguments("cause") ++ em.eidosArguments("effect")
-        val info = args.map(m => (m.odinMention.text, m.grounding.get("wm_compositional").flatMap(_.headOption)))
-        for ((text, groundingClass) <- info) {
+        val info = args.map(m => (m.odinMention.text, m.grounding.get("wm_compositional"), m.grounding.get("wm_flattened")))
+        for ((text, groundingComp, groundingFlat) <- info) {
           pw.println(s"text: ${text}")
-          groundingClass match {
+          pw.println(s"Compositional Grounding:")
+          groundingComp match {
             case None => pw.println("no grounding...")
             case Some(grounding) =>
-              pw.println(s"grounding: ${grounding.name}")
-              pw.println(s"score: ${grounding.score}")
+              grounding.grounding.foreach { gr =>
+                pw.println(s"  --> grounding: ${gr.name}")
+                pw.println(s"      score: ${gr.score}")
+              }
+          }
+          pw.println(s"Flat Grounding:")
+          groundingFlat match {
+            case None => pw.println("no grounding...")
+            case Some(grounding) =>
+              grounding.grounding.foreach { gr =>
+                pw.println(s"  --> grounding: ${gr.name}")
+                pw.println(s"      score: ${gr.score}")
+              }
           }
           pw.println()
         }
 
       }
-
     }
   }
 

--- a/src/main/scala/org/clulab/wm/eidos/exporters/DebugGroundingExporter.scala
+++ b/src/main/scala/org/clulab/wm/eidos/exporters/DebugGroundingExporter.scala
@@ -1,0 +1,30 @@
+package org.clulab.wm.eidos.exporters
+
+import org.clulab.wm.eidos.document.AnnotatedDocument
+import org.clulab.wm.eidos.utils.Closer._
+import org.clulab.wm.eidos.utils.FileUtils
+
+class DebugGroundingExporter(filename: String) extends Exporter {
+
+  override def export(annotatedDocument: AnnotatedDocument): Unit = {
+    FileUtils.printWriterFromFile(filename).autoClose { pw =>
+      annotatedDocument.eidosMentions.filter(_.odinMention matches "Causal").foreach { em =>
+        val args = em.eidosArguments("cause") ++ em.eidosArguments("effect")
+        val info = args.map(m => (m.odinMention.text, m.grounding.get("wm_compositional").flatMap(_.headOption)))
+        for ((text, groundingClass) <- info) {
+          pw.println(s"text: ${text}")
+          groundingClass match {
+            case None => pw.println("no grounding...")
+            case Some(grounding) =>
+              pw.println(s"grounding: ${grounding.name}")
+              pw.println(s"score: ${grounding.score}")
+          }
+          pw.println()
+        }
+
+      }
+
+    }
+  }
+
+}

--- a/src/main/scala/org/clulab/wm/eidos/exporters/Exporter.scala
+++ b/src/main/scala/org/clulab/wm/eidos/exporters/Exporter.scala
@@ -26,6 +26,7 @@ object Exporter {
       case "serialized" => SerializedExporter(filename)
       case "grounding" => GroundingAnnotationExporter(filename + ".ground.csv", reader, groundAs, topN)
       case "reground" => new RegroundExporter(filename + ".jsonld", reader)
+      case "debugGrounding" => new DebugGroundingExporter(filename)
       case _ => throw new NotImplementedError(s"Export mode $exporterString is not supported.")
     }
   }

--- a/src/main/scala/org/clulab/wm/eidos/exporters/RegroundExporter.scala
+++ b/src/main/scala/org/clulab/wm/eidos/exporters/RegroundExporter.scala
@@ -8,20 +8,56 @@ import org.clulab.wm.eidos.utils.Closer.AutoCloser
 import org.clulab.wm.eidos.utils.FileUtils
 
 class RegroundExporter(filename: String, reader: EidosSystem) extends JSONLDExporter(filename, reader) {
-  def export(annotatedDocuments: Seq[AnnotatedDocument]): Unit = {
+  override def export(annotatedDocument: AnnotatedDocument): Unit = {
     val ontologyHandler = reader.components.ontologyHandler
-
-    FileUtils.printWriterFromFile(filename).autoClose { pw =>
-      annotatedDocuments.foreach { annotatedDocument =>
-        annotatedDocument.allEidosMentions.foreach { eidosMention =>
-          ontologyHandler.ground(eidosMention)
-        }
-
-        val corpus = new JLDCorpus(annotatedDocument)
-        val mentionsJSONLD = corpus.serialize()
-
-        pw.println(stringify(mentionsJSONLD, pretty = true))
-      }
+    // Reground
+    annotatedDocument.allEidosMentions.foreach { eidosMention =>
+      ontologyHandler.ground(eidosMention)
     }
+    super.export(annotatedDocument)
+
+//    FileUtils.printWriterFromFile(filename + ".debug.txt").autoClose { pw =>
+//      annotatedDocument.eidosMentions.filter(_.odinMention matches "Causal").foreach { em =>
+//        val args = em.eidosArguments("cause") ++ em.eidosArguments("effect")
+//        val info = args.map(m => (m.odinMention.text, m.grounding.get("wm_compositional").flatMap(_.headOption), m.grounding.get("wm_flattened").flatMap(_.headOption)))
+//        for ((text, groundingComp, groundingFlat) <- info) {
+//          pw.println(s"text: ${text}")
+//          pw.println(s"Compositional Grounding:")
+//          groundingComp match {
+//            case None => pw.println("no grounding...")
+//            case Some(grounding) =>
+//              pw.println(s"  --> grounding: ${grounding.name}")
+//              pw.println(s"      score: ${grounding.score}")
+//          }
+//          pw.println(s"Flat Grounding:")
+//          groundingFlat match {
+//            case None => pw.println("  --> no grounding...")
+//            case Some(grounding) =>
+//              pw.println(s"  --> grounding: ${grounding.name}")
+//              pw.println(s"      score: ${grounding.score}")
+//          }
+//          pw.println()
+//        }
+//
+//      }
+//
+//    }
   }
+
+//  def export(annotatedDocuments: Seq[AnnotatedDocument]): Unit = {
+//    val ontologyHandler = reader.components.ontologyHandler
+//
+//    FileUtils.printWriterFromFile(filename).autoClose { pw =>
+//      annotatedDocuments.foreach { annotatedDocument =>
+//        annotatedDocument.allEidosMentions.foreach { eidosMention =>
+//          ontologyHandler.ground(eidosMention)
+//        }
+//
+//        val corpus = new JLDCorpus(annotatedDocument)
+//        val mentionsJSONLD = corpus.serialize()
+//
+//        pw.println(stringify(mentionsJSONLD, pretty = true))
+//      }
+//    }
+//  }
 }

--- a/src/main/scala/org/clulab/wm/eidos/exporters/RegroundExporter.scala
+++ b/src/main/scala/org/clulab/wm/eidos/exporters/RegroundExporter.scala
@@ -16,32 +16,36 @@ class RegroundExporter(filename: String, reader: EidosSystem) extends JSONLDExpo
     }
     super.export(annotatedDocument)
 
-//    FileUtils.printWriterFromFile(filename + ".debug.txt").autoClose { pw =>
-//      annotatedDocument.eidosMentions.filter(_.odinMention matches "Causal").foreach { em =>
-//        val args = em.eidosArguments("cause") ++ em.eidosArguments("effect")
-//        val info = args.map(m => (m.odinMention.text, m.grounding.get("wm_compositional").flatMap(_.headOption), m.grounding.get("wm_flattened").flatMap(_.headOption)))
-//        for ((text, groundingComp, groundingFlat) <- info) {
-//          pw.println(s"text: ${text}")
-//          pw.println(s"Compositional Grounding:")
-//          groundingComp match {
-//            case None => pw.println("no grounding...")
-//            case Some(grounding) =>
-//              pw.println(s"  --> grounding: ${grounding.name}")
-//              pw.println(s"      score: ${grounding.score}")
-//          }
-//          pw.println(s"Flat Grounding:")
-//          groundingFlat match {
-//            case None => pw.println("  --> no grounding...")
-//            case Some(grounding) =>
-//              pw.println(s"  --> grounding: ${grounding.name}")
-//              pw.println(s"      score: ${grounding.score}")
-//          }
-//          pw.println()
-//        }
-//
-//      }
-//
-//    }
+    FileUtils.printWriterFromFile(filename + ".debug.txt").autoClose { pw =>
+      annotatedDocument.eidosMentions.filter(_.odinMention matches "Causal").foreach { em =>
+        val args = em.eidosArguments("cause") ++ em.eidosArguments("effect")
+        val info = args.map(m => (m.odinMention.text, m.grounding.get("wm_compositional"), m.grounding.get("wm_flattened")))
+        for ((text, groundingComp, groundingFlat) <- info) {
+          pw.println(s"text: ${text}")
+          pw.println(s"Compositional Grounding:")
+          groundingComp match {
+            case None => pw.println("no grounding...")
+            case Some(grounding) =>
+              grounding.grounding.foreach { gr =>
+                pw.println(s"  --> grounding: ${gr.name}")
+                pw.println(s"      score: ${gr.score}")
+              }
+          }
+          pw.println(s"Flat Grounding:")
+          groundingFlat match {
+            case None => pw.println("no grounding...")
+            case Some(grounding) =>
+              grounding.grounding.foreach { gr =>
+                pw.println(s"  --> grounding: ${gr.name}")
+                pw.println(s"      score: ${gr.score}")
+              }
+          }
+          pw.println()
+        }
+
+      }
+
+    }
   }
 
 //  def export(annotatedDocuments: Seq[AnnotatedDocument]): Unit = {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -3,26 +3,43 @@ package org.clulab.wm.eidos.groundings
 import java.time.ZonedDateTime
 
 import org.clulab.wm.eidos.groundings.OntologyAliases._
+import org.clulab.wm.eidos.groundings.grounders.PredicatePackage
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.Namer
 
 object OntologyAliases {
-  type SingleOntologyGrounding = (Namer, Float)
-  type MultipleOntologyGrounding = Seq[SingleOntologyGrounding]
+//  type SingleOntologyGrounding = (Namer, Float)
+  type MultipleOntologyGrounding = Seq[IndividualGrounding]
   // The first string is the name, something like wm or un.  The second is a branch/category.
   type OntologyGroundings = Map[String, OntologyGrounding]
 }
 
+trait IndividualGrounding {
+  def name: String
+  def score: Float
+}
+case class SingleOntologyNodeGrounding(namer: Namer, score: Float) extends IndividualGrounding{
+  def name: String = namer.name
+}
+object SingleOntologyNodeGrounding {
+  def apply(tuple: (Namer, Float)): SingleOntologyNodeGrounding = SingleOntologyNodeGrounding(tuple._1, tuple._2)
+}
+case class PredicateGrounding(predicatePackage: PredicatePackage, score: Float){
+  def name: String = ???
+}
+
+
+
 case class OntologyGrounding(version: Option[String], date: Option[ZonedDateTime], grounding: MultipleOntologyGrounding = Seq.empty, branch: Option[String] = None) {
   def nonEmpty: Boolean = grounding.nonEmpty
   def take(n: Int): MultipleOntologyGrounding = grounding.take(n)
-  def headOption: Option[SingleOntologyGrounding] = grounding.headOption
-  def headName: Option[String] = headOption.map(_._1.name)
+  def headOption: Option[IndividualGrounding] = grounding.headOption
+  def headName: Option[String] = headOption.map(_.name)
 }
 
 trait OntologyGrounder {
   def name: String
   def domainOntology: DomainOntology
-  def groundOntology(mention: EidosMention, topN: Option[Int], threshold: Option[Float]): Seq[OntologyGrounding]
+  def groundEidosMention(mention: EidosMention, topN: Option[Int], threshold: Option[Float]): Seq[OntologyGrounding]
   def groundStrings(strings: Array[String]): Seq[OntologyGrounding]
 }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -3,7 +3,7 @@ package org.clulab.wm.eidos.groundings
 import java.time.ZonedDateTime
 
 import org.clulab.wm.eidos.groundings.OntologyAliases._
-import org.clulab.wm.eidos.groundings.grounders.PredicatePackage
+import org.clulab.wm.eidos.groundings.grounders.{PredicatePackage, PredicateTuple}
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.Namer
 
@@ -24,8 +24,9 @@ case class SingleOntologyNodeGrounding(namer: Namer, score: Float) extends Indiv
 object SingleOntologyNodeGrounding {
   def apply(tuple: (Namer, Float)): SingleOntologyNodeGrounding = SingleOntologyNodeGrounding(tuple._1, tuple._2)
 }
-case class PredicateGrounding(predicatePackage: PredicatePackage, score: Float){
-  def name: String = ???
+case class PredicateGrounding(predicateTuple: PredicateTuple) extends IndividualGrounding {
+  def name: String = predicateTuple.name
+  def score: Float = predicateTuple.score
 }
 
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -3,7 +3,7 @@ package org.clulab.wm.eidos.groundings
 import java.time.ZonedDateTime
 
 import org.clulab.wm.eidos.groundings.OntologyAliases._
-import org.clulab.wm.eidos.groundings.grounders.{PredicatePackage, PredicateTuple}
+import org.clulab.wm.eidos.groundings.grounders.PredicateTuple
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.Namer
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
@@ -30,7 +30,7 @@ class OntologyHandler(
 
     val ontologyGroundings = ontologyGrounders.flatMap { ontologyGrounder =>
       val name: String = ontologyGrounder.name
-      val ontologyGroundings: Seq[OntologyGrounding] = ontologyGrounder.groundOntology(eidosMention, topN = Option(5), threshold= Option(0.5f))
+      val ontologyGroundings: Seq[OntologyGrounding] = ontologyGrounder.groundEidosMention(eidosMention, topN = Option(5), threshold= Option(0.5f))
       val nameAndOntologyGroundings: Seq[(String, OntologyGrounding)] = ontologyGroundings.map { ontologyGrounding =>
         OntologyHandler.mkBranchName(name, ontologyGrounding.branch) -> ontologyGrounding
       }
@@ -152,7 +152,7 @@ class OntologyHandler(
 
     def reformat(grounding: OntologyGrounding): Array[(String, Float)] ={
       val topGroundings = grounding.take(topk).toArray
-      topGroundings.map(gr => (gr._1.name, gr._2))
+      topGroundings.map(gr => (gr.name, gr.score))
     }
 
     // FIXME: the original canonicalization needed the attachment words,

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
@@ -5,6 +5,7 @@ import com.typesafe.config.Config
 import org.clulab.odin.TextBoundMention
 import org.clulab.processors.Document
 import org.clulab.struct.Interval
+import org.clulab.utils.Configured
 import org.clulab.wm.eidos.{EidosProcessor, EidosSystem, SentencesExtractor}
 import org.clulab.wm.eidos.document.AnnotatedDocument
 import org.clulab.wm.eidos.groundings.ontologies.HalfTreeDomainOntology.HalfTreeDomainOntologyBuilder
@@ -21,7 +22,9 @@ class OntologyHandler(
   val wordToVec: EidosWordToVec,
   val sentencesExtractor: SentencesExtractor,
   val canonicalizer: Canonicalizer,
-  val includeParents: Boolean
+  val includeParents: Boolean,
+  val topN: Option[Int],
+  val threshold: Option[Float]
 ) {
 
   def ground(eidosMention: EidosMention): Unit = {
@@ -30,7 +33,7 @@ class OntologyHandler(
 
     val ontologyGroundings = ontologyGrounders.flatMap { ontologyGrounder =>
       val name: String = ontologyGrounder.name
-      val ontologyGroundings: Seq[OntologyGrounding] = ontologyGrounder.groundEidosMention(eidosMention, topN = Option(5), threshold= Option(0.5f))
+      val ontologyGroundings: Seq[OntologyGrounding] = ontologyGrounder.groundEidosMention(eidosMention, topN, threshold)
       val nameAndOntologyGroundings: Seq[(String, OntologyGrounding)] = ontologyGroundings.map { ontologyGrounding =>
         OntologyHandler.mkBranchName(name, ontologyGrounding.branch) -> ontologyGrounding
       }
@@ -203,13 +206,15 @@ object OntologyHandler {
     val useCacheForOntologies: Boolean = config[Boolean]("useCacheForOntologies")
     val useCacheForW2V: Boolean = config[Boolean]("useCacheForW2V")
     val includeParents: Boolean = config[Boolean]("includeParents")
+    val topN: Option[Int] = config.get[Int]("groundTopN")
+    val threshold: Option[Float] = config.get[Double]("groundThreshold").map(_.toFloat)
     val eidosWordToVec: EidosWordToVec = {
       // This isn't intended to be (re)loadable.  This only happens once.
       OntologyHandler.logger.info("Loading W2V...")
       EidosWordToVec(
         config[Boolean]("useGrounding"),
         config[String]("wordToVecPath"),
-        config[Int]("topKNodeGroundings"),
+        config[Int]("topKNodeGroundings"), //TODO: I don't think the W2V should be the one slicing these if our grounding API takes it as a param
         cacheDir,
         useCacheForW2V
       )
@@ -228,8 +233,8 @@ object OntologyHandler {
           grounder
         }
 
-        new OntologyHandler(ontologyGrounders, eidosWordToVec, proc, canonicalizer, includeParents)
-      case _: FakeWordToVec => new OntologyHandler(Seq.empty, eidosWordToVec, proc, canonicalizer, includeParents)
+        new OntologyHandler(ontologyGrounders, eidosWordToVec, proc, canonicalizer, includeParents, topN, threshold)
+      case _: FakeWordToVec => new OntologyHandler(Seq.empty, eidosWordToVec, proc, canonicalizer, includeParents, topN, threshold)
      case _ => ???
     }
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/EidosOntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/EidosOntologyGrounder.scala
@@ -66,7 +66,7 @@ abstract class EidosOntologyGrounder(val name: String, val domainOntology: Domai
     groundPatternsThenEmbeddings(splitText.mkString(" "), splitText, patterns, embeddings)
   }
   def groundPatternsThenEmbeddings(text: String, splitText: Array[String], patterns: Seq[ConceptPatterns], embeddings: Seq[ConceptEmbedding]): MultipleOntologyGrounding = {
-    val exactMatch = conceptEmbeddings.filter(ce => ce.namer.name.split("/").last == text)
+    val exactMatch = embeddings.filter(ce => ce.namer.name.split("/").last == text.toLowerCase)
     if (exactMatch.nonEmpty) {
       return exactMatch.map(em => SingleOntologyNodeGrounding(em.namer, 1.0f))
     }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/FlatOntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/FlatOntologyGrounder.scala
@@ -15,17 +15,8 @@ class FlatOntologyGrounder(name: String, domainOntology: DomainOntology, wordToV
   def groundEidosMention(mention: EidosMention, topN: Option[Int] = Some(5), threshold: Option[Float] = Some(0.5f)): Seq[OntologyGrounding] = {
     // Sieve-based approach
     if (EidosOntologyGrounder.groundableType(mention)) {
-      // First check to see if the text matches a regex from the ontology, if so, that is a very precise
-      // grounding and we want to use it.
-      val matchedPatterns = nodesPatternMatched(mention.odinMention.text, conceptPatterns)
-      if (matchedPatterns.nonEmpty) {
-        Seq(newOntologyGrounding(matchedPatterns))
-      }
-      // Otherwise, back-off to the w2v-based approach
-      else {
-        val canonicalNameParts = canonicalizer.canonicalNameParts(mention)
-        groundStrings(canonicalNameParts)
-      }
+      val canonicalNameParts = canonicalizer.canonicalNameParts(mention)
+      Seq(groundPatternsThenEmbeddings(mention.odinMention.text, canonicalNameParts, conceptPatterns, conceptEmbeddings))
     }
     else
       Seq(newOntologyGrounding())

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/FlatOntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/FlatOntologyGrounder.scala
@@ -2,7 +2,7 @@ package org.clulab.wm.eidos.groundings.grounders
 
 import org.clulab.wm.eidos.groundings.{DomainOntology, EidosWordToVec, OntologyGrounding, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.mentions.EidosMention
-import org.clulab.wm.eidos.utils.Canonicalizer
+import org.clulab.wm.eidos.utils.{Canonicalizer, GroundingUtils}
 
 class FlatOntologyGrounder(name: String, domainOntology: DomainOntology, wordToVec: EidosWordToVec, canonicalizer: Canonicalizer)
     extends EidosOntologyGrounder(name, domainOntology, wordToVec, canonicalizer) {
@@ -16,7 +16,9 @@ class FlatOntologyGrounder(name: String, domainOntology: DomainOntology, wordToV
     // Sieve-based approach
     if (EidosOntologyGrounder.groundableType(mention)) {
       val canonicalNameParts = canonicalizer.canonicalNameParts(mention)
-      Seq(groundPatternsThenEmbeddings(mention.odinMention.text, canonicalNameParts, conceptPatterns, conceptEmbeddings))
+      val aggregated = groundPatternsThenEmbeddings(mention.odinMention.text, canonicalNameParts, conceptPatterns, conceptEmbeddings)
+      val filtered = filterAndSlice(aggregated, topN, threshold)
+      Seq(newOntologyGrounding(filtered))
     }
     else
       Seq(newOntologyGrounding())

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/FlatOntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/FlatOntologyGrounder.scala
@@ -1,8 +1,6 @@
 package org.clulab.wm.eidos.groundings.grounders
 
-import org.clulab.wm.eidos.groundings.DomainOntology
-import org.clulab.wm.eidos.groundings.EidosWordToVec
-import org.clulab.wm.eidos.groundings.OntologyGrounding
+import org.clulab.wm.eidos.groundings.{DomainOntology, EidosWordToVec, OntologyGrounding, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.Canonicalizer
 
@@ -11,10 +9,10 @@ class FlatOntologyGrounder(name: String, domainOntology: DomainOntology, wordToV
   // TODO Move some stuff from above down here if it doesn't apply to other grounders.
 
   def groundStrings(strings: Array[String]): Seq[OntologyGrounding] = {
-    Seq(newOntologyGrounding(wordToVec.calculateSimilarities(strings, conceptEmbeddings)))
+    Seq(newOntologyGrounding(wordToVec.calculateSimilarities(strings, conceptEmbeddings).map(SingleOntologyNodeGrounding(_))))
   }
 
-  def groundOntology(mention: EidosMention, topN: Option[Int] = Some(5), threshold: Option[Float] = Some(0.5f)): Seq[OntologyGrounding] = {
+  def groundEidosMention(mention: EidosMention, topN: Option[Int] = Some(5), threshold: Option[Float] = Some(0.5f)): Seq[OntologyGrounding] = {
     // Sieve-based approach
     if (EidosOntologyGrounder.groundableType(mention)) {
       // First check to see if the text matches a regex from the ontology, if so, that is a very precise

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/InterventionGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/InterventionGrounder.scala
@@ -1,21 +1,20 @@
 package org.clulab.wm.eidos.groundings.grounders
 
-import org.clulab.wm.eidos.groundings.DomainOntology
-import org.clulab.wm.eidos.groundings.EidosWordToVec
-import org.clulab.wm.eidos.groundings.OntologyGrounding
+import org.clulab.wm.eidos.groundings.{DomainOntology, EidosWordToVec, OntologyGrounding, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.Canonicalizer
 
 // TODO: Zupon
+@deprecated("This grounder is deprecated", "2020-08-11")
 class InterventionGrounder(name: String, domainOntology: DomainOntology, w2v: EidosWordToVec, canonicalizer: Canonicalizer)
 // TODO This might extend something else
     extends EidosOntologyGrounder(name, domainOntology, w2v, canonicalizer) {
 
   def groundStrings(strings: Array[String]): Seq[OntologyGrounding] = {
-    Seq(newOntologyGrounding(w2v.calculateSimilarities(strings, conceptEmbeddings), Some("intervention")))
+    Seq(newOntologyGrounding(w2v.calculateSimilarities(strings, conceptEmbeddings).map(SingleOntologyNodeGrounding(_)), Some("intervention")))
   }
 
-  def groundOntology(mention: EidosMention, topN: Option[Int] = Option(5), threshold: Option[Float] = Option(0.5f)): Seq[OntologyGrounding] = {
+  def groundEidosMention(mention: EidosMention, topN: Option[Int] = Option(5), threshold: Option[Float] = Option(0.5f)): Seq[OntologyGrounding] = {
     val canonicalNameParts = canonicalizer.canonicalNameParts(mention)
 
     groundStrings(canonicalNameParts)

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/InterventionSieveGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/InterventionSieveGrounder.scala
@@ -1,10 +1,6 @@
 package org.clulab.wm.eidos.groundings.grounders
 
-import org.clulab.wm.eidos.groundings.ConceptEmbedding
-import org.clulab.wm.eidos.groundings.ConceptPatterns
-import org.clulab.wm.eidos.groundings.DomainOntology
-import org.clulab.wm.eidos.groundings.EidosWordToVec
-import org.clulab.wm.eidos.groundings.OntologyGrounding
+import org.clulab.wm.eidos.groundings.{ConceptEmbedding, ConceptPatterns, DomainOntology, EidosWordToVec, OntologyGrounding, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.Canonicalizer
 
@@ -35,13 +31,14 @@ class InterventionSieveGrounder(name: String, domainOntology: DomainOntology, wo
     )
   }
 
-  def groundOntology(mention: EidosMention, topN: Option[Int] = Some(5), threshold: Option[Float] = Some(0.5f)): Seq[OntologyGrounding] = {
+  def groundEidosMention(mention: EidosMention, topN: Option[Int] = Some(5), threshold: Option[Float] = Some(0.5f)): Seq[OntologyGrounding] = {
     if (EidosOntologyGrounder.groundableType(mention)) {
       // First check to see if the text matches a regex from the main part of the ontology,
       // if so, that is a very precise grounding and we want to use it.
       val matchedPatternsMain = nodesPatternMatched(mention.odinMention.text, conceptPatternsSeq(InterventionSieveGrounder.REST))
       if (matchedPatternsMain.nonEmpty) {
-        Seq(newOntologyGrounding(matchedPatternsMain))
+        val groundings = matchedPatternsMain
+        Seq(newOntologyGrounding(groundings))
       }
       // Otherwise, back-off to the w2v-based approach for main branch and a sieve for interventions
       else {
@@ -50,6 +47,7 @@ class InterventionSieveGrounder(name: String, domainOntology: DomainOntology, wo
         // Main Portion of the ontology
         val mainConceptEmbeddings = conceptEmbeddingsSeq(InterventionSieveGrounder.REST)
         val mainSimilarities = wordToVec.calculateSimilarities(canonicalNameParts, mainConceptEmbeddings)
+          .map(SingleOntologyNodeGrounding(_))
 
         // Intervention Branch
         // Only allow grounding to these nodes if the patterns match
@@ -62,14 +60,13 @@ class InterventionSieveGrounder(name: String, domainOntology: DomainOntology, wo
             matchedPatternsInterventions
           else {
             val interventionConceptEmbeddings = conceptEmbeddingsSeq(InterventionSieveGrounder.INTERVENTION)
-
             wordToVec.calculateSimilarities(canonicalNameParts, interventionConceptEmbeddings)
+              .map(SingleOntologyNodeGrounding(_))
           }
         }
         else
           Seq.empty
-        val similarities = (mainSimilarities ++ interventionSimilarities).sortBy(-_._2).take(topN.get)
-
+        val similarities = (mainSimilarities ++ interventionSimilarities).sortBy(-_.score).take(topN.get)
         Seq(newOntologyGrounding(similarities))
       }
     }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
@@ -1,0 +1,188 @@
+package org.clulab.wm.eidos.groundings.grounders
+
+import org.clulab.odin.Mention
+import org.clulab.processors.Sentence
+import org.clulab.processors.fastnlp.FastNLPProcessorWithSemanticRoles
+import org.clulab.struct.{DirectedGraph, Interval}
+import org.clulab.wm.eidos.groundings.{ConceptEmbedding, ConceptPatterns, DomainOntology, EidosWordToVec, OntologyGrounding}
+import org.clulab.wm.eidos.mentions.EidosMention
+import org.clulab.wm.eidos.utils.Canonicalizer
+import org.slf4j.{Logger, LoggerFactory}
+import sun.reflect.generics.reflectiveObjects.NotImplementedException
+import SRLCompositionalGrounder._
+
+import scala.annotation.tailrec
+
+case class GroundedToken(index: Int, grounding: OntologyGrounding)
+case class PredicatePackage(predicate: GroundedToken, agent: Seq[GroundedToken] = Nil, theme: Seq[GroundedToken] = Nil, other: Seq[GroundedToken] = Nil)
+
+class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v: EidosWordToVec, canonicalizer: Canonicalizer)
+  extends EidosOntologyGrounder(name, domainOntology, w2v, canonicalizer) {
+
+  lazy val proc = new FastNLPProcessorWithSemanticRoles
+
+  def inBranch(s: String, branches: Seq[ConceptEmbedding]): Boolean =
+    branches.exists(_.namer.name == s)
+
+  protected lazy val conceptEmbeddingsSeq: Map[String, Seq[ConceptEmbedding]] =
+    CompositionalGrounder.branches.map { branch =>
+      (branch, conceptEmbeddings.filter { _.namer.branch.contains(branch) })
+    }.toMap
+
+  protected lazy val conceptPatternsSeq: Map[String, Seq[ConceptPatterns]] =
+    CompositionalGrounder.branches.map { branch =>
+      (branch, conceptPatterns.filter { _.namer.branch.contains(branch) })
+    }.toMap
+
+  // primarily used for passing in the canonical name parts
+  override def groundStrings(strings: Array[String]): Seq[OntologyGrounding] = {
+    SRLCompositionalGrounder.logger.info("The SRLCompositionalGrounder isn't designed to be used with canonical name parts only.")
+    ???
+  }
+
+  override def groundText(text: String): OntologyGrounding = {
+    val doc = proc.annotate(text)
+    val groundings = for {
+      s <- doc.sentences
+      // FIXME -- the empty sequence here is a placeholder for increase/decrease triggers
+      ontologyGrounding <- groundSentenceSpan(s, 0, s.words.length, Seq())
+      singleGrounding <- ontologyGrounding.grounding
+    } yield singleGrounding
+
+    val groundingResult = newOntologyGrounding(groundings.sortBy(- _.score))
+    groundingResult
+  }
+
+  def groundSentenceSpan(s: Sentence, start: Int, end: Int, exclude: Seq[Int]): Seq[OntologyGrounding] = {
+    val tokenInterval = Interval(start, end)
+    groundSentenceSpan(s, tokenInterval, exclude)
+  }
+  def groundSentenceSpan(s: Sentence, tokenInterval: Interval, exclude: Seq[Int]): Seq[OntologyGrounding] = {
+    //  3) for each Concept (cause/effect), look for all predicates --> these are the processes
+    val conceptPredicates = groundPredicates(s, tokenInterval, exclude)
+
+    //  9) ask Keith to pretty please make a way to output it in the json
+    ???
+  }
+
+  override def groundEidosMention(mention: EidosMention, topN: Option[Int] = None, threshold: Option[Float] = None): Seq[OntologyGrounding] = {
+    // Do nothing to non-groundableType mentions
+    if (!EidosOntologyGrounder.groundableType(mention))
+      Seq(newOntologyGrounding())
+    // or else ground them.
+    else {
+      val attachmentTriggers = findAttachmentTriggers(mention.odinMention)
+      groundSentenceSpan(mention.odinMention.sentenceObj, mention.odinMention.start, mention.odinMention.end, attachmentTriggers)
+    }
+  }
+
+
+
+  def groundPredicates(sentence: Sentence, tokenInterval: Interval, exclude: Seq[Int]): Seq[PredicatePackage] = {
+    val srls = sentence.semanticRoles.get
+    val predicates = srls.roots.toSeq
+      // keep only predicates that are within the mention
+      .filter(tokenInterval contains _)
+      // remove the predicates which correspond to our increase/decrease/quantifiers
+      .filterNot(exclude contains _)
+      // start with those closest to the syntactic root of the sentence to begin with "higher level" predicates
+      .sortBy(minGraphDistanceToSyntacticRoot(_, sentence.dependencies.get))
+
+    packagePredicates(predicates, Seq(), Set(), srls, predicates.toSet)
+  }
+
+
+
+  @tailrec
+  private def packagePredicates(remaining: Seq[Int], results: Seq[PredicatePackage], seen: Set[Int], srls: DirectedGraph[String], predicates: Set[Int]): Seq[PredicatePackage] = {
+    remaining match {
+      case Seq() => results
+      case Seq(curr) => results ++ Seq(mkPredicatePackage(curr, srls, predicates))
+      case curr :: rest =>
+        if (seen contains curr) {
+          // we've been here before
+          packagePredicates(rest, results, seen, srls, predicates)
+        } else if (srls.roots contains curr) {
+          // Otherwise, it's new and it's a predicate
+          val packaged = mkPredicatePackage(curr, srls, predicates)
+          packagePredicates(rest, results ++ Seq(packaged), seen ++ Set(curr), srls, predicates)
+        }
+        else {
+          ???
+          // I don't think this should happen
+          // It's not a predicate, meaning it has already been included in some other predicate's package
+          // packagePredicate(rest, results, seen ++ Set(curr), srls, predicates)
+        }
+    }
+  }
+
+  // Ground the predicate and also ground each of the relevant arguments
+  // Return a PredicatePackage object
+  private def mkPredicatePackage(predicate: Int, srls: DirectedGraph[String], validPredicates: Set[Int]): PredicatePackage = {
+    // Otherwise, it's new.  If it's a predicate:
+    val groundedPredicate = groundToken(predicate, validPredicates)
+    // get the arguments
+    val agents = groundArguments(predicate, AGENT_ROLE, srls, validPredicates)
+    val themes = groundArguments(predicate, THEME_ROLE, srls, validPredicates)
+    val others = groundArguments(predicate, OTHER_ROLE, srls, validPredicates)
+    PredicatePackage(groundedPredicate, agents, themes, others)
+  }
+
+  // Find all arguments from a given predicate of a certain role (e.g., A1, A0, etc) and ground them
+  private def groundArguments(predicate: Int, role: String, srls: DirectedGraph[String], validPredicates: Set[Int]): Seq[GroundedToken] = {
+    srls.outgoingEdges(predicate)
+      .filter(_._2 == role)
+      .map(tok => groundToken(tok._1, validPredicates))
+  }
+
+  // Ground a single token in isolation
+  //  4) if an arg is itself a predicate => it's a process
+  //  6) else if it matches a property regex => it's a property
+  //  7) else it's a concept
+  //  8) assemble the groundings for above steps into the data structure
+  private def groundToken(token: Int, validPredicates: Set[Int]): GroundedToken = {
+    if (validPredicates contains token) {
+      GroundedToken(token, groundProcess())
+    } else if (isProperty()) {
+      GroundedToken(token, groundProperty())
+    } else {
+      GroundedToken(token, groundConcept())
+    }
+  }
+
+  private def isProperty(): Boolean = ???
+
+  // Find the shortest distance (in the syntax graph) between a given token and any of the roots
+  private def minGraphDistanceToSyntacticRoot(token: Int, deps: DirectedGraph[String]): Int = {
+    // Get the sentence roots -- there can be more than one
+    val roots = deps.roots
+    // for each, check the shortest path from that root to the given token
+    val pathLengths = roots.map(root => deps.shortestPath(root, token, ignoreDirection = true).length)
+    // select the shortest to be the distance from the token to any of the roots
+    pathLengths.min
+  }
+  private def findAttachmentTriggers(mention: Mention): Seq[Int] = ???
+  private def isModifierTrigger(token: Int, mention: Mention): Boolean = ???
+
+  private  def groundProcess() = groundBranch(PROCESS)
+  private def groundProperty() = groundBranch(PROPERTY)
+  private def groundConcept() = groundBranch(CONCEPT)
+
+  private def groundBranch(branch: String) = ???
+
+}
+
+object SRLCompositionalGrounder{
+
+  protected lazy val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  // Semantic Roles
+  val AGENT_ROLE = "A0"
+  val THEME_ROLE = "A1"
+  val OTHER_ROLE = "AX"
+  val TIME_ROLE = "AM-TMP"
+  val LOC_ROLE = "AM-LOC" // FIXME: may need offline processing to make happen
+  // Compositional Ontology Branches
+  val PROCESS = "process"
+  val CONCEPT = "concept"
+  val PROPERTY = "property"
+}

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
@@ -2,7 +2,6 @@ package org.clulab.wm.eidos.groundings.grounders
 
 import org.clulab.odin.Mention
 import org.clulab.processors.Sentence
-import org.clulab.processors.fastnlp.FastNLPProcessorWithSemanticRoles
 import org.clulab.struct.{DirectedGraph, Interval}
 import org.clulab.wm.eidos.attachments.{ContextAttachment, Property, TriggeredAttachment}
 import org.clulab.wm.eidos.groundings.{ConceptEmbedding, ConceptPatterns, DomainOntology, EidosWordToVec, OntologyGrounding, PredicateGrounding}
@@ -10,6 +9,8 @@ import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.{Canonicalizer, GroundingUtils}
 import org.slf4j.{Logger, LoggerFactory}
 import SRLCompositionalGrounder._
+import org.clulab.dynet.Utils
+import org.clulab.processors.clu.CluProcessor
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
@@ -22,13 +23,13 @@ case class PredicateTuple(theme: OntologyGrounding, themeProperties: OntologyGro
       val sb = new ArrayBuffer[String]()
       sb.append(s"THEME: ${theme.headName.get}")
       if (themeProperties.nonEmpty) {
-       sb.append(s" (Properties: ${themeProperties.take(5).map(_.name).mkString(", ")})")
+       sb.append(s" (Theme properties: ${themeProperties.take(5).map(_.name).mkString(", ")})")
       }
       if (themeProcess.nonEmpty) {
-        sb.append(s"; THEME PROCESS: ${themeProcess.headName.get})")
+        sb.append(s"; THEME PROCESS: ${themeProcess.headName.get}")
       }
       if (themeProcessProperties.nonEmpty) {
-        sb.append(s" (Properties: ${themeProcessProperties.take(5).map(_.name).mkString(", ")})")
+        sb.append(s" (Process properties: ${themeProcessProperties.take(5).map(_.name).mkString(", ")})")
       }
       sb.mkString("")
     } else {
@@ -44,39 +45,14 @@ case class PredicateTuple(theme: OntologyGrounding, themeProperties: OntologyGro
   }
 }
 
-case class PredicatePackage(predicate: Seq[GroundedSpan], agent: Seq[GroundedSpan] = Nil, theme: Seq[GroundedSpan] = Nil, other: Seq[GroundedSpan] = Nil) {
-  def toPredicateTuple(grounder: EidosOntologyGrounder): PredicateTuple = {
-    def emptyGrounding: OntologyGrounding = grounder.newOntologyGrounding()
-    def emptyTuple: PredicateTuple = PredicateTuple(emptyGrounding, emptyGrounding, emptyGrounding, emptyGrounding)
-    def propsGrounding(props: Seq[GroundedSpan]): OntologyGrounding = {
-      val allProps = props.flatMap(p => p.grounding.grounding)
-      val branch = props.head.grounding.branch
-      grounder.newOntologyGrounding(allProps, branch)
-    }
-
-    val (propertyThemes, otherThemes) = theme.partition(_.isProperty)
-    // fixme: this isn't quite right -- what about the process properties??
-
-    (predicate, otherThemes, propertyThemes) match {
-      case (Seq(), Seq(), Seq())  => emptyTuple
-      case (Seq(), Seq(), props)  =>
-        println(s"There are properties, but no theme or process: $this")
-        emptyTuple
-      case (preds, Seq(), Seq())  => PredicateTuple( preds.head.grounding,  emptyGrounding,        emptyGrounding,       emptyGrounding)
-      case (preds, Seq(), props)  => PredicateTuple( preds.head.grounding,  propsGrounding(props), emptyGrounding,       emptyGrounding)
-      case (Seq(), themes, Seq()) => PredicateTuple( themes.head.grounding, emptyGrounding,        emptyGrounding,       emptyGrounding)
-      case (Seq(), themes, props) => PredicateTuple( themes.head.grounding, propsGrounding(props), emptyGrounding,       emptyGrounding)
-      case (preds, themes, Seq()) => PredicateTuple( themes.head.grounding, emptyGrounding,        preds.head.grounding, emptyGrounding)
-      case (preds, themes, props) => PredicateTuple( themes.head.grounding, propsGrounding(props), preds.head.grounding, emptyGrounding)
-      case _ => throw new RuntimeException(s"Unhandled situation in converting predicate to tuple: ${this.toString}")
-    }
-  }
-}
-
 class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v: EidosWordToVec, canonicalizer: Canonicalizer)
   extends EidosOntologyGrounder(name, domainOntology, w2v, canonicalizer) {
 
-  lazy val proc = new FastNLPProcessorWithSemanticRoles
+  lazy val proc = {
+    Utils.initializeDyNet()
+    new CluProcessor()
+  }
+
 
   def inBranch(s: String, branches: Seq[ConceptEmbedding]): Boolean =
     branches.exists(_.namer.name == s)
@@ -112,12 +88,13 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
   }
 
   override def groundEidosMention(mention: EidosMention, topN: Option[Int] = None, threshold: Option[Float] = None): Seq[OntologyGrounding] = {
-    // Do nothing to non-groundableType mentions
+    // Do nothing to non-groundable mentions
     if (!EidosOntologyGrounder.groundableType(mention))
       Seq(newOntologyGrounding())
     // or else ground them.
     else {
-      groundSentenceSpan(mention.odinMention.sentenceObj, mention.odinMention.start, mention.odinMention.end, attachmentStrings(mention.odinMention), topN, threshold)
+      val reParsed = proc.annotate(mention.odinMention.sentenceObj.getSentenceText)
+      groundSentenceSpan(reParsed.sentences.head, mention.odinMention.start, mention.odinMention.end, attachmentStrings(mention.odinMention), topN, threshold)
     }
   }
 
@@ -127,87 +104,101 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
   }
 
   def groundSentenceSpan(s: Sentence, tokenInterval: Interval, exclude: Set[String], topN: Option[Int], threshold: Option[Float]): Seq[OntologyGrounding] = {
-    val conceptPredicates = groundPredicates(s, tokenInterval, exclude, topN, threshold)
-    val predicateGroundings = conceptPredicates
-      // Convert to the flattened tuple
-      .map(_.toPredicateTuple(this))
-      // Put in the format needed to export as a Grounding
-      .map(PredicateGrounding)
-    val filtered = filterAndSlice(predicateGroundings, topN, threshold)
-
-    if (filtered.nonEmpty) {
-      Seq(newOntologyGrounding(filtered))
-    } else {
-      val pseudoTheme = groundToBranches(Seq(CONCEPT), tokenInterval, s, topN, threshold)
-      val predicateTuple = PredicateTuple(pseudoTheme, newOntologyGrounding(), newOntologyGrounding(), newOntologyGrounding())
-      Seq(newOntologyGrounding(Seq(PredicateGrounding(predicateTuple)), Some(CONCEPT)))
+    val sentenceHelper = SentenceHelper(s, tokenInterval, exclude)
+    val srlGrounding = sentenceHelper.validPredicates match {
+      case Seq() =>
+        // No predicates
+        val pseudoTheme = groundToBranches(Seq(CONCEPT), tokenInterval, s, topN, threshold)
+        val predicateTuple = PredicateTuple(pseudoTheme, newOntologyGrounding(), newOntologyGrounding(), newOntologyGrounding())
+        PredicateGrounding(predicateTuple)
+      case preds =>
+        val predicateTuple = f(preds.head, Seq(), sentenceHelper, topN, threshold)
+        PredicateGrounding(predicateTuple)
     }
-  }
 
-  def groundPredicates(sentence: Sentence, tokenInterval: Interval, exclude: Set[String], topN: Option[Int], threshold: Option[Float]): Seq[PredicatePackage] = {
-    val sentenceHelper = SentenceHelper(sentence, tokenInterval, exclude)
-    packagePredicates(sentenceHelper.validPredicates, Seq(), Set(), sentenceHelper, topN, threshold)
-  }
+    Seq(newOntologyGrounding(Seq(srlGrounding)))
 
+    // Am I done here? or do I need to filter and slice?
+  }
 
   @tailrec
-  private def packagePredicates(remaining: Seq[Int], results: Seq[PredicatePackage], seen: Set[Int], s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): Seq[PredicatePackage] = {
-    remaining match {
-      case Seq() => results
-      case Seq(curr) => results ++ Seq(mkPredicatePackage(curr, s, topN, threshold))
-      case Seq(curr, tail @ _*) =>
-        if (seen contains curr) {
-          // we've been here before
-          packagePredicates(tail, results, seen, s, topN, threshold)
-        } else if (s.srls.roots contains curr) {
-          // Otherwise, it's new and it's a predicate
-          // TODO: this currently does not "nest" the predicates, if we decide we want to, we'll need to adjust it
-          //  if on the other hand, we want only to output the 4-tuples, then it shouldn't matter
-          val packaged = mkPredicatePackage(curr, s, topN, threshold)
-          println(s"packaged: $packaged")
-          packagePredicates(tail, results ++ Seq(packaged), seen ++ Set(curr), s, topN, threshold)
-        }
-        else {
-          ???
-          // I don't think this should happen
-          // It's not a predicate, meaning it has already been included in some other predicate's package
-          // packagePredicate(rest, results, seen ++ Set(curr), srls, predicates)
-        }
+  private def f(pred: Int, attachedProperties: Seq[OntologyGrounding], s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): PredicateTuple = {
+    val themes = getThemes(pred, s, backoff = true).sortBy(s.minGraphDistanceToSyntacticRoot)
+    val theme = themes.headOption
+
+    val propertyOpt = maybeProperty(Interval(pred, pred + 1), s)
+    if (propertyOpt.isEmpty) {
+      val groundedPred = groundChunk(pred, s, topN, threshold)
+      val groundedAttachedProps = attachedProperties.headOption.getOrElse(newOntologyGrounding())
+      if (theme.isDefined) {
+        // If there's a theme, it occupies the theme position in the tuple
+        val (groundedTheme, groundedThemeProps) = tupelize(theme.get, s, topN, threshold)
+        PredicateTuple(groundedTheme, groundedThemeProps, groundedPred.grounding, groundedAttachedProps)
+      } else {
+        // Promote the predicate
+        PredicateTuple(groundedPred.grounding, groundedAttachedProps, newOntologyGrounding(), newOntologyGrounding())
+      }
+    }
+    else {
+      // If the predicate was a property, it is "demoted" to a process property
+      if (theme.nonEmpty) {
+        f(theme.get, attachedProperties ++ Seq(propertyOpt.get), s, topN, threshold)
+      } else {
+        // property and no theme -- promote the property
+        // todo: should we do this?
+        logger.warn("Promoting Property with no Theme or Process")
+        PredicateTuple(propertyOpt.get, newOntologyGrounding(), newOntologyGrounding(), newOntologyGrounding())
+      }
     }
   }
 
-  // Ground the predicate and also ground each of the relevant arguments
-  // Return a PredicatePackage object
-  private def mkPredicatePackage(predicate: Int, s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): PredicatePackage = {
-    // Otherwise, it's new.  If it's a predicate:
-    println("\n**************************************************")
-    println(s"grounding the predicate: ${s.words(predicate)}")
-    val groundedPredicate = groundChunk(predicate, s, topN, threshold)
-    // get the arguments
-    println(s"grounding the agents")
-    val agents = groundArguments(predicate, AGENT_ROLE, s, topN, threshold)
-    println(s"grounding the themes")
-    val themes = groundArguments(predicate, THEME_ROLE, s, topN, threshold)
-    println(s"grounding the others")
-    val others = groundArguments(predicate, OTHER_ROLE, s, topN, threshold)
 
-    groundedPredicate match {
-      case prop if prop.isProperty =>
-        println("The predicate was a property, so we're switching the themes with it")
-        // If the predicate is a property, then the we need to switch the theme and the predicate
-        PredicatePackage(themes, agents, Seq(groundedPredicate), others)
-      case _ => PredicatePackage(Seq(groundedPredicate), agents, themes, others)
+  def tupelize(tok: Int, s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): (OntologyGrounding, OntologyGrounding) = {
+
+    val propertyOpt = maybeProperty(Interval(tok, tok + 1), s)
+    if (propertyOpt.isDefined) {
+      // it's a property and there's a theme
+      val themes = getThemes(tok, s, backoff = false)
+      if (themes.nonEmpty) {
+        // there is a theme
+        val groundedThemes = themes
+          .map(t => groundChunk(t, s, topN, threshold))
+          .sortBy(_.grounding.headOption.map(_.score).getOrElse(-1.0f))
+        // Since we know there's at least one theme, head here is safe
+        val bestGroundedTheme = groundedThemes.head
+        (bestGroundedTheme.grounding, propertyOpt.get)
+      } else {
+        // there is no theme, promote the property?
+        // todo: do we want to do this?
+        logger.warn("Promoting Property with no Theme")
+        (propertyOpt.get, newOntologyGrounding())
+      }
+    } else {
+      // the token is not a property
+      val groundedTok = groundChunk(tok, s, topN, threshold)
+      (groundedTok.grounding, newOntologyGrounding())
     }
-
-
   }
 
-  // Find all arguments from a given predicate of a certain role (e.g., A1, A0, etc) and ground them
-  private def groundArguments(predicate: Int, role: String, s:SentenceHelper, topN: Option[Int], threshold: Option[Float]): Seq[GroundedSpan] = {
+  private def getThemes(predicate: Int, s: SentenceHelper, backoff: Boolean): Array[Int] = {
+    val found = getArguments(predicate, THEME_ROLE, s)
+    if (found.isEmpty && backoff) {
+      val other = getArguments(predicate, OTHER_ROLE, s).toSet
+      val compounds = s.outgoingOfType(predicate, Seq("compound")).toSet
+      // prevent infinite loops in edge cases
+      (other.intersect(compounds) - predicate).toArray
+    } else {
+      // prevent infinite loops in edge cases
+      found.filterNot(_ == predicate)
+    }
+  }
+
+  private def getArguments(predicate: Int, role: String, s: SentenceHelper): Array[Int] = {
     s.srls.outgoingEdges(predicate)
-      .filter(_._2 == role)
-      .flatMap(dst => handlePrepositions(dst, s))
-      .map(tok => groundChunk(tok._1, s, topN, threshold))
+      .filter(edge => edge._2 == role)
+      .filter(edge => s.tokenInterval.contains(edge._1))
+//      .flatMap(handlePrepositions(_, s))
+      .map(_._1)
   }
 
   // In SRL, currently the arguments that point to a preposition stay there, rather than continuing
@@ -215,7 +206,7 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
   // object(s) of the preposition, if any.
   private def handlePrepositions(step: (Int, String), s: SentenceHelper): Seq[(Int, String)] = {
     val (dst, role) = step
-    println(s"Checking for preposition: ${s.words(dst)}")
+//    println(s"Checking for preposition: ${s.words(dst)}")
     s.tokenOrObjOfPreposition(dst).map((_, role))
   }
 
@@ -233,30 +224,16 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
     // First check to see if it's a property, if it is, ground as that
     val propertyOpt = maybeProperty(trimmedChunk, s)
     if (propertyOpt.isDefined) {
-      val g = GroundedSpan(trimmedChunk, propertyOpt.get, isProperty = true)
-      println(s"PROPERTY: grounded <<${s.wordsSliceString(trimmedChunk)}>> as: ${g}")
-      g
+      GroundedSpan(trimmedChunk, propertyOpt.get, isProperty = true)
     } else {
       // Otherwise, ground as either a process or concept
-      val g = GroundedSpan(trimmedChunk, groundToBranches(Seq(CONCEPT, PROCESS), trimmedChunk, s.sentence, topN, threshold), isProperty = false)
-      println(s"grounded <<${s.wordsSliceString(trimmedChunk)}>> as: ${g}")
-      g
+      GroundedSpan(trimmedChunk, groundToBranches(Seq(CONCEPT, PROCESS), trimmedChunk, s.sentence, topN, threshold), isProperty = false)
     }
   }
 
   private def maybeProperty(span: Interval, s: SentenceHelper): Option[OntologyGrounding] = {
-    val tempGrounding = groundProperty(span, s, topN=Option(1), threshold=Option(0.8f))
+    val tempGrounding = groundProperty(span, s, topN=Option(1), threshold=Option(0.85f))
     if (tempGrounding.nonEmpty) Option(tempGrounding) else None
-  }
-
-  // Find the shortest distance (in the syntax graph) between a given token and any of the roots
-  private def minGraphDistanceToSyntacticRoot(token: Int, deps: DirectedGraph[String]): Int = {
-    // Get the sentence roots -- there can be more than one
-    val roots = deps.roots
-    // for each, check the shortest path from that root to the given token
-    val pathLengths = roots.map(root => deps.shortestPath(root, token, ignoreDirection = true).length)
-    // select the shortest to be the distance from the token to any of the roots
-    pathLengths.min
   }
 
   // Get the triggers, quantifiers, and context phrases of the attachments
@@ -271,13 +248,6 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
     }
   }
 
-//  private def groundToAllBranches(span: Interval, s: Sentence, topN: Option[Int], threshold: Option[Float]): OntologyGrounding = {
-//    val contentWords = canonicalizer.canonicalWordsFromSentence(s, span).toArray
-//    val initialGroundings = groundPatternsThenEmbeddings(contentWords, conceptPatterns, conceptEmbeddings)
-//    val filtered = filterAndSlice(initialGroundings, topN, threshold)
-//    newOntologyGrounding(filtered)
-//  }
-
   private def groundProperty(span: Interval, s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): OntologyGrounding = groundToBranches(Seq(PROPERTY), span, s, topN, threshold)
 
   private def groundToBranches(branches: Seq[String], span: Interval, s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): OntologyGrounding = {
@@ -291,137 +261,146 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
     val filtered = filterAndSlice(initialGroundings, topN, threshold)
     newOntologyGrounding(filtered)
   }
+}
 
-
-  // Helper class to hold a bunch of things that are needed throughout the process for grounding
-  case class SentenceHelper(sentence: Sentence, tokenInterval: Interval, exclude: Set[String]) {
-    val chunks: Array[String] = sentence.chunks.get
-    val chunkIntervals: Seq[Interval] = chunkSpans
-    val words: Array[String] = sentence.words
-    val srls: DirectedGraph[String] = sentence.semanticRoles.get
-    val dependencies: DirectedGraph[String] = sentence.dependencies.get
-    // The roots of the SRL graph that are within the concept being grounded and aren't part of
-    // an something we're ignoring (e.g., increase/decrease/quantification)
-    val validPredicates: Seq[Int] = {
-      srls.roots.toSeq
+// Helper class to hold a bunch of things that are needed throughout the process for grounding
+case class SentenceHelper(sentence: Sentence, tokenInterval: Interval, exclude: Set[String]) {
+  val chunks: Array[String] = sentence.chunks.get
+  val chunkIntervals: Seq[Interval] = chunkSpans
+  val words: Array[String] = sentence.words
+  val srls: DirectedGraph[String] = sentence.enhancedSemanticRoles.get
+  val dependencies: DirectedGraph[String] = sentence.dependencies.get
+  // The roots of the SRL graph that are within the concept being grounded and aren't part of
+  // an something we're ignoring (e.g., increase/decrease/quantification)
+  val validPredicates: Seq[Int] = {
+    srls.roots.toSeq
       // keep only predicates that are within the mention
       .filter(tokenInterval contains _)
       // remove the predicates which correspond to our increase/decrease/quantifiers
       .filterNot(exclude contains words(_))
       // start with those closest to the syntactic root of the sentence to begin with "higher level" predicates
-      .sortBy(minGraphDistanceToSyntacticRoot(_, sentence.dependencies.get))
-    }
-
-    val allTokensInvolvedInPredicates: Seq[Int] = {
-      srls.allEdges
-        .flatMap(edge => Seq(edge._1, edge._2))
-        .flatMap(tokenOrObjOfPreposition)
-        .distinct
-        .sorted
-    }
-
-    def findStart(chunkSpan: Interval, tok: Int): Int = {
-      if (chunkSpan.start == tok) {
-        tok
-      } else {
-        val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
-        // not the first thing in the sequence
-        val startLimit = if (currTokenIdx > 0) {
-          allTokensInvolvedInPredicates(currTokenIdx - 1) + 1
-        } else chunkSpan.start
-        println(s"startLimit: $startLimit")
-        val start = math.max(chunkSpan.start, startLimit)
-        println(s"start: $start")
-        start
-      }
-    }
-
-    def findEnd(chunkSpan: Interval, tok: Int): Int = {
-      if (chunkSpan.end == tok) {
-        tok
-      } else {
-        val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
-        // not the first thing in the sequence
-        val endLimit = if (currTokenIdx < allTokensInvolvedInPredicates.length - 1) {
-          allTokensInvolvedInPredicates(currTokenIdx + 1) // don't need to subtract 1 bc exclusive interval
-        } else chunkSpan.end
-        println(s"endLimit: $endLimit")
-        val end = math.min(chunkSpan.end, endLimit)
-        println(s"end: $end")
-        end
-      }
-    }
-
-    def chunkAvoidingSRLs(chunkSpan: Interval, tok: Int): Interval = {
-      assert(allTokensInvolvedInPredicates.contains(tok))
-      val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
-      println(s"Trimming: (tok=$tok, idx=${currTokenIdx})")
-      println(allTokensInvolvedInPredicates.mkString(", "))
-
-      // If the tok starts the chunk
-      val start = findStart(chunkSpan, tok)
-      val end = findEnd(chunkSpan, tok)
-      Interval(start, end)
-    }
-
-    // Make a Seq of the Intervals corresponding to the syntactic chunks in the sentence (inclusive, exclusive).
-    def chunkSpans: Seq[Interval] = {
-      val chunkIntervals = new ArrayBuffer[Interval]
-      var currStart = -1
-      var currEnd = -1
-      val chunks = sentence.chunks.get
-      val numTokens = chunks.length
-      for ((t, i) <- chunks.zipWithIndex) {
-        if (t.startsWith("B")) {
-          // New chunk has started, package the previous
-          if (currStart != -1 && currEnd != -1) {
-            chunkIntervals.append(Interval(currStart, currEnd))
-          }
-          currStart = i
-          currEnd = -1
-        } else if (t.startsWith("I")) {
-          // if this isn't the last thing in the sentence
-          if (i + 1 < numTokens) {
-            if (chunks(i + 1) != t) {
-              // the next chunk is different, so this is the end
-              currEnd = i + 1
-            }
-          }
-        } else {
-          // chunk starts with "O", if this is the first one, mark it as the end
-          if (currEnd == -1) currEnd = i
-        }
-      }
-      // Handle any remaining chunks that didn't get added yet
-      if (currStart != -1 && currEnd != -1) {
-        chunkIntervals.append(Interval(currStart, currEnd))
-      }
-      chunkIntervals
-    }
-
-    def wordsSlice(span: Interval): Array[String] = words.slice(span.start, span.end)
-    def wordsSliceString(span: Interval): String = wordsSlice(span).mkString(" ")
-    def tokenOrObjOfPreposition(tok: Int): Seq[Int] = {
-      if (sentence.tags.get(tok) == "IN") {
-        println(s"It's a preposition... (tok=$tok)")
-        // if it's a preposition, follow the outgoing `case` dependency edge
-        val out = dependencies
-          // Get the next tokens that this token links to
-          .incomingEdges(tok)
-          // Get the subset that corresponds to the `case` dependency
-          .collect{ case e if e._2 == "case" => e._1 }
-        println(s"Followed to: ${out.map(words(_)).mkString(", ")}")
-        out
-      } else {
-        Seq(tok)
-      }
-    }
-
+      .sortBy(minGraphDistanceToSyntacticRoot)
   }
 
+  // Find the shortest distance (in the syntax graph) between a given token and any of the roots
+  def minGraphDistanceToSyntacticRoot(token: Int): Int = {
+    // Get the sentence roots -- there can be more than one
+    val roots = dependencies.roots
+    if (roots.isEmpty) return 0
+    // for each, check the shortest path from that root to the given token
+    val pathLengths = roots.map(root => dependencies.shortestPath(root, token, ignoreDirection = true).length)
+    // select the shortest to be the distance from the token to any of the roots
+    pathLengths.min
+  }
 
+  val allTokensInvolvedInPredicates: Seq[Int] = {
+    srls.allEdges
+      .flatMap(edge => Seq(edge._1, edge._2))
+//      .flatMap(tokenOrObjOfPreposition)
+      .distinct
+      .sorted
+  }
 
+  def findStart(chunkSpan: Interval, tok: Int): Int = {
+    if (chunkSpan.start == tok) {
+      tok
+    } else {
+      val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
+      // not the first thing in the sequence
+      val startLimit = if (currTokenIdx > 0) {
+        allTokensInvolvedInPredicates(currTokenIdx - 1) + 1
+      } else chunkSpan.start
+      val start = math.max(chunkSpan.start, startLimit)
+      start
+    }
+  }
 
+  def findEnd(chunkSpan: Interval, tok: Int): Int = {
+    if (chunkSpan.end == tok) {
+      tok
+    } else {
+      val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
+      // not the first thing in the sequence
+      val endLimit = if (currTokenIdx < allTokensInvolvedInPredicates.length - 1) {
+        allTokensInvolvedInPredicates(currTokenIdx + 1) // don't need to subtract 1 bc exclusive interval
+      } else chunkSpan.end
+      val end = math.min(chunkSpan.end, endLimit)
+      end
+    }
+  }
+
+  def chunkAvoidingSRLs(chunkSpan: Interval, tok: Int): Interval = {
+    assert(allTokensInvolvedInPredicates.contains(tok))
+    val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
+//    println(s"Trimming: (tok=$tok, idx=${currTokenIdx})")
+//    println(allTokensInvolvedInPredicates.mkString(", "))
+
+    // If the tok starts the chunk
+    val start = findStart(chunkSpan, tok)
+    val end = findEnd(chunkSpan, tok)
+    Interval(start, end)
+  }
+
+  // Make a Seq of the Intervals corresponding to the syntactic chunks in the sentence (inclusive, exclusive).
+  def chunkSpans: Seq[Interval] = {
+    val chunkIntervals = new ArrayBuffer[Interval]
+    var currStart = -1
+    var currEnd = -1
+    val chunks = sentence.chunks.get
+    val numTokens = chunks.length
+    for ((t, i) <- chunks.zipWithIndex) {
+      if (t.startsWith("B")) {
+        // New chunk has started, package the previous
+        if (currStart != -1 && currEnd != -1) {
+          chunkIntervals.append(Interval(currStart, currEnd))
+        }
+        currStart = i
+        currEnd = -1
+      } else if (t.startsWith("I")) {
+        // if this isn't the last thing in the sentence
+        if (i + 1 < numTokens) {
+          if (chunks(i + 1) != t) {
+            // the next chunk is different, so this is the end
+            currEnd = i + 1
+          }
+        }
+      } else {
+        // chunk starts with "O", if this is the first one, mark it as the end
+        if (currEnd == -1) currEnd = i
+      }
+    }
+    // Handle any remaining chunks that didn't get added yet
+    if (currStart != -1 && currEnd != -1) {
+      chunkIntervals.append(Interval(currStart, currEnd))
+    }
+    chunkIntervals
+  }
+
+  def wordsSlice(span: Interval): Array[String] = words.slice(span.start, span.end)
+  def wordsSliceString(span: Interval): String = wordsSlice(span).mkString(" ")
+  def tokenOrObjOfPreposition(tok: Int): Seq[Int] = {
+    if (sentence.tags.get(tok) == "IN") {
+      println(s"It's a preposition... (tok=$tok)")
+      // if it's a preposition, follow the outgoing `case` dependency edge
+      val out = dependencies
+        // Get the next tokens that this token links to
+        .incomingEdges(tok)
+        // Get the subset that corresponds to the `case` dependency
+        .collect{ case e if Seq("case", "mark").contains(e._2) => e._1 }
+      println(s"Followed to: ${out.map(words(_)).mkString(", ")}")
+      out
+    } else {
+      Seq(tok)
+    }
+  }
+
+  def outgoingOfType(tok: Int, constraints: Seq[String]): Array[Int] = {
+    dependencies.outgoingEdges(tok)
+      // keep only the ones that satisfy the constraints
+      .filter(edge => constraints.contains(edge._2))
+      // return the dsts
+      .map(_._1)
+  }
 }
 
 
@@ -432,7 +411,7 @@ object SRLCompositionalGrounder{
   // Semantic Roles
   val AGENT_ROLE = "A0"
   val THEME_ROLE = "A1"
-  val OTHER_ROLE = "AX"
+  val OTHER_ROLE = "Ax"
   val TIME_ROLE = "AM-TMP"
   val LOC_ROLE = "AM-LOC" // FIXME: may need offline processing to make happen
 

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
@@ -4,19 +4,74 @@ import org.clulab.odin.Mention
 import org.clulab.processors.Sentence
 import org.clulab.processors.fastnlp.FastNLPProcessorWithSemanticRoles
 import org.clulab.struct.{DirectedGraph, Interval}
-import org.clulab.wm.eidos.attachments.{ContextAttachment, TriggeredAttachment}
-import org.clulab.wm.eidos.groundings.{ConceptEmbedding, ConceptPatterns, DomainOntology, EidosWordToVec, OntologyGrounding}
+import org.clulab.wm.eidos.attachments.{ContextAttachment, Property, TriggeredAttachment}
+import org.clulab.wm.eidos.groundings.{ConceptEmbedding, ConceptPatterns, DomainOntology, EidosWordToVec, OntologyGrounding, PredicateGrounding}
 import org.clulab.wm.eidos.mentions.EidosMention
-import org.clulab.wm.eidos.utils.Canonicalizer
+import org.clulab.wm.eidos.utils.{Canonicalizer, GroundingUtils}
 import org.slf4j.{Logger, LoggerFactory}
-
 import SRLCompositionalGrounder._
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ArrayBuffer
 
-case class GroundedSpan(tokenInterval: Interval, grounding: OntologyGrounding)
-case class PredicatePackage(predicate: GroundedSpan, agent: Seq[GroundedSpan] = Nil, theme: Seq[GroundedSpan] = Nil, other: Seq[GroundedSpan] = Nil)
+case class GroundedSpan(tokenInterval: Interval, grounding: OntologyGrounding, isProperty: Boolean = false)
+case class PredicateTuple(theme: OntologyGrounding, themeProperties: OntologyGrounding, themeProcess: OntologyGrounding, themeProcessProperties: OntologyGrounding) {
+
+  val name: String = {
+    if (theme.nonEmpty) {
+      val sb = new ArrayBuffer[String]()
+      sb.append(s"THEME: ${theme.headName.get}")
+      if (themeProperties.nonEmpty) {
+       sb.append(s" (Properties: ${themeProperties.take(5).map(_.name).mkString(", ")})")
+      }
+      if (themeProcess.nonEmpty) {
+        sb.append(s"; THEME PROCESS: ${themeProcess.headName.get})")
+      }
+      if (themeProcessProperties.nonEmpty) {
+        sb.append(s" (Properties: ${themeProcessProperties.take(5).map(_.name).mkString(", ")})")
+      }
+      sb.mkString("")
+    } else {
+      "Empty Compositional Grounding"
+    }
+  }
+  val score: Float = {
+    val themeScore = theme.grounding.headOption.map(_.score)
+    val themeProcessScore = themeProcess.grounding.headOption.map(_.score)
+    val allScores = themeScore ++ themeProcessScore
+    if (allScores.isEmpty) 0.0f
+    else GroundingUtils.noisyOr(allScores.toSeq)
+  }
+}
+
+case class PredicatePackage(predicate: Seq[GroundedSpan], agent: Seq[GroundedSpan] = Nil, theme: Seq[GroundedSpan] = Nil, other: Seq[GroundedSpan] = Nil) {
+  def toPredicateTuple(grounder: EidosOntologyGrounder): PredicateTuple = {
+    def emptyGrounding: OntologyGrounding = grounder.newOntologyGrounding()
+    def emptyTuple: PredicateTuple = PredicateTuple(emptyGrounding, emptyGrounding, emptyGrounding, emptyGrounding)
+    def propsGrounding(props: Seq[GroundedSpan]): OntologyGrounding = {
+      val allProps = props.flatMap(p => p.grounding.grounding)
+      val branch = props.head.grounding.branch
+      grounder.newOntologyGrounding(allProps, branch)
+    }
+
+    val (propertyThemes, otherThemes) = theme.partition(_.isProperty)
+    // fixme: this isn't quite right -- what about the process properties??
+
+    (predicate, otherThemes, propertyThemes) match {
+      case (Seq(), Seq(), Seq())  => emptyTuple
+      case (Seq(), Seq(), props)  =>
+        println(s"There are properties, but no theme or process: $this")
+        emptyTuple
+      case (preds, Seq(), Seq())  => PredicateTuple( preds.head.grounding,  emptyGrounding,        emptyGrounding,       emptyGrounding)
+      case (preds, Seq(), props)  => PredicateTuple( preds.head.grounding,  propsGrounding(props), emptyGrounding,       emptyGrounding)
+      case (Seq(), themes, Seq()) => PredicateTuple( themes.head.grounding, emptyGrounding,        emptyGrounding,       emptyGrounding)
+      case (Seq(), themes, props) => PredicateTuple( themes.head.grounding, propsGrounding(props), emptyGrounding,       emptyGrounding)
+      case (preds, themes, Seq()) => PredicateTuple( themes.head.grounding, emptyGrounding,        preds.head.grounding, emptyGrounding)
+      case (preds, themes, props) => PredicateTuple( themes.head.grounding, propsGrounding(props), preds.head.grounding, emptyGrounding)
+      case _ => throw new RuntimeException(s"Unhandled situation in converting predicate to tuple: ${this.toString}")
+    }
+  }
+}
 
 class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v: EidosWordToVec, canonicalizer: Canonicalizer)
   extends EidosOntologyGrounder(name, domainOntology, w2v, canonicalizer) {
@@ -38,8 +93,7 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
 
   // primarily used for passing in the canonical name parts
   override def groundStrings(strings: Array[String]): Seq[OntologyGrounding] = {
-    SRLCompositionalGrounder.logger.info("The SRLCompositionalGrounder isn't designed to be used with canonical name parts only.")
-    ???
+    throw new RuntimeException("The SRLCompositionalGrounder isn't designed to be used with canonical name parts only.")
   }
 
   override def groundText(text: String): OntologyGrounding = {
@@ -48,7 +102,8 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
       s <- doc.sentences
       // TODO (at some point) -- the empty sequence here is a placeholder for increase/decrease triggers
       //  Currently we don't have "access" to those here, but that could be changed
-      ontologyGrounding <- groundSentenceSpan(s, 0, s.words.length, Set())
+      //  Further, the Nones are for a topN and a threshold, which we don't have here
+      ontologyGrounding <- groundSentenceSpan(s, 0, s.words.length, Set(), None, None)
       singleGrounding <- ontologyGrounding.grounding
     } yield singleGrounding
 
@@ -62,42 +117,55 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
       Seq(newOntologyGrounding())
     // or else ground them.
     else {
-      groundSentenceSpan(mention.odinMention.sentenceObj, mention.odinMention.start, mention.odinMention.end, attachmentStrings(mention.odinMention))
+      groundSentenceSpan(mention.odinMention.sentenceObj, mention.odinMention.start, mention.odinMention.end, attachmentStrings(mention.odinMention), topN, threshold)
     }
   }
 
-  def groundSentenceSpan(s: Sentence, start: Int, end: Int, exclude: Set[String]): Seq[OntologyGrounding] = {
+  def groundSentenceSpan(s: Sentence, start: Int, end: Int, exclude: Set[String], topN: Option[Int], threshold: Option[Float]): Seq[OntologyGrounding] = {
     val tokenInterval = Interval(start, end)
-    groundSentenceSpan(s, tokenInterval, exclude)
+    groundSentenceSpan(s, tokenInterval, exclude, topN, threshold)
   }
 
-  def groundSentenceSpan(s: Sentence, tokenInterval: Interval, exclude: Set[String]): Seq[OntologyGrounding] = {
-    val conceptPredicates = groundPredicates(s, tokenInterval, exclude)
-    // TODO: Convert these into OntologyGroundings
-    ???
+  def groundSentenceSpan(s: Sentence, tokenInterval: Interval, exclude: Set[String], topN: Option[Int], threshold: Option[Float]): Seq[OntologyGrounding] = {
+    val conceptPredicates = groundPredicates(s, tokenInterval, exclude, topN, threshold)
+    val predicateGroundings = conceptPredicates
+      // Convert to the flattened tuple
+      .map(_.toPredicateTuple(this))
+      // Put in the format needed to export as a Grounding
+      .map(PredicateGrounding)
+    val filtered = filterAndSlice(predicateGroundings, topN, threshold)
+
+    if (filtered.nonEmpty) {
+      Seq(newOntologyGrounding(filtered))
+    } else {
+      val pseudoTheme = groundToBranches(Seq(CONCEPT), tokenInterval, s, topN, threshold)
+      val predicateTuple = PredicateTuple(pseudoTheme, newOntologyGrounding(), newOntologyGrounding(), newOntologyGrounding())
+      Seq(newOntologyGrounding(Seq(PredicateGrounding(predicateTuple)), Some(CONCEPT)))
+    }
   }
 
-  def groundPredicates(sentence: Sentence, tokenInterval: Interval, exclude: Set[String]): Seq[PredicatePackage] = {
+  def groundPredicates(sentence: Sentence, tokenInterval: Interval, exclude: Set[String], topN: Option[Int], threshold: Option[Float]): Seq[PredicatePackage] = {
     val sentenceHelper = SentenceHelper(sentence, tokenInterval, exclude)
-    packagePredicates(sentenceHelper.validPredicates, Seq(), Set(), sentenceHelper)
+    packagePredicates(sentenceHelper.validPredicates, Seq(), Set(), sentenceHelper, topN, threshold)
   }
 
 
   @tailrec
-  private def packagePredicates(remaining: Seq[Int], results: Seq[PredicatePackage], seen: Set[Int], s: SentenceHelper): Seq[PredicatePackage] = {
+  private def packagePredicates(remaining: Seq[Int], results: Seq[PredicatePackage], seen: Set[Int], s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): Seq[PredicatePackage] = {
     remaining match {
       case Seq() => results
-      case Seq(curr) => results ++ Seq(mkPredicatePackage(curr, s))
-      case curr :: rest =>
+      case Seq(curr) => results ++ Seq(mkPredicatePackage(curr, s, topN, threshold))
+      case Seq(curr, tail @ _*) =>
         if (seen contains curr) {
           // we've been here before
-          packagePredicates(rest, results, seen, s)
+          packagePredicates(tail, results, seen, s, topN, threshold)
         } else if (s.srls.roots contains curr) {
           // Otherwise, it's new and it's a predicate
           // TODO: this currently does not "nest" the predicates, if we decide we want to, we'll need to adjust it
           //  if on the other hand, we want only to output the 4-tuples, then it shouldn't matter
-          val packaged = mkPredicatePackage(curr, s)
-          packagePredicates(rest, results ++ Seq(packaged), seen ++ Set(curr), s)
+          val packaged = mkPredicatePackage(curr, s, topN, threshold)
+          println(s"packaged: $packaged")
+          packagePredicates(tail, results ++ Seq(packaged), seen ++ Set(curr), s, topN, threshold)
         }
         else {
           ???
@@ -110,48 +178,75 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
 
   // Ground the predicate and also ground each of the relevant arguments
   // Return a PredicatePackage object
-  private def mkPredicatePackage(predicate: Int, s: SentenceHelper): PredicatePackage = {
+  private def mkPredicatePackage(predicate: Int, s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): PredicatePackage = {
     // Otherwise, it's new.  If it's a predicate:
-    val groundedPredicate = groundChunk(predicate, s)
+    println("\n**************************************************")
+    println(s"grounding the predicate: ${s.words(predicate)}")
+    val groundedPredicate = groundChunk(predicate, s, topN, threshold)
     // get the arguments
-    val agents = groundArguments(predicate, AGENT_ROLE, s)
-    val themes = groundArguments(predicate, THEME_ROLE, s)
-    val others = groundArguments(predicate, OTHER_ROLE, s)
-    PredicatePackage(groundedPredicate, agents, themes, others)
+    println(s"grounding the agents")
+    val agents = groundArguments(predicate, AGENT_ROLE, s, topN, threshold)
+    println(s"grounding the themes")
+    val themes = groundArguments(predicate, THEME_ROLE, s, topN, threshold)
+    println(s"grounding the others")
+    val others = groundArguments(predicate, OTHER_ROLE, s, topN, threshold)
+
+    groundedPredicate match {
+      case prop if prop.isProperty =>
+        println("The predicate was a property, so we're switching the themes with it")
+        // If the predicate is a property, then the we need to switch the theme and the predicate
+        PredicatePackage(themes, agents, Seq(groundedPredicate), others)
+      case _ => PredicatePackage(Seq(groundedPredicate), agents, themes, others)
+    }
+
+
   }
 
   // Find all arguments from a given predicate of a certain role (e.g., A1, A0, etc) and ground them
-  private def groundArguments(predicate: Int, role: String, s:SentenceHelper): Seq[GroundedSpan] = {
+  private def groundArguments(predicate: Int, role: String, s:SentenceHelper, topN: Option[Int], threshold: Option[Float]): Seq[GroundedSpan] = {
     s.srls.outgoingEdges(predicate)
       .filter(_._2 == role)
-      .map(tok => groundChunk(tok._1, s))
+      .flatMap(dst => handlePrepositions(dst, s))
+      .map(tok => groundChunk(tok._1, s, topN, threshold))
+  }
+
+  // In SRL, currently the arguments that point to a preposition stay there, rather than continuing
+  // on to the object of the preposition.  However, when grounding, we want the object.  This traverses to the
+  // object(s) of the preposition, if any.
+  private def handlePrepositions(step: (Int, String), s: SentenceHelper): Seq[(Int, String)] = {
+    val (dst, role) = step
+    println(s"Checking for preposition: ${s.words(dst)}")
+    s.tokenOrObjOfPreposition(dst).map((_, role))
   }
 
   // Ground the chunk that the token is in, but in isolation from the rest of the sentence
-  //  a) if an arg is itself a predicate => it's a process
-  //  b) else if it matches a property regex => it's a property
-  //  c) else it's a concept
-  private def groundChunk(token: Int, s: SentenceHelper): GroundedSpan = {
-    val chunkSpan = s.chunkIntervals.collect{ case c if c.contains(token) => c} match {
-      case Seq() =>
-        logger.warn(s"Token $token is not in a chunk.  chunks: ${s.chunks.mkString(", ")}")
-        Interval(token, token + 1)  // if empty, backoff
-      case Seq(chunk) => chunk      // one found, yay! We'll use it
-      case chunks => throw new RuntimeException(s"Chunks have overlapped, there is a problem.  \n\ttoken: $token\n\tchunks: ${chunks.mkString(", ")}")
-    }
-    if (s.validPredicates contains token) {
-      GroundedSpan(chunkSpan, groundProcess(chunkSpan, s))
-    } else if (isProperty(chunkSpan, s)) {
-      GroundedSpan(chunkSpan, groundProperty(chunkSpan, s))
+  private def groundChunk(token: Int, s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): GroundedSpan = {
+//    val chunkSpan = s.chunkIntervals.collect{ case c if c.contains(token) => c} match {
+//      case Seq() =>
+//        logger.warn(s"Token $token is not in a chunk.  chunks: ${s.chunks.mkString(", ")}")
+//        Interval(token, token + 1)  // if empty, backoff
+//      case Seq(chunk) => chunk      // one found, yay! We'll use it
+//      case chunks => throw new RuntimeException(s"Chunks have overlapped, there is a problem.  \n\ttoken: $token\n\tchunks: ${chunks.mkString(", ")}")
+//    }
+//    val trimmedChunk = s.chunkAvoidingSRLs(chunkSpan, token)
+    val trimmedChunk = Interval(token, token+1)
+    // First check to see if it's a property, if it is, ground as that
+    val propertyOpt = maybeProperty(trimmedChunk, s)
+    if (propertyOpt.isDefined) {
+      val g = GroundedSpan(trimmedChunk, propertyOpt.get, isProperty = true)
+      println(s"PROPERTY: grounded <<${s.wordsSliceString(trimmedChunk)}>> as: ${g}")
+      g
     } else {
-      GroundedSpan(chunkSpan, groundConcept(chunkSpan, s))
+      // Otherwise, ground as either a process or concept
+      val g = GroundedSpan(trimmedChunk, groundToBranches(Seq(CONCEPT, PROCESS), trimmedChunk, s.sentence, topN, threshold), isProperty = false)
+      println(s"grounded <<${s.wordsSliceString(trimmedChunk)}>> as: ${g}")
+      g
     }
   }
 
-
-  private def isProperty(span: Interval, s: SentenceHelper): Boolean = {
-    val spanText = s.wordsSliceString(span)
-    nodesPatternMatched(spanText, conceptPatternsSeq(PROPERTY)).nonEmpty
+  private def maybeProperty(span: Interval, s: SentenceHelper): Option[OntologyGrounding] = {
+    val tempGrounding = groundProperty(span, s, topN=Option(1), threshold=Option(0.8f))
+    if (tempGrounding.nonEmpty) Option(tempGrounding) else None
   }
 
   // Find the shortest distance (in the syntax graph) between a given token and any of the roots
@@ -168,19 +263,33 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
   private def attachmentStrings(mention: Mention): Set[String] = {
     mention.attachments.flatMap { a =>
       a match {
-        case t: TriggeredAttachment => Seq(t.trigger) ++ t.quantifiers.getOrElse(Seq())
+        case t: TriggeredAttachment if !t.isInstanceOf[Property] => Seq(t.trigger) ++ t.quantifiers.getOrElse(Seq())
+        case _: Property => Seq.empty
         case c: ContextAttachment => Seq(c.text)
         case _ => ???
       }
     }
   }
 
-  private  def groundProcess(span: Interval, s: SentenceHelper): OntologyGrounding = groundBranch(PROCESS, span, s)
-  private def groundProperty(span: Interval, s: SentenceHelper): OntologyGrounding = groundBranch(PROPERTY, span, s)
-  private def groundConcept(span: Interval, s: SentenceHelper): OntologyGrounding = groundBranch(CONCEPT, span, s)
+//  private def groundToAllBranches(span: Interval, s: Sentence, topN: Option[Int], threshold: Option[Float]): OntologyGrounding = {
+//    val contentWords = canonicalizer.canonicalWordsFromSentence(s, span).toArray
+//    val initialGroundings = groundPatternsThenEmbeddings(contentWords, conceptPatterns, conceptEmbeddings)
+//    val filtered = filterAndSlice(initialGroundings, topN, threshold)
+//    newOntologyGrounding(filtered)
+//  }
 
-  private def groundBranch(branch: String, span: Interval, s: SentenceHelper): OntologyGrounding = {
-    groundPatternsThenEmbeddings(s.wordsSlice(span), conceptPatternsSeq(branch), conceptEmbeddingsSeq(branch))
+  private def groundProperty(span: Interval, s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): OntologyGrounding = groundToBranches(Seq(PROPERTY), span, s, topN, threshold)
+
+  private def groundToBranches(branches: Seq[String], span: Interval, s: SentenceHelper, topN: Option[Int], threshold: Option[Float]): OntologyGrounding = {
+    groundToBranches(branches, span, s.sentence, topN, threshold)
+  }
+  private def groundToBranches(branches: Seq[String], span: Interval, s: Sentence, topN: Option[Int], threshold: Option[Float]): OntologyGrounding = {
+    val patterns = branches.flatMap(conceptPatternsSeq(_))
+    val embeddings = branches.flatMap(conceptEmbeddingsSeq(_))
+    val contentWords = canonicalizer.canonicalWordsFromSentence(s, span).toArray
+    val initialGroundings = groundPatternsThenEmbeddings(contentWords, patterns, embeddings)
+    val filtered = filterAndSlice(initialGroundings, topN, threshold)
+    newOntologyGrounding(filtered)
   }
 
 
@@ -190,6 +299,7 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
     val chunkIntervals: Seq[Interval] = chunkSpans
     val words: Array[String] = sentence.words
     val srls: DirectedGraph[String] = sentence.semanticRoles.get
+    val dependencies: DirectedGraph[String] = sentence.dependencies.get
     // The roots of the SRL graph that are within the concept being grounded and aren't part of
     // an something we're ignoring (e.g., increase/decrease/quantification)
     val validPredicates: Seq[Int] = {
@@ -200,6 +310,58 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
       .filterNot(exclude contains words(_))
       // start with those closest to the syntactic root of the sentence to begin with "higher level" predicates
       .sortBy(minGraphDistanceToSyntacticRoot(_, sentence.dependencies.get))
+    }
+
+    val allTokensInvolvedInPredicates: Seq[Int] = {
+      srls.allEdges
+        .flatMap(edge => Seq(edge._1, edge._2))
+        .flatMap(tokenOrObjOfPreposition)
+        .distinct
+        .sorted
+    }
+
+    def findStart(chunkSpan: Interval, tok: Int): Int = {
+      if (chunkSpan.start == tok) {
+        tok
+      } else {
+        val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
+        // not the first thing in the sequence
+        val startLimit = if (currTokenIdx > 0) {
+          allTokensInvolvedInPredicates(currTokenIdx - 1) + 1
+        } else chunkSpan.start
+        println(s"startLimit: $startLimit")
+        val start = math.max(chunkSpan.start, startLimit)
+        println(s"start: $start")
+        start
+      }
+    }
+
+    def findEnd(chunkSpan: Interval, tok: Int): Int = {
+      if (chunkSpan.end == tok) {
+        tok
+      } else {
+        val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
+        // not the first thing in the sequence
+        val endLimit = if (currTokenIdx < allTokensInvolvedInPredicates.length - 1) {
+          allTokensInvolvedInPredicates(currTokenIdx + 1) // don't need to subtract 1 bc exclusive interval
+        } else chunkSpan.end
+        println(s"endLimit: $endLimit")
+        val end = math.min(chunkSpan.end, endLimit)
+        println(s"end: $end")
+        end
+      }
+    }
+
+    def chunkAvoidingSRLs(chunkSpan: Interval, tok: Int): Interval = {
+      assert(allTokensInvolvedInPredicates.contains(tok))
+      val currTokenIdx = allTokensInvolvedInPredicates.indexOf(tok)
+      println(s"Trimming: (tok=$tok, idx=${currTokenIdx})")
+      println(allTokensInvolvedInPredicates.mkString(", "))
+
+      // If the tok starts the chunk
+      val start = findStart(chunkSpan, tok)
+      val end = findEnd(chunkSpan, tok)
+      Interval(start, end)
     }
 
     // Make a Seq of the Intervals corresponding to the syntactic chunks in the sentence (inclusive, exclusive).
@@ -239,7 +401,26 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
 
     def wordsSlice(span: Interval): Array[String] = words.slice(span.start, span.end)
     def wordsSliceString(span: Interval): String = wordsSlice(span).mkString(" ")
+    def tokenOrObjOfPreposition(tok: Int): Seq[Int] = {
+      if (sentence.tags.get(tok) == "IN") {
+        println(s"It's a preposition... (tok=$tok)")
+        // if it's a preposition, follow the outgoing `case` dependency edge
+        val out = dependencies
+          // Get the next tokens that this token links to
+          .incomingEdges(tok)
+          // Get the subset that corresponds to the `case` dependency
+          .collect{ case e if e._2 == "case" => e._1 }
+        println(s"Followed to: ${out.map(words(_)).mkString(", ")}")
+        out
+      } else {
+        Seq(tok)
+      }
+    }
+
   }
+
+
+
 
 }
 

--- a/src/main/scala/org/clulab/wm/eidos/serialization/jsonld/JLDDeserializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/jsonld/JLDDeserializer.scala
@@ -39,9 +39,7 @@ import org.clulab.wm.eidos.document.AnnotatedDocument.Corpus
 import org.clulab.wm.eidos.document.attachments.DctDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.LocationDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.TitleDocumentAttachment
-import org.clulab.wm.eidos.groundings.AdjectiveGrounding
-import org.clulab.wm.eidos.groundings.OntologyAliases
-import org.clulab.wm.eidos.groundings.OntologyGrounding
+import org.clulab.wm.eidos.groundings.{AdjectiveGrounding, OntologyAliases, OntologyGrounding, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.mentions.CrossSentenceEventMention
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.PassThruNamer
@@ -532,7 +530,7 @@ class JLDDeserializer {
           val floatVal = (value \ "value").extract[Double].toFloat
           val namer = new PassThruNamer(ontologyConcept)
 
-          (namer, floatVal)
+          SingleOntologyNodeGrounding(namer, floatVal)
         }
       }.getOrElse(List.empty)
 

--- a/src/main/scala/org/clulab/wm/eidos/serialization/jsonld/JLDSerializer.scala
+++ b/src/main/scala/org/clulab/wm/eidos/serialization/jsonld/JLDSerializer.scala
@@ -25,8 +25,7 @@ import org.clulab.wm.eidos.document._
 import org.clulab.wm.eidos.document.attachments.DctDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.LocationDocumentAttachment
 import org.clulab.wm.eidos.document.attachments.TitleDocumentAttachment
-import org.clulab.wm.eidos.groundings.AdjectiveGrounding
-import org.clulab.wm.eidos.groundings.OntologyGrounding
+import org.clulab.wm.eidos.groundings.{AdjectiveGrounding, OntologyGrounding, PredicateGrounding, SingleOntologyNodeGrounding}
 import org.clulab.wm.eidos.mentions.EidosCrossSentenceEventMention
 import org.clulab.wm.eidos.mentions.EidosCrossSentenceMention
 import org.clulab.wm.eidos.mentions.EidosEventMention
@@ -198,8 +197,10 @@ object JLDOntologyGrounding {
 
 class JLDOntologyGroundings(serializer: JLDSerializer, name: String, grounding: OntologyGrounding)
     extends JLDObject(serializer, JLDOntologyGroundings.typename) {
-  val jldGroundings: Seq[JObject] = grounding.grounding.map { case (namer, value) =>
-    new JLDOntologyGrounding(serializer, namer.name, value).toJObject
+  val jldGroundings: Seq[JObject] = grounding.grounding.map {
+    case s: SingleOntologyNodeGrounding =>
+      new JLDOntologyGrounding(serializer, s.name, s.score).toJObject
+    case pred: PredicateGrounding => ??? // FIXME
   }
 //  val versionOpt = if (name == "wm") Some("a1a6dbee0296bdd2b81a4a751fce17c9ed0a3af8") else None
 

--- a/src/main/scala/org/clulab/wm/eidos/utils/GroundingUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/GroundingUtils.scala
@@ -40,7 +40,8 @@ object GroundingUtils {
       getGroundingsStringOpt(mention, namespace, topK, delim).getOrElse("(namespace unavailable)")
 
   def noisyOr(values: Seq[Float], scale: Float = 1.0f): Float = {
-    val result = 1.0f - values.fold(1.0f)((product, value) => product * (1.0f - value))
+    val epsilon = 0.01f
+    val result = 1.0f - values.fold(1.0f)((product, value) => product * (1.0f - (value - epsilon)))
     result * scale
   }
 }

--- a/src/main/scala/org/clulab/wm/eidos/utils/GroundingUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/GroundingUtils.scala
@@ -39,6 +39,8 @@ object GroundingUtils {
   def getGroundingsString(mention: EidosMention, namespace: String, topK: Int = 5, delim: String = ", "): String =
       getGroundingsStringOpt(mention, namespace, topK, delim).getOrElse("(namespace unavailable)")
 
-  def noisyOr(values: Seq[Float]): Float =
-    1.0f - values.fold(1.0f)((product, value) => product * (1.0f - value))
+  def noisyOr(values: Seq[Float], scale: Float = 1.0f): Float = {
+    val result = 1.0f - values.fold(1.0f)((product, value) => product * (1.0f - value))
+    result * scale
+  }
 }

--- a/src/main/scala/org/clulab/wm/eidos/utils/GroundingUtils.scala
+++ b/src/main/scala/org/clulab/wm/eidos/utils/GroundingUtils.scala
@@ -1,8 +1,7 @@
 package org.clulab.wm.eidos.utils
 
-import org.clulab.wm.eidos.groundings.OntologyAliases
+import org.clulab.wm.eidos.groundings.{OntologyAliases, OntologyGrounding}
 import org.clulab.wm.eidos.groundings.grounders.EidosOntologyGrounder
-import org.clulab.wm.eidos.groundings.OntologyGrounding
 import org.clulab.wm.eidos.mentions.EidosMention
 
 object GroundingUtils {
@@ -39,4 +38,7 @@ object GroundingUtils {
 
   def getGroundingsString(mention: EidosMention, namespace: String, topK: Int = 5, delim: String = ", "): String =
       getGroundingsStringOpt(mention, namespace, topK, delim).getOrElse("(namespace unavailable)")
+
+  def noisyOr(values: Seq[Float]): Float =
+    1.0f - values.fold(1.0f)((product, value) => product * (1.0f - value))
 }

--- a/src/test/scala/org/clulab/wm/eidos/groundings/TestOntologyGrounder.scala
+++ b/src/test/scala/org/clulab/wm/eidos/groundings/TestOntologyGrounder.scala
@@ -64,7 +64,10 @@ class TestOntologyGrounder extends EnglishTest {
       val eidosMentions = annotatedDocument.eidosMentions.filter { eidosMention => eidosMention.odinMention.eq(odinMention) }
       val eidosMention = eidosMentions.head
       val unGrounding = eidosMention.grounding("un").grounding
-      val grounding = unGrounding.map { case (namer, value) => (namer.name, value) }
+      val grounding = unGrounding.map {
+        case s: SingleOntologyNodeGrounding => (s.name, s.score)
+        case _ => ???
+      }
 
       val ontologyYaml = Resourcer.getText("/org/clulab/wm/eidos/english/ontologies/un_ontology.yml")
       val ontologyHandler = ieSystem.components.ontologyHandler

--- a/src/test/scala/org/clulab/wm/eidos/text/english/grounding/TestGrounding.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/english/grounding/TestGrounding.scala
@@ -57,7 +57,7 @@ class TestGrounding extends EnglishTest {
     def split(text: String): Array[String] = text.split(' ')
 
     def groundings(mention: EidosMention, topN: Option[Int] = groundTopN, threshold: Option[Float] = threshold): OntologyGroundings = {
-      val ontologyGroundings: Seq[OntologyGrounding] = ontologyGrounder.groundOntology(mention, topN = groundTopN, threshold = threshold)
+      val ontologyGroundings: Seq[OntologyGrounding] = ontologyGrounder.groundEidosMention(mention, topN = groundTopN, threshold = threshold)
       val groundings = ontologyGroundings.map { ontologyGrounding =>
         val newName = name + ontologyGrounding.branch.map { branch => "/" + branch }.getOrElse("")
 
@@ -69,7 +69,7 @@ class TestGrounding extends EnglishTest {
 
     protected def topGroundingValue(mention: EidosMention, componentName: String): Float = {
       val allGroundings = groundings(mention)
-      val topGrounding = allGroundings(name + "/" + componentName).headOption.get._2
+      val topGrounding = allGroundings(name + "/" + componentName).headOption.get.score
       topGrounding
     }
 
@@ -83,7 +83,7 @@ class TestGrounding extends EnglishTest {
     def allGroundingNames(mention: EidosMention, topN: Option[Int], threshold: Option[Float]): Seq[String] = {
       val allGroundings = groundings(mention, topN, threshold)
       val names = allGroundings.values.flatMap { ontologyGrounding =>
-        ontologyGrounding.grounding.map { grounding => grounding._1.name }
+        ontologyGrounding.grounding.map { grounding => grounding.name }
       }.toSeq
 
       names
@@ -92,7 +92,7 @@ class TestGrounding extends EnglishTest {
     def allGroundingInfo(mention: EidosMention): Seq[(String,Float)] = {
       val allGroundings = groundings(mention)
       val names = allGroundings.values.flatMap { ontologyGrounding =>
-        ontologyGrounding.grounding.map { grounding => (grounding._1.name, grounding._2) }
+        ontologyGrounding.grounding.map { grounding => (grounding.name, grounding.score) }
       }.toSeq
 
       names


### PR DESCRIPTION
@kwalcock this is **SUPER** not ready yet, but it involves the renaming i alluded to and, more importantly, I _think_ I needed to refactor the SingleOntologyGrounding to handle the new representation, so what I did (note -- this can still be thought of as a draft if you hate it) is to: 
- make a trait (IndividualGrounding)
- there are two case classes which inherit from it:
  -`SingleOntologyNodeGrounding` which is basically the old one, and 
  -`PredicateGrounding` which isn't implemented yet but will eventually hold the new representation

The "backend" of the latter is there, it's basically the `PredicatePackage` case class, but I am waiting to hear back from Ben if we can simply output the flat 4-tuple in the json-ld (i.e., if the `PredicateGrounding` can be based on the 4-tuple), or if we need to output the full structure.   @MihaiSurdeanu may also have an opinion.

OK -- so again, this is NOT done, there are several methods not implemented yet, but it involved a major enough refactor that I wanted you to have early preview ability if you wanted.

Also -- side note, I didn't try hard to work the refactor efficiently into the other CompositionalGrounder (it's added, but just surface assessment, rather than looking at a larger refactor to make better use of the refactor) because we're planning to deprecate it.  I also deprecated the InterventionGrounder while I was at it.

Whew.  what a message!

PS - don't judge me too hard on my attempt at recursion, I haven't tested it yet bc it's not implemented fully.  BUT while I don't want you to judge me, you CAN suggest fixes!!! :D 👍 