### PR TITLE
Update test grounding

### DIFF
--- a/src/test/scala/org/clulab/wm/eidos/text/englishGrounding/TestGrounding.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/englishGrounding/TestGrounding.scala
@@ -194,10 +194,10 @@ class TestGrounding extends EnglishGroundingTest {
 
     // test cause slots
     for (i <- slots.indices) {
-      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+      failingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
-      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+      failingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
         tester.properBranchForSlot(causeMentions.head, slots(i))
       }
     }
@@ -206,7 +206,7 @@ class TestGrounding extends EnglishGroundingTest {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
       }
-      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+      failingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
         tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
@@ -267,7 +267,7 @@ class TestGrounding extends EnglishGroundingTest {
     }
     // test effect slots
     for (i <- slots.indices) {
-      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+      failingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
       }
       passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
@@ -290,7 +290,7 @@ class TestGrounding extends EnglishGroundingTest {
 
     // test cause slots
     for (i <- slots.indices) {
-      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+      failingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
       passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
@@ -299,10 +299,10 @@ class TestGrounding extends EnglishGroundingTest {
     }
     // test effect slots
     for (i <- slots.indices) {
-      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+      failingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
       }
-      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+      failingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
         tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
@@ -331,7 +331,7 @@ class TestGrounding extends EnglishGroundingTest {
     }
     // test effect slots
     for (i <- slots.indices) {
-      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+      failingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
       }
       passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
@@ -380,7 +380,7 @@ class TestGrounding extends EnglishGroundingTest {
 
     // test cause slots
     for (i <- slots.indices) {
-      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+      failingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
       passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
@@ -413,10 +413,10 @@ class TestGrounding extends EnglishGroundingTest {
 
     // test cause slots
     for (i <- slots.indices) {
-      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+      failingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
-      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+      failingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
         tester.properBranchForSlot(causeMentions.head, slots(i))
       }
     }
@@ -454,10 +454,10 @@ class TestGrounding extends EnglishGroundingTest {
     }
     // test effect slots
     for (i <- slots.indices) {
-      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+      failingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
       }
-      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+      failingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
         tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }

--- a/src/test/scala/org/clulab/wm/eidos/text/englishGrounding/TestGrounding.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/englishGrounding/TestGrounding.scala
@@ -43,6 +43,20 @@ class TestGrounding extends EnglishGroundingTest {
         }
       }
     }
+
+    def testBranch(grounding: String, branch: String): Unit = {
+      if (grounding.nonEmpty) grounding should startWith (branch) else grounding should startWith ("")
+    }
+
+    def properBranchForSlot(mention: EidosMention, slot: String, topN: Option[Int] = groundTopN, threshold: Option[Float] = threshold): Unit = {
+      val groundingNames = allGroundingNames(mention, topN, threshold)
+      slot match {
+        case "theme" => testBranch(groundingNames.head.head, "wm/concept/")
+        case "themeProperty" => testBranch(groundingNames.head(1), "wm/property/")
+        case "process" => testBranch(groundingNames.head(2), "wm/process/")
+        case "processProperty" => testBranch(groundingNames.head(3), "wm/property/")
+      }
+    }
   }
 
   object CompositionalGroundingTextTester {
@@ -183,15 +197,21 @@ class TestGrounding extends EnglishGroundingTest {
     val effectGroundings = Seq("wm/process/conflict/insurgency", "", "", "")
 
     // test cause slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
+      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+      }
     }
     // test effect slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
+      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
   }
@@ -209,15 +229,21 @@ class TestGrounding extends EnglishGroundingTest {
     val effectGroundings = Seq("wm/concept/crisis_or_disaster/conflict/", "", "", "")
 
     // test cause slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
+      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+      }
     }
     // test effect slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
+      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
   }
@@ -235,15 +261,21 @@ class TestGrounding extends EnglishGroundingTest {
     val effectGroundings = Seq("wm/concept/goods/water/", "", "wm/process/transportation/", "wm/property/price_or_cost")
 
     // test cause slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
+      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+      }
     }
     // test effect slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
+      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
   }
@@ -261,15 +293,21 @@ class TestGrounding extends EnglishGroundingTest {
     val effectGroundings = Seq("wm/concept/infrastructure/education_supplies", "wm/property/availability", "", "")
 
     // test cause slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
+      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+      }
     }
     // test effect slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
+      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
   }
@@ -287,15 +325,21 @@ class TestGrounding extends EnglishGroundingTest {
     val effectGroundings = Seq("wm/process/population/migrate/emigrate", "", "", "")
 
     // test cause slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
+      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+      }
     }
     // test effect slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
+      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
   }
