### PR TITLE
updates NegationHandler to fix 'not only' bug

### DIFF
--- a/src/main/scala/org/clulab/wm/eidos/attachments/NegationHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/attachments/NegationHandler.scala
@@ -150,7 +150,7 @@ class NegationHandler(val language: String) {
       if !argumentIntervals.exists(_.contains(tok))
       out <- outgoing.lift(tok)
       (ix, label) <- out
-      if label == "neg"
+      if label == "neg" && !(event.sentenceObj.words(tok) == "only")
     } negations.append(
       new TextBoundMention(
         Seq("Negation_trigger"),
@@ -178,7 +178,7 @@ class NegationHandler(val language: String) {
     for {
       (ix, lemma) <- leftContext ++ rightContext
       if !argumentIntervals.exists(_.contains(ix))
-      if (Seq("fail", "not") contains lemma) && !(previouslyFound contains ix)
+      if (Seq("fail", "not") contains lemma) && !(previouslyFound contains ix) && !(event.sentenceObj.words(ix+1) == "only")
     } yield new TextBoundMention(
       Seq("Negation_trigger"),
       Interval(ix),

--- a/src/main/scala/org/clulab/wm/eidos/attachments/NegationHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/attachments/NegationHandler.scala
@@ -5,6 +5,7 @@ import org.clulab.wm.eidos.EidosSystem
 
 import scala.collection.mutable.ArrayBuffer
 import org.clulab.struct.Interval
+import org.clulab.wm.eidos.attachments.NegationHandler.failNot
 import org.clulab.wm.eidoscommon.EidosParameters
 import org.clulab.wm.eidoscommon.Language
 
@@ -150,7 +151,7 @@ class NegationHandler(val language: String) {
       if !argumentIntervals.exists(_.contains(tok))
       out <- outgoing.lift(tok)
       (ix, label) <- out
-      if label == "neg" && !(event.sentenceObj.words(tok) == "only")
+      if label == "neg" && event.sentenceObj.words(tok) != "only"
     } negations.append(
       new TextBoundMention(
         Seq("Negation_trigger"),
@@ -178,7 +179,7 @@ class NegationHandler(val language: String) {
     for {
       (ix, lemma) <- leftContext ++ rightContext
       if !argumentIntervals.exists(_.contains(ix))
-      if (Seq("fail", "not") contains lemma) && !(previouslyFound contains ix) && !(event.sentenceObj.words(ix+1) == "only")
+      if (failNot contains lemma) && !(previouslyFound contains ix) && event.sentenceObj.words(ix+1) != "only"
     } yield new TextBoundMention(
       Seq("Negation_trigger"),
       Interval(ix),
@@ -233,5 +234,7 @@ class NegationHandler(val language: String) {
 object NegationHandler{
 
   def apply(language: String): NegationHandler = new NegationHandler(language)
+
+  val failNot = Seq("fail", "not")
 
 }

--- a/src/main/scala/org/clulab/wm/eidos/attachments/NegationHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/attachments/NegationHandler.scala
@@ -178,10 +178,12 @@ class NegationHandler(val language: String) {
     // Check for single-token negative verbs
     for {
       (ix, lemma) <- leftContext ++ rightContext
-      if !argumentIntervals.exists(_.contains(ix))
-      // make sure ix+1 is not the end of the sentence (to avoid ix+1 error at end of sent)
-      if rightContext.isEmpty || (rightContext.nonEmpty && rightContext.last._1 < sentenceWords.lastIndexOf(sentenceWords.last))
-      if (NegationHandler.failNot contains lemma) && !(previouslyFound contains ix) && event.sentenceObj.words(ix+1) != "only"
+      // These are ordered roughly from fastest and most effective to slowest and least.
+      if NegationHandler.failNot contains lemma     // lemma is either "fail" or "not", and
+      if !(previouslyFound contains ix)             // ix is not a duplicate, and
+      if !argumentIntervals.exists(_.contains(ix))  // ix is not part of any argument interval, and
+      if !sentenceWords.indices.contains(ix + 1) || // either there is no next word at all or
+        sentenceWords(ix + 1) != "only"           // there is one and the next word is not "only"
     } yield new TextBoundMention(
       Seq("Negation_trigger"),
       Interval(ix),

--- a/src/main/scala/org/clulab/wm/eidos/attachments/NegationHandler.scala
+++ b/src/main/scala/org/clulab/wm/eidos/attachments/NegationHandler.scala
@@ -150,7 +150,9 @@ class NegationHandler(val language: String) {
       if !argumentIntervals.exists(_.contains(tok))
       out <- outgoing.lift(tok)
       (ix, label) <- out
-      if label == "neg" && event.sentenceObj.words(tok) != "only"
+      if label == "neg"   // if label is "neg"
+      if !NegationHandler.fakeNegation.contains(event.sentenceObj.words(tok))   // if the outgoing word is not in fakeNegation
+      if !out.contains((ix+1, "advmod"))    // if the subsequent token from the neg is not the advmod
     } negations.append(
       new TextBoundMention(
         Seq("Negation_trigger"),
@@ -183,7 +185,7 @@ class NegationHandler(val language: String) {
       if !(previouslyFound contains ix)             // ix is not a duplicate, and
       if !argumentIntervals.exists(_.contains(ix))  // ix is not part of any argument interval, and
       if !sentenceWords.indices.contains(ix + 1) || // either there is no next word at all or
-        sentenceWords(ix + 1) != "only"           // there is one and the next word is not "only"
+        !NegationHandler.fakeNegation.contains(sentenceWords(ix + 1))           // there is one and the next word is not "only"
     } yield new TextBoundMention(
       Seq("Negation_trigger"),
       Interval(ix),
@@ -240,5 +242,8 @@ object NegationHandler{
   def apply(language: String): NegationHandler = new NegationHandler(language)
 
   val failNot = Seq("fail", "not")
+  // avoid adding negation attachment to "X not _ caused Y, but also..." contexts
+  // this seq could be expanded as needed
+  val fakeNegation = Seq("only", "just", "merely", "simply", "exclusively", "solely")
 
 }


### PR DESCRIPTION
Stops from making a negation attachment based on dependencies or left/right context if
- the outgoing dependency `neg` is coming from the token "only"
- the subsequent token to the word "not" is the token "only"
