### PR TITLE
Add date to time for logging

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <property name="eidos:pattern" value="%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" />
+    <property name="eidos:pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n" />
 
     <appender name="eidos:stderr" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.err</target>


### PR DESCRIPTION
When eidos runs for days at a time, it is unclear when the messages are issued.