### PR TITLE
Add grounding slot filter

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -40,7 +40,7 @@ case class OntologyGrounding(version: Option[String], date: Option[ZonedDateTime
   def headName: Option[String] = headOption.map(_.name)
   // discard the top grounding, take the next
   def dropFirst(): OntologyGrounding = OntologyGrounding(version, date, grounding.drop(1), branch)
-  def filterSlots(slot: String): OntologyGrounding = OntologyGrounding(version, date, grounding.filter(_.name.contains(slot)))
+  def filterSlots(slot: String): OntologyGrounding = OntologyGrounding(version, date, grounding.filter(_.name.contains("/"+slot+"/")))
 }
 
 trait OntologyGrounder {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -40,6 +40,7 @@ case class OntologyGrounding(version: Option[String], date: Option[ZonedDateTime
   def headName: Option[String] = headOption.map(_.name)
   // discard the top grounding, take the next
   def dropFirst(): OntologyGrounding = OntologyGrounding(version, date, grounding.drop(1), branch)
+  def filterSlots(slot: String): OntologyGrounding = OntologyGrounding(version, date, grounding.filter(_.name.contains("/"+slot+"/")))
 }
 
 trait OntologyGrounder {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/OntologyGrounder.scala
@@ -40,7 +40,7 @@ case class OntologyGrounding(version: Option[String], date: Option[ZonedDateTime
   def headName: Option[String] = headOption.map(_.name)
   // discard the top grounding, take the next
   def dropFirst(): OntologyGrounding = OntologyGrounding(version, date, grounding.drop(1), branch)
-  def filterSlots(slot: String): OntologyGrounding = OntologyGrounding(version, date, grounding.filter(_.name.contains("/"+slot+"/")))
+  def filterSlots(slot: String): OntologyGrounding = OntologyGrounding(version, date, grounding.filter(_.name.contains(slot)))
 }
 
 trait OntologyGrounder {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
@@ -20,18 +20,12 @@ import scala.collection.mutable.ArrayBuffer
 
 case class GroundedSpan(tokenInterval: Interval, grounding: OntologyGrounding, isProperty: Boolean = false)
 case class PredicateTuple(
-  var theme: OntologyGrounding,
-  var themeProperties: OntologyGrounding,
-  var themeProcess: OntologyGrounding,
-  var themeProcessProperties: OntologyGrounding,
+  theme: OntologyGrounding,
+  themeProperties: OntologyGrounding,
+  themeProcess: OntologyGrounding,
+  themeProcessProperties: OntologyGrounding,
   predicates: Set[Int]
   ) {
-
-  // accepts only groundings from the correct branch for each slot
-  theme = theme.filterSlots(SRLCompositionalGrounder.CONCEPT)
-  themeProperties = themeProperties.filterSlots(SRLCompositionalGrounder.PROPERTY)
-  themeProcess = themeProcess.filterSlots(SRLCompositionalGrounder.PROCESS)
-  themeProcessProperties = themeProcessProperties.filterSlots(SRLCompositionalGrounder.PROPERTY)
 
   def nameAndScore(gr: OntologyGrounding): String = nameAndScore(gr.headOption.get)
   def nameAndScore(gr: IndividualGrounding): String = {
@@ -546,6 +540,22 @@ case class SentenceHelper(sentence: Sentence, tokenInterval: Interval, exclude: 
       // return the dsts
       .map(_._1)
   }
+}
+
+object PredicateTuple {
+  def apply(
+    theme: OntologyGrounding,
+    themeProperties: OntologyGrounding,
+    themeProcess: OntologyGrounding,
+    themeProcessProperties: OntologyGrounding,
+    predicates: Set[Int]
+  ): PredicateTuple = new PredicateTuple(
+    theme.filterSlots(SRLCompositionalGrounder.CONCEPT),
+    themeProperties.filterSlots(SRLCompositionalGrounder.PROPERTY),
+    themeProcess.filterSlots(SRLCompositionalGrounder.PROCESS),
+    themeProcessProperties.filterSlots(SRLCompositionalGrounder.PROPERTY),
+    predicates
+  )
 }
 
 object SRLCompositionalGrounder extends Logging {

--- a/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
+++ b/src/main/scala/org/clulab/wm/eidos/groundings/grounders/SRLCompositionalGrounder.scala
@@ -7,7 +7,6 @@ import org.clulab.wm.eidos.attachments.{ContextAttachment, Property, TriggeredAt
 import org.clulab.wm.eidos.groundings.{ConceptEmbedding, ConceptPatterns, EidosWordToVec, IndividualGrounding, OntologyGrounding, PredicateGrounding}
 import org.clulab.dynet.Utils
 import org.clulab.processors.clu.CluProcessor
-import org.clulab.wm.eidos.groundings.OntologyAliases.MultipleOntologyGrounding
 import org.clulab.wm.eidos.groundings.grounders.SRLCompositionalGrounder.propertyConfidenceThreshold
 import org.clulab.wm.eidos.mentions.EidosMention
 import org.clulab.wm.eidos.utils.GroundingUtils
@@ -31,11 +30,6 @@ case class PredicateTuple(
   def nameAndScore(gr: IndividualGrounding): String = {
     s"${gr.name} (${gr.score})"
   }
-
-//  val themeFiltered: MultipleOntologyGrounding = theme.filter("theme")
-//  val themePropertiesFiltered: MultipleOntologyGrounding = themeProperties.filter("property")
-//  val themeProcessFiltered: MultipleOntologyGrounding = themeProcess.filter("process")
-//  val themeProcessPropertiesFiltered: MultipleOntologyGrounding = themeProcessProperties.filter("property")
 
   val name: String = {
     if (theme.nonEmpty) {


### PR DESCRIPTION
Adds a filter to the groundings when crafting a `PredicateTuple` to make sure `theme` groundings are in the `concept` branch, `process` groundings are in `process` branch, and `themeProperty` and `processProperty` groundings are in the `property` branch of the compositional ontology.