### PR TITLE
add to transparent.txt

### DIFF
--- a/src/main/resources/org/clulab/wm/eidos/english/filtering/transparent.txt
+++ b/src/main/resources/org/clulab/wm/eidos/english/filtering/transparent.txt
@@ -7,6 +7,7 @@
 access
 adult
 availability
+amount
 application
 belief
 capacity
@@ -30,12 +31,15 @@ incidence
 individual
 instrument
 intervention
+level
 lifestyle
 man
+measure
 mechanism
 more
 mouse
 need
+number
 origin
 pastoralist
 patient
@@ -45,6 +49,7 @@ policy
 program
 project
 proposal
+quantity
 rat
 safety
 risk


### PR DESCRIPTION
Added words relating to quantity/amount/levels to `transparent.txt`.
@BeckySharp let me know if there were others I should add; these were the ones I originally had in the Ontology PR (that I removed to add here).