@@ -339,15 +383,21 @@ class TestGrounding extends EnglishGroundingTest {
     val effectGroundings = Seq("wm/concept/entity/people/migration/", "", "", "")
 
     // test cause slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
+      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+      }
     }
     // test effect slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
+      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
   }
@@ -366,15 +416,21 @@ class TestGrounding extends EnglishGroundingTest {
     val effectGroundings = Seq("wm/concept/entity/people/migration/", "", "", "")
 
     // test cause slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
+      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+      }
     }
     // test effect slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
+      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
   }
@@ -392,15 +448,21 @@ class TestGrounding extends EnglishGroundingTest {
     val effectGroundings = Seq("wm/concept/goods/water", "", "wm/process/transportation/", "wm/property/price_or_cost")
 
     // test cause slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
       }
+      passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+      }
     }
     // test effect slots
-    for (i <- 0 to 3) {
+    for (i <- slots.indices) {
       passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
         tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
+      passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
       }
     }
   }
@@ -422,15 +484,21 @@ class TestGrounding extends EnglishGroundingTest {
       val effectGroundings = Seq(theme, themeProperty, process, processProperty)
 
       // test cause slots
-      for (i <- 0 to 3) {
+      for (i <- slots.indices) {
         passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
           tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
         }
+        passingTest should "ground to proper branch for cause \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(causeMentions.head, slots(i))
+        }
       }
       // test effect slots
-      for (i <- 0 to 3) {
+      for (i <- slots.indices) {
         passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
           tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+        }
+        passingTest should "ground to proper branch for effect \"" + slots(i) + "\" slot" taggedAs Somebody in {
+        tester.properBranchForSlot(effectMentions.head, slots(i))
         }
       }
     }

--- a/src/test/scala/org/clulab/wm/eidos/text/englishGrounding/TestGrounding.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/englishGrounding/TestGrounding.scala
@@ -167,6 +167,7 @@ class TestGrounding extends EnglishGroundingTest {
   val themeProperty = "themeProperty"
   val process = "process"
   val processProperty = "processProperty"
+  val slots: Seq[String] = Seq("theme", "themeProperty", "process", "processProperty")
 
   val tester: CompositionalGroundingTextTester = CompositionalGroundingTextTester("wm_compositional")
 
@@ -178,30 +179,20 @@ class TestGrounding extends EnglishGroundingTest {
     val causeMentions = eidosMentions._1
     val effectMentions = eidosMentions._2
 
-    passingTest should "process \"" + text + "\" cause theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/concept/goods/fuel", theme)
-    }
-    passingTest should "process \"" + text + "\" cause theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/property/availability", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" cause process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" cause process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", processProperty)
-    }
+    val causeGroundings = Seq("wm/concept/goods/fuel", "wm/property/availability", "", "")
+    val effectGroundings = Seq("wm/process/conflict/insurgency", "", "", "")
 
-    passingTest should "process \"" + text + "\" effect theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/process/conflict/insurgency", theme)
+    // test cause slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
+      }
     }
-    passingTest should "process \"" + text + "\" effect theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" effect process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" effect process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", processProperty)
+    // test effect slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
     }
   }
 
@@ -214,30 +205,20 @@ class TestGrounding extends EnglishGroundingTest {
     val causeMentions = eidosMentions._1
     val effectMentions = eidosMentions._2
 
-    passingTest should "process \"" + text + "\" cause theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/concept/goods/fuel", theme)
-    }
-    passingTest should "process \"" + text + "\" cause theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/property/price_or_cost", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" cause process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" cause process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", processProperty)
-    }
+    val causeGroundings = Seq("wm/concept/goods/fuel", "wm/property/price_or_cost", "", "")
+    val effectGroundings = Seq("wm/concept/crisis_or_disaster/conflict/", "", "", "")
 
-    passingTest should "process \"" + text + "\" effect theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/concept/crisis_or_disaster/conflict/", theme)
+    // test cause slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
+      }
     }
-    passingTest should "process \"" + text + "\" effect theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" effect process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" effect process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", processProperty)
+    // test effect slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
     }
   }
 
@@ -250,30 +231,20 @@ class TestGrounding extends EnglishGroundingTest {
     val causeMentions = eidosMentions._1
     val effectMentions = eidosMentions._2
 
-    passingTest should "process \"" + text + "\" cause theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head,"wm/concept/crisis_or_disaster/conflict/", theme)
-    }
-    passingTest should "process \"" + text + "\" cause theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head,"", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" cause process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head,"", process)
-    }
-    passingTest should "process \"" + text + "\" cause process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head,"", processProperty)
-    }
+    val causeGroundings = Seq("wm/concept/crisis_or_disaster/conflict/", "", "", "")
+    val effectGroundings = Seq("wm/concept/goods/water/", "", "wm/process/transportation/", "wm/property/price_or_cost")
 
