### PR TITLE
attempt at simplifying

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyHandler.scala
@@ -187,7 +187,7 @@ class OntologyHandler(
               if (isAlreadyCanonicalized) text.split(' ')
               else recanonicalize(text).toArray // Attempt to regenerate them.
 
-          g.groundOntology(isGroundableType = true, mentionText, canonicalNameParts)
+          g.groundText(isGroundableType = true, mentionText, canonicalNameParts)
       }
       case _ => throw new RuntimeException("Regrounding needs an EidosOntologyGrounder")
     }

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/EidosOntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/EidosOntologyGrounder.scala
@@ -43,7 +43,7 @@ abstract class EidosOntologyGrounder(val name: String, val domainOntology: Domai
     }
 
   // For API to reground strings
-  def groundOntology(isGroundableType: Boolean, mentionText: String, canonicalNameParts: Array[String]): OntologyGrounding = {
+  def groundText(isGroundableType: Boolean, mentionText: String, canonicalNameParts: Array[String]): OntologyGrounding = {
     // Sieve-based approach
     if (isGroundableType) {
       newOntologyGrounding(groundPatternsThenEmbeddings(mentionText, canonicalNameParts, conceptPatterns, conceptEmbeddings))
@@ -67,11 +67,6 @@ abstract class EidosOntologyGrounder(val name: String, val domainOntology: Domai
         }
         false
     }
-  }
-
-  // For API to reground strings
-  def groundText(text: String): OntologyGrounding = {
-    newOntologyGrounding(groundPatternsThenEmbeddings(text, conceptPatterns, conceptEmbeddings))
   }
 
   def groundPatternsThenEmbeddings(text: String, patterns: Seq[ConceptPatterns], embeddings: Seq[ConceptEmbedding]): MultipleOntologyGrounding = {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
@@ -101,19 +101,23 @@ class SRLCompositionalGrounder(name: String, domainOntology: DomainOntology, w2v
     throw new RuntimeException("The SRLCompositionalGrounder isn't designed to be used with canonical name parts only.")
   }
 
-  override def groundText(text: String): OntologyGrounding = {
-    val doc = proc.annotate(text)
-    val groundings = for {
-      s <- doc.sentences
-      // TODO (at some point) -- the empty sequence here is a placeholder for increase/decrease triggers
-      //  Currently we don't have "access" to those here, but that could be changed
-      //  Further, the Nones are for a topN and a threshold, which we don't have here
-      ontologyGrounding <- groundSentenceSpan(s, 0, s.words.length, Set(), None, None)
-      singleGrounding <- ontologyGrounding.grounding
-    } yield singleGrounding
+  override def groundText(isGroundableType: Boolean, text: String, canonicalNameParts: Array[String]): OntologyGrounding = {
+    if (isGroundableType) {
+      val doc = proc.annotate(text)
+      val groundings = for {
+        s <- doc.sentences
+        // TODO (at some point) -- the empty sequence here is a placeholder for increase/decrease triggers
+        //  Currently we don't have "access" to those here, but that could be changed
+        //  Further, the Nones are for a topN and a threshold, which we don't have here
+        ontologyGrounding <- groundSentenceSpan(s, 0, s.words.length, Set(), None, None)
+        singleGrounding <- ontologyGrounding.grounding
+      } yield singleGrounding
 
-    val groundingResult = newOntologyGrounding(groundings.sortBy(- _.score))
-    groundingResult
+      val groundingResult = newOntologyGrounding(groundings.sortBy(- _.score))
+      groundingResult
+    } else {
+      newOntologyGrounding()
+    }
   }
 
   override def groundEidosMention(mention: EidosMention, topN: Option[Int] = None, threshold: Option[Float] = None): Seq[OntologyGrounding] = {

--- a/src/test/scala/org/clulab/wm/eidos/system/TestEidosMention.scala
+++ b/src/test/scala/org/clulab/wm/eidos/system/TestEidosMention.scala
@@ -9,8 +9,6 @@ import org.clulab.wm.eidos.text.english.cag.CAG._
 import org.clulab.wm.eidoscommon.utils.{EqualityBagger, IdentityBagger}
 
 class TestEidosMention extends ExtractionTest {
-  
-  def groundOntology(mention: EidosMention): Map[String, OntologyGrounding] = Map.empty
 
 //  object StopwordManager extends StopwordManaging {
 //    def containsStopword(stopword: String) = stopword == "policy"


### PR DESCRIPTION
@kwalcock thoughts?
There were 2 methods in the superclass(es) that both seemed to (a) receive text and (b) return an OntologyGrounding, but where one didn't call the other.  In the subclass SRLOntologyGrounding at least I don't think the right one was overridden.  Basically, there was confusion.  Here I removed one and searched for any stray usages to remove them.