-    passingTest should "process \"" + text + "\" effect theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/concept/goods/water/", theme)
+    // test cause slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
+      }
     }
-    passingTest should "process \"" + text + "\" effect theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" effect process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/process/transportation/", process)
-    }
-    passingTest should "process \"" + text + "\" effect process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/property/price_or_cost", processProperty)
+    // test effect slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
     }
   }
 
@@ -286,30 +257,20 @@ class TestGrounding extends EnglishGroundingTest {
     val causeMentions = eidosMentions._1
     val effectMentions = eidosMentions._2
 
-    passingTest should "process \"" + text + "\" cause theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/concept/crisis_or_disaster/conflict/hostility", theme)
-    }
-    passingTest should "process \"" + text + "\" cause theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" cause process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" cause process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", processProperty)
-    }
+    val causeGroundings = Seq("wm/concept/crisis_or_disaster/conflict/hostility", "", "", "")
+    val effectGroundings = Seq("wm/concept/infrastructure/education_supplies", "wm/property/availability", "", "")
 
-    passingTest should "process \"" + text + "\" effect theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/concept/infrastructure/education_supplies", theme)
+    // test cause slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
+      }
     }
-    passingTest should "process \"" + text + "\" effect theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/property/availability", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" effect process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" effect process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", processProperty)
+    // test effect slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
     }
   }
 
@@ -322,30 +283,20 @@ class TestGrounding extends EnglishGroundingTest {
     val causeMentions = eidosMentions._1
     val effectMentions = eidosMentions._2
 
-    passingTest should "process \"" + text + "\" cause theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/concept/goods/food", theme)
-    }
-    passingTest should "process \"" + text + "\" cause theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/property/security", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" cause process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" cause process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", processProperty)
-    }
+    val causeGroundings = Seq("wm/concept/goods/food", "wm/property/security", "", "")
+    val effectGroundings = Seq("wm/process/population/migrate/emigrate", "", "", "")
 
-    passingTest should "process \"" + text + "\" effect theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/process/population/migrate/emigrate", theme)
+    // test cause slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
+      }
     }
-    passingTest should "process \"" + text + "\" effect theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" effect process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" effect process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", processProperty)
+    // test effect slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
     }
   }
 
@@ -384,30 +335,20 @@ class TestGrounding extends EnglishGroundingTest {
     val causeMentions = eidosMentions._1
     val effectMentions = eidosMentions._2
 
-    passingTest should "process \"" + text + "\" cause theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/concept/agriculture/crop/sorghum", theme)
-    }
-    passingTest should "process \"" + text + "\" cause theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/property/availability", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" cause process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/process/access", process)
-    }
-    passingTest should "process \"" + text + "\" cause process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", processProperty)
-    }
+    val causeGroundings = Seq("wm/concept/agriculture/crop/sorghum", "wm/property/availability", "wm/process/access", "")
+    val effectGroundings = Seq("wm/concept/entity/people/migration/", "", "", "")
 
-    passingTest should "process \"" + text + "\" effect theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/concept/entity/people/migration/", theme)
+    // test cause slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
+      }
     }
-    passingTest should "process \"" + text + "\" effect theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" effect process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" effect process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", processProperty)
+    // test effect slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
     }
   }
 
@@ -421,30 +362,20 @@ class TestGrounding extends EnglishGroundingTest {
     val causeMentions = eidosMentions._1
     val effectMentions = eidosMentions._2
 
-    passingTest should "process \"" + text + "\" cause theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/concept/agriculture/crop/sorghum", theme)
-    }
-    passingTest should "process \"" + text + "\" cause theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/property/unavailability", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" cause process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" cause process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", processProperty)
-    }
+    val causeGroundings = Seq("wm/concept/agriculture/crop/sorghum", "wm/property/unavailability", "", "")
+    val effectGroundings = Seq("wm/concept/entity/people/migration/", "", "", "")
 
-    passingTest should "process \"" + text + "\" effect theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/concept/entity/people/migration/", theme)
+    // test cause slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
+      }
     }
-    passingTest should "process \"" + text + "\" effect theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" effect process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" effect process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", processProperty)
+    // test effect slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
     }
   }
 
@@ -457,30 +388,20 @@ class TestGrounding extends EnglishGroundingTest {
     val causeMentions = eidosMentions._1
     val effectMentions = eidosMentions._2
 
-    passingTest should "process \"" + text + "\" cause theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/concept/goods/fuel", theme)
-    }
-    passingTest should "process \"" + text + "\" cause theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "wm/property/price_or_cost", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" cause process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", process)
-    }
-    passingTest should "process \"" + text + "\" cause process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(causeMentions.head, "", processProperty)
-    }
+    val causeGroundings = Seq("wm/concept/goods/fuel", "wm/property/price_or_cost", "", "")
+    val effectGroundings = Seq("wm/concept/goods/water", "", "wm/process/transportation/", "wm/property/price_or_cost")
 
-    passingTest should "process \"" + text + "\" effect theme correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/concept/goods/water", theme)
+    // test cause slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
+      }
     }
-    passingTest should "process \"" + text + "\" effect theme property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "", themeProperty)
-    }
-    passingTest should "process \"" + text + "\" effect process correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/process/transportation/", process)
-    }
-    passingTest should "process \"" + text + "\" effect process property correctly" taggedAs Somebody in {
-      tester.groundingShouldContain(effectMentions.head, "wm/property/price_or_cost", processProperty)
+    // test effect slots
+    for (i <- 0 to 3) {
+      passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+        tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
+      }
     }
   }
 
@@ -497,17 +418,20 @@ class TestGrounding extends EnglishGroundingTest {
       val causeMentions = eidosMentions._1
       val effectMentions = eidosMentions._2
 
-      passingTest should "process \"" + text + "\" cause correctly" taggedAs Somebody in {
-        if (tester.active) {
-          tester.allGroundingNames(causeMentions.head) should contain("wm/???")
+      val causeGroundings = Seq(theme, themeProperty, process, processProperty)
+      val effectGroundings = Seq(theme, themeProperty, process, processProperty)
+
+      // test cause slots
+      for (i <- 0 to 3) {
+        passingTest should "process \"" + text + "\" cause " + slots(i) + " correctly" taggedAs Somebody in {
+          tester.groundingShouldContain(causeMentions.head, causeGroundings(i), slots(i))
         }
-        tester.groundingShouldContain(causeMentions.head, "wm/???")
       }
-      passingTest should "process \"" + text + "\" effect correctly" taggedAs Somebody in {
-        if (tester.active) {
-          tester.allGroundingNames(effectMentions.head) should contain("wm/???")
+      // test effect slots
+      for (i <- 0 to 3) {
+        passingTest should "process \"" + text + "\" effect " + slots(i) + " correctly" taggedAs Somebody in {
+          tester.groundingShouldContain(effectMentions.head, effectGroundings(i), slots(i))
         }
-        tester.groundingShouldContain(effectMentions.head, "wm/???")
       }
     }
   */

--- a/src/test/scala/org/clulab/wm/eidos/text/englishGrounding/TestGrounding.scala
+++ b/src/test/scala/org/clulab/wm/eidos/text/englishGrounding/TestGrounding.scala
@@ -125,14 +125,10 @@ class TestGrounding extends EnglishGroundingTest {
           val process_name = process.grounding.headOption.map(_.name).getOrElse("")
           val process_property = predicateTuple.themeProcessProperties
           val process_property_name = process_property.grounding.headOption.map(_.name).getOrElse("")
-          // fixme: (?) why are we returning only the theme?
           val tuple = Seq(theme_name, property_name, process_name, process_property_name)
-          //          println("\nRETURNED TUPLE:")
-          //          println(tuple)
           tuple
         }
       }
-
       names
     }.toSeq
     // to get both name AND score of groundings
@@ -152,7 +148,7 @@ class TestGrounding extends EnglishGroundingTest {
       val doc = ieSystem.annotate(text)
       val causes = {
         val odinCauses = causeIntervals.map(x =>
-          new TextBoundMention(label = "Entity", x, 0, doc, true, "FakeRule"))
+            new TextBoundMention(label = "Entity", x, 0, doc, true, "FakeRule"))
         val annotatedDocument = AnnotatedDocument(doc, odinCauses)
         val eidosCauses = annotatedDocument.eidosMentions
 
@@ -163,7 +159,7 @@ class TestGrounding extends EnglishGroundingTest {
 
       val effects = {
         val odinEffects = effectIntervals.map(x =>
-          new TextBoundMention(label = "Entity", x, 0, doc, true, "FakeRule"))
+            new TextBoundMention(label = "Entity", x, 0, doc, true, "FakeRule"))
         val annotatedDocument = AnnotatedDocument(doc, odinEffects)
         val eidosEffects = annotatedDocument.eidosMentions
 


### PR DESCRIPTION
This PR updates `TestGrounding.scala` to
- Test grounding for all four slots of the compositional ontology (theme, theme property, process, process property) instead of just the theme
- Make sure each slot grounds to the proper branch of the ontology (theme -> `wm/concept/`, properties -> `wm/property/`, process -> `wm/process/`)